### PR TITLE
fix: dedupe bootstrap list

### DIFF
--- a/packages/helia/src/utils/bootstrappers.ts
+++ b/packages/helia/src/utils/bootstrappers.ts
@@ -1,0 +1,11 @@
+
+// this list comes from https://github.com/ipfs/kubo/blob/da28fbc65a2e0f1ce59f9923823326ae2bc4f713/config/bootstrap_peers.go#L17
+export const bootstrapConfig = {
+  list: [
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt',
+    '/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ'
+  ]
+}

--- a/packages/helia/src/utils/libp2p.browser.ts
+++ b/packages/helia/src/utils/libp2p.browser.ts
@@ -12,6 +12,7 @@ import { createLibp2p as create } from 'libp2p'
 import { autoNATService } from 'libp2p/autonat'
 import { circuitRelayTransport, circuitRelayServer } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
+import { bootstrapConfig } from './bootstrappers.js'
 import type { CreateLibp2pOptions } from './libp2p.js'
 import type { Libp2p } from '@libp2p/interface-libp2p'
 import type { PubSub } from '@libp2p/interface-pubsub'
@@ -41,14 +42,7 @@ export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{
       mplex()
     ],
     peerDiscovery: [
-      bootstrap({
-        list: [
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
-        ]
-      })
+      bootstrap(bootstrapConfig)
     ],
     contentRouters: [
       ipniContentRouting('https://cid.contact')

--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -13,6 +13,7 @@ import { autoNATService } from 'libp2p/autonat'
 import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
 import { uPnPNATService } from 'libp2p/upnp-nat'
+import { bootstrapConfig } from './bootstrappers.js'
 import type { Libp2p } from '@libp2p/interface-libp2p'
 import type { PubSub } from '@libp2p/interface-pubsub'
 import type { Datastore } from 'interface-datastore'
@@ -46,14 +47,7 @@ export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{
     ],
     peerDiscovery: [
       mdns(),
-      bootstrap({
-        list: [
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
-          '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
-        ]
-      })
+      bootstrap(bootstrapConfig)
     ],
     contentRouters: [
       ipniContentRouting('https://cid.contact')


### PR DESCRIPTION
List of bootstrap nodes is in one place now and links to the source.

Refs: https://github.com/ipfs/helia/pull/127#discussion_r1199152374