### PR TITLE
feat: allow passing partial libp2p config to helia factory

### DIFF
--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -187,7 +187,7 @@
     "sinon-ts": "^1.0.0"
   },
   "browser": {
-    "./dist/src/utils/libp2p.js": "./dist/src/utils/libp2p.browser.js"
+    "./dist/src/utils/libp2p-defaults.js": "./dist/src/utils/libp2p-defaults.browser.js"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts"

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -3,25 +3,22 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { bootstrap } from '@libp2p/bootstrap'
 import { ipniContentRouting } from '@libp2p/ipni-content-routing'
-import { kadDHT, type DualKadDHT } from '@libp2p/kad-dht'
+import { type DualKadDHT, kadDHT } from '@libp2p/kad-dht'
 import { mplex } from '@libp2p/mplex'
 import { webRTC, webRTCDirect } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
 import { webTransport } from '@libp2p/webtransport'
 import { ipnsSelector } from 'ipns/selector'
 import { ipnsValidator } from 'ipns/validator'
-import { createLibp2p as create } from 'libp2p'
 import { autoNATService } from 'libp2p/autonat'
-import { circuitRelayTransport, circuitRelayServer } from 'libp2p/circuit-relay'
+import { circuitRelayTransport } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
 import { bootstrapConfig } from './bootstrappers.js'
-import type { CreateLibp2pOptions } from './libp2p.js'
-import type { Libp2p } from '@libp2p/interface-libp2p'
 import type { PubSub } from '@libp2p/interface-pubsub'
+import type { Libp2pOptions } from 'libp2p'
 
-export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{ dht: DualKadDHT, pubsub: PubSub }>> {
-  return create({
-    ...opts,
+export function libp2pDefaults (): Libp2pOptions<{ dht: DualKadDHT, pubsub: PubSub, identify: unknown, autoNAT: unknown }> {
+  return {
     addresses: {
       listen: [
         '/webrtc'
@@ -61,10 +58,7 @@ export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{
         selectors: {
           ipns: ipnsSelector
         }
-      }),
-      relay: circuitRelayServer({
-        advertise: true
       })
     }
-  })
+  }
 }

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -1,0 +1,67 @@
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
+import { noise } from '@chainsafe/libp2p-noise'
+import { yamux } from '@chainsafe/libp2p-yamux'
+import { bootstrap } from '@libp2p/bootstrap'
+import { ipniContentRouting } from '@libp2p/ipni-content-routing'
+import { type DualKadDHT, kadDHT } from '@libp2p/kad-dht'
+import { mdns } from '@libp2p/mdns'
+import { mplex } from '@libp2p/mplex'
+import { tcp } from '@libp2p/tcp'
+import { webSockets } from '@libp2p/websockets'
+import { ipnsSelector } from 'ipns/selector'
+import { ipnsValidator } from 'ipns/validator'
+import { autoNATService } from 'libp2p/autonat'
+import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from 'libp2p/circuit-relay'
+import { identifyService } from 'libp2p/identify'
+import { uPnPNATService } from 'libp2p/upnp-nat'
+import { bootstrapConfig } from './bootstrappers.js'
+import type { PubSub } from '@libp2p/interface-pubsub'
+import type { Libp2pOptions } from 'libp2p'
+
+export function libp2pDefaults (): Libp2pOptions<{ dht: DualKadDHT, pubsub: PubSub, relay: CircuitRelayService, identify: unknown, autoNAT: unknown, upnp: unknown }> {
+  return {
+    addresses: {
+      listen: [
+        '/ip4/0.0.0.0/tcp/0'
+      ]
+    },
+    transports: [
+      tcp(),
+      webSockets(),
+      circuitRelayTransport({
+        discoverRelays: 1
+      })
+    ],
+    connectionEncryption: [
+      noise()
+    ],
+    streamMuxers: [
+      yamux(),
+      mplex()
+    ],
+    peerDiscovery: [
+      mdns(),
+      bootstrap(bootstrapConfig)
+    ],
+    contentRouters: [
+      ipniContentRouting('https://cid.contact')
+    ],
+    services: {
+      identify: identifyService(),
+      autoNAT: autoNATService(),
+      upnp: uPnPNATService(),
+      pubsub: gossipsub(),
+      dht: kadDHT({
+        validators: {
+          ipns: ipnsValidator
+        },
+        selectors: {
+          ipns: ipnsSelector
+        }
+      }),
+      relay: circuitRelayServer({
+        advertise: true
+      })
+    }
+  }
+}

--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -1,75 +1,24 @@
-import { gossipsub } from '@chainsafe/libp2p-gossipsub'
-import { noise } from '@chainsafe/libp2p-noise'
-import { yamux } from '@chainsafe/libp2p-yamux'
-import { bootstrap } from '@libp2p/bootstrap'
-import { ipniContentRouting } from '@libp2p/ipni-content-routing'
-import { type DualKadDHT, kadDHT } from '@libp2p/kad-dht'
-import { mdns } from '@libp2p/mdns'
-import { mplex } from '@libp2p/mplex'
-import { tcp } from '@libp2p/tcp'
-import { webSockets } from '@libp2p/websockets'
-import { ipnsSelector } from 'ipns/selector'
-import { ipnsValidator } from 'ipns/validator'
-import { createLibp2p as create } from 'libp2p'
-import { autoNATService } from 'libp2p/autonat'
-import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from 'libp2p/circuit-relay'
-import { identifyService } from 'libp2p/identify'
-import { uPnPNATService } from 'libp2p/upnp-nat'
-import { bootstrapConfig } from './bootstrappers.js'
+import { createLibp2p as create, type Libp2pOptions } from 'libp2p'
+import { libp2pDefaults } from './libp2p-defaults.js'
 import type { Libp2p } from '@libp2p/interface-libp2p'
 import type { PubSub } from '@libp2p/interface-pubsub'
+import type { DualKadDHT } from '@libp2p/kad-dht'
 import type { Datastore } from 'interface-datastore'
+import type { CircuitRelayService } from 'libp2p/circuit-relay'
 
 export interface CreateLibp2pOptions {
   datastore: Datastore
   start?: boolean
 }
 
-export async function createLibp2p (opts: CreateLibp2pOptions): Promise<Libp2p<{ dht: DualKadDHT, pubsub: PubSub, relay: CircuitRelayService }>> {
+export async function createLibp2p (datastore: Datastore, options?: Libp2pOptions<any>): Promise<Libp2p<{ dht: DualKadDHT, pubsub: PubSub, relay: CircuitRelayService }>> {
+  const defaults = libp2pDefaults()
+  options = options ?? {}
+
   return create({
-    ...opts,
-    addresses: {
-      listen: [
-        '/ip4/0.0.0.0/tcp/0'
-      ]
-    },
-    transports: [
-      tcp(),
-      webSockets(),
-      circuitRelayTransport({
-        discoverRelays: 1
-      })
-    ],
-    connectionEncryption: [
-      noise()
-    ],
-    streamMuxers: [
-      yamux(),
-      mplex()
-    ],
-    peerDiscovery: [
-      mdns(),
-      bootstrap(bootstrapConfig)
-    ],
-    contentRouters: [
-      ipniContentRouting('https://cid.contact')
-    ],
-    services: {
-      identify: identifyService(),
-      autoNAT: autoNATService(),
-      upnp: uPnPNATService(),
-      pubsub: gossipsub(),
-      dht: kadDHT({
-        validators: {
-          ipns: ipnsValidator
-        },
-        selectors: {
-          ipns: ipnsSelector
-        }
-      }),
-      relay: circuitRelayServer({
-        advertise: true
-      })
-    }
+    datastore,
+    ...defaults,
+    ...options,
+    start: false
   })
 }

--- a/packages/helia/test/libp2p.spec.ts
+++ b/packages/helia/test/libp2p.spec.ts
@@ -1,0 +1,53 @@
+/* eslint-env mocha */
+
+import { webSockets } from '@libp2p/websockets'
+import { expect } from 'aegir/chai'
+import { createLibp2p } from 'libp2p'
+import { createHelia } from '../src/index.js'
+import type { Helia } from '@helia/interface'
+
+describe('libp2p', () => {
+  let helia: Helia
+
+  afterEach(async () => {
+    if (helia != null) {
+      await helia.stop()
+    }
+  })
+
+  it('allows passing libp2p config', async () => {
+    const config = {}
+
+    helia = await createHelia({
+      libp2p: config
+    })
+
+    expect(Object.keys(helia.libp2p.services)).to.not.be.empty()
+  })
+
+  it('allows overriding libp2p config', async () => {
+    const config = {
+      services: {}
+    }
+
+    helia = await createHelia({
+      libp2p: config
+    })
+
+    expect(Object.keys(helia.libp2p.services)).to.be.empty()
+  })
+
+  it('allows passing a libp2p node', async () => {
+    const libp2p = await createLibp2p({
+      transports: [
+        webSockets()
+      ]
+    })
+
+    helia = await createHelia({
+      libp2p
+    })
+
+    expect(helia.libp2p).to.equal(libp2p)
+  })
+})


### PR DESCRIPTION
If the user just wants to override specific parts of the libp2p config don't make them pass a whole libp2p object in, instead accept an Libp2pOptions object and use the keys from that to override the default config.