### PR TITLE
fix: make all helia args optional

### DIFF
--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -144,6 +144,7 @@
     "@libp2p/interfaces": "^3.3.1",
     "blockstore-core": "^3.0.0",
     "cborg": "^1.10.0",
+    "datastore-core": "^8.0.4",
     "interface-blockstore": "^4.0.1",
     "interface-datastore": "^7.0.3",
     "interface-store": "^3.0.4",
@@ -167,7 +168,6 @@
     "@ipld/dag-json": "^10.0.1",
     "@libp2p/websockets": "^5.0.3",
     "aegir": "^38.1.0",
-    "datastore-core": "^8.0.4",
     "libp2p": "^0.42.2"
   },
   "typedoc": {

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -48,17 +48,17 @@ export interface HeliaInit {
   /**
    * A libp2p node is required to perform network operations
    */
-  libp2p: Libp2p
+  libp2p?: Libp2p
 
   /**
    * The blockstore is where blocks are stored
    */
-  blockstore: Blockstore
+  blockstore?: Blockstore
 
   /**
    * The datastore is where data is stored
    */
-  datastore: Datastore
+  datastore?: Datastore
 
   /**
    * By default sha256, sha512 and identity hashes are supported for
@@ -83,7 +83,7 @@ export interface HeliaInit {
 /**
  * Create and return a Helia node
  */
-export async function createHelia (init: HeliaInit): Promise<Helia> {
+export async function createHelia (init: HeliaInit = {}): Promise<Helia> {
   const helia = new HeliaImpl(init)
 
   if (init.start !== false) {

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -18,7 +18,6 @@ import type { Libp2p } from '@libp2p/interface-libp2p'
 import type { Blockstore } from 'interface-blockstore'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Datastore } from 'interface-datastore'
 import type { Pins } from './pins.js'
 import type { ProgressEvent, ProgressOptions } from 'progress-events'
@@ -49,22 +48,6 @@ export interface Helia {
   pins: Pins
 
   /**
-   * Returns information about this node
-   *
-   * @example
-   *
-   * ```typescript
-   * import { createHelia } from 'helia'
-   *
-   * const node = await createHelia()
-   * const id = await node.info()
-   * console.info(id)
-   * // { peerId: PeerId(12D3Foo), ... }
-   * ```
-   */
-  info: (options?: InfoOptions) => Promise<InfoResponse>
-
-  /**
    * Starts the Helia node
    */
   start: () => Promise<void>
@@ -93,36 +76,4 @@ export interface InfoOptions extends AbortOptions {
    * to the ID of the current node.
    */
   peerId?: PeerId
-}
-
-export interface InfoResponse {
-  /**
-   * The ID of the peer this info is about
-   */
-  peerId: PeerId
-
-  /**
-   * The multiaddrs the peer is listening on
-   */
-  multiaddrs: Multiaddr[]
-
-  /**
-   * The peer's reported agent version
-   */
-  agentVersion: string
-
-  /**
-   * The peer's reported protocol version
-   */
-  protocolVersion: string
-
-  /**
-   * The protocols the peer supports
-   */
-  protocols: string[]
-
-  /**
-   * The status of the node
-   */
-  status: 'running' | 'stopped'
 }


### PR DESCRIPTION
Default to using in-memory block/datastores if they aren't provided and a libp2p proxy that will throw if you invoke any of it's methods.