### PR TITLE
chore: update helia and go-ipfs version in benchmark

### DIFF
--- a/benchmarks/gc/package.json
+++ b/benchmarks/gc/package.json
@@ -20,7 +20,7 @@
     "blockstore-fs": "^1.0.1",
     "datastore-level": "^10.0.1",
     "execa": "^7.0.0",
-    "go-ipfs": "^0.18.1",
+    "go-ipfs": "^0.19.0",
     "helia": "^1.0.0",
     "ipfs-core": "^0.18.0",
     "ipfsd-ctl": "^13.0.0",

--- a/benchmarks/gc/package.json
+++ b/benchmarks/gc/package.json
@@ -21,7 +21,7 @@
     "datastore-level": "^10.0.1",
     "execa": "^7.0.0",
     "go-ipfs": "^0.18.1",
-    "helia": "~0.0.0",
+    "helia": "^1.0.0",
     "ipfs-core": "^0.18.0",
     "ipfsd-ctl": "^13.0.0",
     "it-all": "^2.0.0",


### PR DESCRIPTION
This was not done as part of the release because it's not in the workspaces list by default.