### PR TITLE
chore: Adds codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ipfs/helia-dev


### PR DESCRIPTION
Addresses: #35 

Adding @ipfs/helia-dev as CODEOWNERS.