### PR TITLE
feat: provide default libp2p instance

### DIFF
--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -145,6 +145,7 @@
     "@ipld/dag-pb": "^4.0.3",
     "@libp2p/bootstrap": "^8.0.0",
     "@libp2p/interface-libp2p": "^3.1.0",
+    "@libp2p/interface-pubsub": "^4.0.1",
     "@libp2p/interfaces": "^3.3.2",
     "@libp2p/ipni-content-routing": "^1.0.0",
     "@libp2p/kad-dht": "^9.3.3",

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -138,18 +138,29 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "@chainsafe/libp2p-gossipsub": "^8.0.0",
+    "@chainsafe/libp2p-noise": "^12.0.0",
+    "@chainsafe/libp2p-yamux": "^4.0.2",
     "@helia/interface": "^1.0.0",
-    "@ipld/dag-pb": "^4.0.2",
-    "@libp2p/interface-libp2p": "^1.1.0",
-    "@libp2p/interfaces": "^3.3.1",
-    "@libp2p/logger": "^2.0.5",
+    "@ipld/dag-pb": "^4.0.3",
+    "@libp2p/bootstrap": "^8.0.0",
+    "@libp2p/interface-libp2p": "^3.1.0",
+    "@libp2p/interfaces": "^3.3.2",
+    "@libp2p/ipni-content-routing": "^1.0.0",
+    "@libp2p/kad-dht": "^9.3.3",
+    "@libp2p/logger": "^2.0.7",
+    "@libp2p/mdns": "^8.0.0",
+    "@libp2p/mplex": "^8.0.3",
+    "@libp2p/tcp": "^7.0.1",
+    "@libp2p/webrtc": "^2.0.4",
+    "@libp2p/webtransport": "^2.0.1",
     "blockstore-core": "^4.0.0",
     "cborg": "^1.10.0",
     "datastore-core": "^9.0.0",
     "interface-blockstore": "^5.0.0",
     "interface-datastore": "^8.0.0",
     "interface-store": "^5.0.1",
-    "ipfs-bitswap": "^17.0.0",
+    "ipfs-bitswap": "^18.0.0",
     "it-all": "^3.0.1",
     "it-drain": "^3.0.1",
     "it-filter": "^3.0.1",
@@ -162,19 +173,20 @@
     "uint8arrays": "^4.0.3"
   },
   "devDependencies": {
-    "@chainsafe/libp2p-noise": "^11.0.0",
-    "@chainsafe/libp2p-yamux": "^3.0.5",
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.1",
-    "@libp2p/websockets": "^5.0.3",
+    "@libp2p/websockets": "^6.0.1",
     "@types/sinon": "^10.0.14",
     "aegir": "^39.0.4",
     "delay": "^5.0.0",
-    "libp2p": "^0.44.0",
+    "libp2p": "^0.45.1",
     "sinon": "^15.0.2",
     "sinon-ts": "^1.0.0"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts"
+  },
+  "browser": {
+    "./dist/src/utils/libp2p.js": "./dist/src/utils/libp2p.browser.js"
   }
 }

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -183,10 +183,10 @@
     "sinon": "^15.0.2",
     "sinon-ts": "^1.0.0"
   },
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
-  },
   "browser": {
     "./dist/src/utils/libp2p.js": "./dist/src/utils/libp2p.browser.js"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
   }
 }

--- a/packages/helia/src/utils/libp2p.browser.ts
+++ b/packages/helia/src/utils/libp2p.browser.ts
@@ -1,0 +1,68 @@
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
+import { noise } from '@chainsafe/libp2p-noise'
+import { yamux } from '@chainsafe/libp2p-yamux'
+import { bootstrap } from '@libp2p/bootstrap'
+import { ipniContentRouting } from '@libp2p/ipni-content-routing'
+import { kadDHT, type DualKadDHT } from '@libp2p/kad-dht'
+import { mplex } from '@libp2p/mplex'
+import { webRTC, webRTCDirect } from '@libp2p/webrtc'
+import { webSockets } from '@libp2p/websockets'
+import { webTransport } from '@libp2p/webtransport'
+import { createLibp2p as create } from 'libp2p'
+import { autoNATService } from 'libp2p/autonat'
+import { circuitRelayTransport, circuitRelayServer } from 'libp2p/circuit-relay'
+import { identifyService } from 'libp2p/identify'
+import type { CreateLibp2pOptions } from './libp2p.js'
+import type { Libp2p } from '@libp2p/interface-libp2p'
+import type { PubSub } from '@libp2p/interface-pubsub'
+
+export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{ dht: DualKadDHT, pubsub: PubSub }>> {
+  return create({
+    ...opts,
+    addresses: {
+      listen: [
+        '/webrtc'
+      ]
+    },
+    transports: [
+      webRTC(),
+      webRTCDirect(),
+      webTransport(),
+      webSockets(),
+      circuitRelayTransport({
+        discoverRelays: 1
+      })
+    ],
+    connectionEncryption: [
+      noise()
+    ],
+    streamMuxers: [
+      yamux(),
+      mplex()
+    ],
+    peerDiscovery: [
+      bootstrap({
+        list: [
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
+        ]
+      })
+    ],
+    contentRouters: [
+      ipniContentRouting('https://cid.contact')
+    ],
+    services: {
+      identify: identifyService(),
+      autoNAT: autoNATService(),
+      pubsub: gossipsub(),
+      dht: kadDHT({
+        clientMode: true
+      }),
+      relay: circuitRelayServer({
+        advertise: true
+      })
+    }
+  })
+}

--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -1,0 +1,72 @@
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
+import { noise } from '@chainsafe/libp2p-noise'
+import { yamux } from '@chainsafe/libp2p-yamux'
+import { bootstrap } from '@libp2p/bootstrap'
+import { ipniContentRouting } from '@libp2p/ipni-content-routing'
+import { type DualKadDHT, kadDHT } from '@libp2p/kad-dht'
+import { mdns } from '@libp2p/mdns'
+import { mplex } from '@libp2p/mplex'
+import { tcp } from '@libp2p/tcp'
+import { webSockets } from '@libp2p/websockets'
+import { createLibp2p as create } from 'libp2p'
+import { autoNATService } from 'libp2p/autonat'
+import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from 'libp2p/circuit-relay'
+import { identifyService } from 'libp2p/identify'
+import { uPnPNATService } from 'libp2p/upnp-nat'
+import type { Libp2p } from '@libp2p/interface-libp2p'
+import type { PubSub } from '@libp2p/interface-pubsub'
+import type { Datastore } from 'interface-datastore'
+
+export interface CreateLibp2pOptions {
+  datastore: Datastore
+  start?: boolean
+}
+
+export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{ dht: DualKadDHT, pubsub: PubSub, relay: CircuitRelayService }>> {
+  return create({
+    ...opts,
+    addresses: {
+      listen: [
+        '/ip4/0.0.0.0/tcp/0'
+      ]
+    },
+    transports: [
+      tcp(),
+      webSockets(),
+      circuitRelayTransport({
+        discoverRelays: 1
+      })
+    ],
+    connectionEncryption: [
+      noise()
+    ],
+    streamMuxers: [
+      yamux(),
+      mplex()
+    ],
+    peerDiscovery: [
+      mdns(),
+      bootstrap({
+        list: [
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+          '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
+        ]
+      })
+    ],
+    contentRouters: [
+      ipniContentRouting('https://cid.contact')
+    ],
+    services: {
+      identify: identifyService(),
+      autoNAT: autoNATService(),
+      upnp: uPnPNATService(),
+      pubsub: gossipsub(),
+      dht: kadDHT(),
+      relay: circuitRelayServer({
+        advertise: true
+      })
+    }
+  })
+}

--- a/packages/helia/test/factory.spec.ts
+++ b/packages/helia/test/factory.spec.ts
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { Key } from 'interface-datastore'
+import { CID } from 'multiformats/cid'
+import { createHelia } from '../src/index.js'
+import type { Helia } from '@helia/interface'
+
+describe('helia factory', () => {
+  let helia: Helia
+
+  afterEach(async () => {
+    if (helia != null) {
+      await helia.stop()
+    }
+  })
+
+  it('allows creating offline node', async () => {
+    helia = await createHelia({
+      start: false
+    })
+
+    expect(helia.libp2p.isStarted()).to.be.false()
+  })
+
+  it('does not require any constructor args', async () => {
+    helia = await createHelia()
+
+    const cid = CID.parse('QmaQwYWpchozXhFv8nvxprECWBSCEppN9dfd2VQiJfRo3F')
+    const block = Uint8Array.from([0, 1, 2, 3])
+    await helia.blockstore.put(cid, block)
+    expect(await helia.blockstore.has(cid)).to.be.true()
+
+    const key = new Key(`/${cid.toString()}`)
+    await helia.datastore.put(key, block)
+    expect(await helia.datastore.has(key)).to.be.true()
+  })
+})

--- a/packages/helia/test/gc.spec.ts
+++ b/packages/helia/test/gc.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import * as dagCbor from '@ipld/dag-cbor'
@@ -41,7 +42,7 @@ describe('gc', () => {
     }
   })
 
-  it('pins a dag-pb node and does not garbage collect it or it\'s children', async () => {
+  it('pins a dag-pb node and does not garbage collect it or its children', async () => {
     const child1 = await createAndPutBlock(dagPb.code, dagPb.encode({
       Data: Uint8Array.from([0, 1, 2, 3]),
       Links: []
@@ -82,7 +83,7 @@ describe('gc', () => {
     await expect(helia.blockstore.has(doomed)).to.eventually.be.false()
   })
 
-  it('pins a dag-cbor node and does not garbage collect it or it\'s children', async () => {
+  it('pins a dag-cbor node and does not garbage collect it or its children', async () => {
     const child1 = await createAndPutBlock(dagCbor.code, dagCbor.encode({
       foo: 'bar'
     }), helia.blockstore)
@@ -117,7 +118,7 @@ describe('gc', () => {
     await expect(helia.blockstore.has(doomed)).to.eventually.be.false()
   })
 
-  it('pins a dag-json node and does not garbage collect it or it\'s children', async () => {
+  it('pins a dag-json node and does not garbage collect it or its children', async () => {
     const child1 = await createAndPutBlock(dagJson.code, dagJson.encode({
       foo: 'bar'
     }), helia.blockstore)

--- a/packages/helia/test/index.spec.ts
+++ b/packages/helia/test/index.spec.ts
@@ -5,9 +5,7 @@ import { webSockets } from '@libp2p/websockets'
 import { expect } from 'aegir/chai'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
-import { Key } from 'interface-datastore'
 import { createLibp2p } from 'libp2p'
-import { CID } from 'multiformats/cid'
 import { createHelia } from '../src/index.js'
 import type { Helia } from '@helia/interface'
 
@@ -56,44 +54,5 @@ describe('helia', () => {
 
   it('should have a libp2p', async () => {
     expect(helia).to.have.property('libp2p').that.is.ok()
-  })
-
-  it('allows creating offline node', async () => {
-    const helia = await createHelia({
-      start: false,
-      datastore: new MemoryDatastore(),
-      blockstore: new MemoryBlockstore(),
-      libp2p: await createLibp2p({
-        start: false,
-        transports: [
-          webSockets()
-        ],
-        connectionEncryption: [
-          noise()
-        ],
-        streamMuxers: [
-          yamux()
-        ]
-      })
-    })
-
-    expect(helia.libp2p.isStarted()).to.be.false()
-  })
-
-  it('does not require any constructor args', async () => {
-    const helia = await createHelia()
-
-    const cid = CID.parse('QmaQwYWpchozXhFv8nvxprECWBSCEppN9dfd2VQiJfRo3F')
-    const block = Uint8Array.from([0, 1, 2, 3])
-    await helia.blockstore.put(cid, block)
-    expect(await helia.blockstore.has(cid)).to.be.true()
-
-    const key = new Key(`/${cid.toString()}`)
-    await helia.datastore.put(key, block)
-    expect(await helia.datastore.has(key)).to.be.true()
-
-    expect(() => {
-      helia.libp2p.isStarted()
-    }).to.throw('Please configure Helia with a libp2p instance')
   })
 })

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -156,7 +156,6 @@
   },
   "dependencies": {
     "@libp2p/interface-libp2p": "^3.1.0",
-    "@libp2p/interface-peer-id": "^2.0.2",
     "@libp2p/interfaces": "^3.3.2",
     "interface-blockstore": "^5.0.0",
     "interface-datastore": "^8.0.0",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -157,7 +157,7 @@
   "dependencies": {
     "@libp2p/interface-libp2p": "^3.1.0",
     "@libp2p/interface-peer-id": "^2.0.2",
-    "@libp2p/interfaces": "^3.3.1",
+    "@libp2p/interfaces": "^3.3.2",
     "interface-blockstore": "^5.0.0",
     "interface-datastore": "^8.0.0",
     "interface-store": "^5.0.1",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -155,13 +155,13 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-libp2p": "^1.1.0",
-    "@libp2p/interface-peer-id": "^2.0.1",
+    "@libp2p/interface-libp2p": "^3.1.0",
+    "@libp2p/interface-peer-id": "^2.0.2",
     "@libp2p/interfaces": "^3.3.1",
     "interface-blockstore": "^5.0.0",
     "interface-datastore": "^8.0.0",
     "interface-store": "^5.0.1",
-    "ipfs-bitswap": "^17.0.0",
+    "ipfs-bitswap": "^18.0.0",
     "multiformats": "^11.0.1",
     "progress-events": "^1.0.0"
   },

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -17,7 +17,6 @@
 import type { Blocks } from './blocks.js'
 import type { Pins } from './pins.js'
 import type { Libp2p } from '@libp2p/interface-libp2p'
-import type { PeerId } from '@libp2p/interface-peer-id'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { Datastore } from 'interface-datastore'
 import type { CID } from 'multiformats/cid'
@@ -28,11 +27,11 @@ export type { Await, AwaitIterable } from 'interface-store'
 /**
  * The API presented by a Helia node.
  */
-export interface Helia {
+export interface Helia<T = Libp2p> {
   /**
    * The underlying libp2p node
    */
-  libp2p: Libp2p
+  libp2p: T
 
   /**
    * Where the blocks are stored
@@ -71,12 +70,4 @@ export type GcEvents =
 
 export interface GCOptions extends AbortOptions, ProgressOptions<GcEvents> {
 
-}
-
-export interface InfoOptions extends AbortOptions {
-  /**
-   * If passed, return information about this PeerId, defaults
-   * to the ID of the current node.
-   */
-  peerId?: PeerId
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -52,21 +52,21 @@
     "test:electron-main": "aegir test -t electron-main"
   },
   "devDependencies": {
-    "@chainsafe/libp2p-noise": "^11.0.0",
-    "@chainsafe/libp2p-yamux": "^3.0.5",
+    "@chainsafe/libp2p-noise": "^12.0.0",
+    "@chainsafe/libp2p-yamux": "^4.0.2",
     "@helia/interface": "^1.0.0",
-    "@libp2p/tcp": "^6.1.2",
-    "@libp2p/websockets": "^5.0.3",
+    "@libp2p/tcp": "^7.0.1",
+    "@libp2p/websockets": "^6.0.1",
     "@multiformats/sha3": "^2.0.15",
     "aegir": "^39.0.4",
     "blockstore-core": "^4.0.0",
     "datastore-core": "^9.0.0",
-    "go-ipfs": "^0.19.0",
+    "go-ipfs": "^0.20.0",
     "helia": "^1.0.0",
     "ipfsd-ctl": "^13.0.0",
     "it-to-buffer": "^4.0.1",
     "kubo-rpc-client": "^3.0.0",
-    "libp2p": "^0.44.0",
+    "libp2p": "^0.45.1",
     "multiformats": "^11.0.1"
   },
   "browser": {

--- a/packages/interop/test/blockstore.spec.ts
+++ b/packages/interop/test/blockstore.spec.ts
@@ -19,7 +19,9 @@ describe('blockstore', () => {
     kubo = await createKuboNode()
 
     // connect the two nodes
-    await helia.libp2p.peerStore.addressBook.add(kubo.peer.id, kubo.peer.addresses)
+    await helia.libp2p.peerStore.merge(kubo.peer.id, {
+      multiaddrs: kubo.peer.addresses
+    })
     await helia.libp2p.dial(kubo.peer.id)
   })
 

--- a/packages/interop/test/fixtures/create-helia.browser.ts
+++ b/packages/interop/test/fixtures/create-helia.browser.ts
@@ -6,6 +6,7 @@ import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type HeliaInit } from 'helia'
 import { createLibp2p } from 'libp2p'
+import { identifyService } from 'libp2p/identify'
 import type { Helia } from '@helia/interface'
 
 export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia> {
@@ -26,8 +27,12 @@ export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia
       yamux()
     ],
     datastore,
-    nat: {
-      enabled: false
+    services: {
+      identify: identifyService()
+    },
+    connectionGater: {
+      // allow dialing loopback
+      denyDialMultiaddr: () => false
     }
   })
 

--- a/packages/interop/test/fixtures/create-helia.ts
+++ b/packages/interop/test/fixtures/create-helia.ts
@@ -5,6 +5,7 @@ import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type HeliaInit } from 'helia'
 import { createLibp2p } from 'libp2p'
+import { identifyService } from 'libp2p/identify'
 import type { Helia } from '@helia/interface'
 
 export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia> {
@@ -27,8 +28,8 @@ export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia
       yamux()
     ],
     datastore,
-    nat: {
-      enabled: false
+    services: {
+      identify: identifyService()
     }
   })
 

--- a/packages/interop/test/hashes.spec.ts
+++ b/packages/interop/test/hashes.spec.ts
@@ -24,7 +24,9 @@ describe('hashes', () => {
     kubo = await createKuboNode()
 
     // connect the two nodes
-    await helia.libp2p.peerStore.addressBook.add(kubo.peer.id, kubo.peer.addresses)
+    await helia.libp2p.peerStore.merge(kubo.peer.id, {
+      multiaddrs: kubo.peer.addresses
+    })
     await helia.libp2p.dial(kubo.peer.id)
   })
 


### PR DESCRIPTION
The original intention was to allow users to configure a libp2p node to their requirements but it's a non-trivial undertaking unless the user is deeply familiar with the libp2p stack.

Instead, let's provide node and browser libp2p instances with sensible defaults that give the user the best chance of success on first try.

Fixes #121