### PR TITLE
chore: update benchmark

### DIFF
--- a/benchmarks/gc/package.json
+++ b/benchmarks/gc/package.json
@@ -31,6 +31,6 @@
     "kubo-rpc-client": "^3.0.1",
     "libp2p": "^0.42.2",
     "multiformats": "^11.0.1",
-    "tinybench": "^2.3.1"
+    "tinybench": "^2.4.0"
   }
 }

--- a/benchmarks/gc/src/README.md
+++ b/benchmarks/gc/src/README.md
@@ -11,10 +11,12 @@ All three implementations use on-disk block/datastores to ensure a reasonable ba
 
 Warning! It can take a long time with realistic pinset sizes - on the order of a whole day.
 
+You can speed things up by removing js-ipfs from the `impls` array.
+
 To run:
 
 1. Add `benchmarks/*` to the `workspaces` entry in the root `package.json` of this repo
-3. Run
+2. Run
     ```console
     $ npm run reset
     $ npm i

--- a/benchmarks/gc/tsconfig.json
+++ b/benchmarks/gc/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": [
     "src",


### PR DESCRIPTION
https://github.com/tinylibs/tinybench/pull/33 has been merged so update the minimum used version