### PR TITLE
fix: ensure pinned blocks are present

### DIFF
--- a/packages/helia/.aegir.js
+++ b/packages/helia/.aegir.js
@@ -1,0 +1,49 @@
+import { circuitRelayServer } from 'libp2p/circuit-relay'
+import { identifyService } from 'libp2p/identify'
+import { WebSockets } from '@multiformats/mafmt'
+
+/** @type {import('aegir').PartialOptions} */
+const options = {
+  test: {
+    before: async () => {
+      // use dynamic import otherwise the source may not have been built yet
+      const { createHelia } = await import('./dist/src/index.js')
+
+      const helia = await createHelia({
+        libp2p: {
+          addresses: {
+            listen: [
+              `/ip4/127.0.0.1/tcp/0/ws`
+            ]
+          },
+          services: {
+            identify: identifyService(),
+            relay: circuitRelayServer({
+              reservations: {
+                maxReservations: Infinity,
+                applyDefaultLimit: false
+              }
+            })
+          }
+        }
+      })
+
+      return {
+        env: {
+          RELAY_SERVER: helia.libp2p.getMultiaddrs()
+            .filter(ma => WebSockets.matches(ma))
+            .map(ma => ma.toString())
+            .pop()
+        },
+        helia
+      }
+    },
+    after: async (_, beforeResult) => {
+      if (beforeResult.helia != null) {
+        await beforeResult.helia.stop()
+      }
+    }
+  }
+}
+
+export default options

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -180,6 +180,7 @@
   "devDependencies": {
     "@ipld/dag-cbor": "^9.0.0",
     "@ipld/dag-json": "^10.0.1",
+    "@multiformats/mafmt": "^12.1.5",
     "@types/sinon": "^10.0.14",
     "aegir": "^39.0.4",
     "delay": "^6.0.0",

--- a/packages/helia/src/helia.ts
+++ b/packages/helia/src/helia.ts
@@ -7,6 +7,7 @@ import { CustomProgressEvent } from 'progress-events'
 import { PinsImpl } from './pins.js'
 import { BlockStorage } from './storage.js'
 import { assertDatastoreVersionIsCurrent } from './utils/datastore-version.js'
+import { NetworkedStorage } from './utils/networked-storage.js'
 import type { HeliaInit } from '.'
 import type { GCOptions, Helia } from '@helia/interface'
 import type { Pins } from '@helia/interface/pins'
@@ -56,11 +57,14 @@ export class HeliaImpl implements Helia {
       }
     })
 
-    this.pins = new PinsImpl(init.datastore, init.blockstore, init.dagWalkers ?? [])
+    const networkedStorage = new NetworkedStorage(init.blockstore, {
+      bitswap: this.#bitswap
+    })
+
+    this.pins = new PinsImpl(init.datastore, networkedStorage, init.dagWalkers ?? [])
 
     this.libp2p = init.libp2p
-    this.blockstore = new BlockStorage(init.blockstore, this.pins, {
-      bitswap: this.#bitswap,
+    this.blockstore = new BlockStorage(networkedStorage, this.pins, {
       holdGcLock: init.holdGcLock
     })
     this.datastore = init.datastore

--- a/packages/helia/src/storage.ts
+++ b/packages/helia/src/storage.ts
@@ -1,19 +1,15 @@
-import filter from 'it-filter'
-import forEach from 'it-foreach'
 import createMortice from 'mortice'
-import { CustomProgressEvent, type ProgressOptions } from 'progress-events'
 import type { Blocks, Pair, DeleteManyBlocksProgressEvents, DeleteBlockProgressEvents, GetBlockProgressEvents, GetManyBlocksProgressEvents, PutManyBlocksProgressEvents, PutBlockProgressEvents, GetAllBlocksProgressEvents } from '@helia/interface/blocks'
 import type { Pins } from '@helia/interface/pins'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { Blockstore } from 'interface-blockstore'
 import type { AwaitIterable } from 'interface-store'
-import type { Bitswap } from 'ipfs-bitswap'
 import type { Mortice } from 'mortice'
 import type { CID } from 'multiformats/cid'
+import type { ProgressOptions } from 'progress-events'
 
 export interface BlockStorageInit {
   holdGcLock?: boolean
-  bitswap?: Bitswap
 }
 
 export interface GetOptions extends AbortOptions {
@@ -28,7 +24,6 @@ export interface GetOptions extends AbortOptions {
 export class BlockStorage implements Blocks {
   public lock: Mortice
   private readonly child: Blockstore
-  private readonly bitswap?: Bitswap
   private readonly pins: Pins
 
   /**
@@ -36,7 +31,6 @@ export class BlockStorage implements Blocks {
    */
   constructor (blockstore: Blockstore, pins: Pins, options: BlockStorageInit = {}) {
     this.child = blockstore
-    this.bitswap = options.bitswap
     this.pins = pins
     this.lock = createMortice({
       singleProcess: options.holdGcLock
@@ -54,18 +48,6 @@ export class BlockStorage implements Blocks {
     const releaseLock = await this.lock.readLock()
 
     try {
-      if (await this.child.has(cid)) {
-        options.onProgress?.(new CustomProgressEvent<CID>('blocks:put:duplicate', cid))
-        return cid
-      }
-
-      if (this.bitswap?.isStarted() === true) {
-        options.onProgress?.(new CustomProgressEvent<CID>('blocks:put:bitswap:notify', cid))
-        this.bitswap.notify(cid, block, options)
-      }
-
-      options.onProgress?.(new CustomProgressEvent<CID>('blocks:put:blockstore:put', cid))
-
       return await this.child.put(cid, block, options)
     } finally {
       releaseLock()
@@ -79,23 +61,7 @@ export class BlockStorage implements Blocks {
     const releaseLock = await this.lock.readLock()
 
     try {
-      const missingBlocks = filter(blocks, async ({ cid }): Promise<boolean> => {
-        const has = await this.child.has(cid)
-
-        if (has) {
-          options.onProgress?.(new CustomProgressEvent<CID>('blocks:put-many:duplicate', cid))
-        }
-
-        return !has
-      })
-
-      const notifyEach = forEach(missingBlocks, ({ cid, block }): void => {
-        options.onProgress?.(new CustomProgressEvent<CID>('blocks:put-many:bitswap:notify', cid))
-        this.bitswap?.notify(cid, block, options)
-      })
-
-      options.onProgress?.(new CustomProgressEvent('blocks:put-many:blockstore:put-many'))
-      yield * this.child.putMany(notifyEach, options)
+      yield * this.child.putMany(blocks, options)
     } finally {
       releaseLock()
     }
@@ -108,18 +74,6 @@ export class BlockStorage implements Blocks {
     const releaseLock = await this.lock.readLock()
 
     try {
-      if (this.bitswap?.isStarted() != null && !(await this.child.has(cid))) {
-        options.onProgress?.(new CustomProgressEvent<CID>('blocks:get:bitswap:get', cid))
-        const block = await this.bitswap.want(cid, options)
-
-        options.onProgress?.(new CustomProgressEvent<CID>('blocks:get:blockstore:put', cid))
-        await this.child.put(cid, block, options)
-
-        return block
-      }
-
-      options.onProgress?.(new CustomProgressEvent<CID>('blocks:get:blockstore:get', cid))
-
       return await this.child.get(cid, options)
     } finally {
       releaseLock()
@@ -133,15 +87,7 @@ export class BlockStorage implements Blocks {
     const releaseLock = await this.lock.readLock()
 
     try {
-      options.onProgress?.(new CustomProgressEvent('blocks:get-many:blockstore:get-many'))
-      yield * this.child.getMany(forEach(cids, async (cid): Promise<void> => {
-        if (this.bitswap?.isStarted() === true && !(await this.child.has(cid))) {
-          options.onProgress?.(new CustomProgressEvent<CID>('blocks:get-many:bitswap:get', cid))
-          const block = await this.bitswap.want(cid, options)
-          options.onProgress?.(new CustomProgressEvent<CID>('blocks:get-many:blockstore:put', cid))
-          await this.child.put(cid, block, options)
-        }
-      }))
+      yield * this.child.getMany(cids, options)
     } finally {
       releaseLock()
     }
@@ -158,7 +104,6 @@ export class BlockStorage implements Blocks {
         throw new Error('CID was pinned')
       }
 
-      options.onProgress?.(new CustomProgressEvent<CID>('blocks:delete:blockstore:delete', cid))
       await this.child.delete(cid, options)
     } finally {
       releaseLock()
@@ -174,7 +119,6 @@ export class BlockStorage implements Blocks {
     try {
       const storage = this
 
-      options.onProgress?.(new CustomProgressEvent('blocks:delete-many:blockstore:delete-many'))
       yield * this.child.deleteMany((async function * (): AsyncGenerator<CID> {
         for await (const cid of cids) {
           if (await storage.pins.isPinned(cid)) {
@@ -203,7 +147,6 @@ export class BlockStorage implements Blocks {
     const releaseLock = await this.lock.readLock()
 
     try {
-      options.onProgress?.(new CustomProgressEvent('blocks:get-all:blockstore:get-many'))
       yield * this.child.getAll(options)
     } finally {
       releaseLock()

--- a/packages/helia/src/utils/networked-storage.ts
+++ b/packages/helia/src/utils/networked-storage.ts
@@ -1,0 +1,146 @@
+import filter from 'it-filter'
+import forEach from 'it-foreach'
+import { CustomProgressEvent, type ProgressOptions } from 'progress-events'
+import type { Blocks, Pair, DeleteManyBlocksProgressEvents, DeleteBlockProgressEvents, GetBlockProgressEvents, GetManyBlocksProgressEvents, PutManyBlocksProgressEvents, PutBlockProgressEvents, GetAllBlocksProgressEvents } from '@helia/interface/blocks'
+import type { AbortOptions } from '@libp2p/interfaces'
+import type { Blockstore } from 'interface-blockstore'
+import type { AwaitIterable } from 'interface-store'
+import type { Bitswap } from 'ipfs-bitswap'
+import type { CID } from 'multiformats/cid'
+
+export interface BlockStorageInit {
+  holdGcLock?: boolean
+  bitswap?: Bitswap
+}
+
+export interface GetOptions extends AbortOptions {
+  progress?: (evt: Event) => void
+}
+
+/**
+ * Networked storage wraps a regular blockstore - when getting blocks if the
+ * blocks are not present Bitswap will be used to fetch them from network peers.
+ */
+export class NetworkedStorage implements Blocks {
+  private readonly child: Blockstore
+  private readonly bitswap?: Bitswap
+
+  /**
+   * Create a new BlockStorage
+   */
+  constructor (blockstore: Blockstore, options: BlockStorageInit = {}) {
+    this.child = blockstore
+    this.bitswap = options.bitswap
+  }
+
+  unwrap (): Blockstore {
+    return this.child
+  }
+
+  /**
+   * Put a block to the underlying datastore
+   */
+  async put (cid: CID, block: Uint8Array, options: AbortOptions & ProgressOptions<PutBlockProgressEvents> = {}): Promise<CID> {
+    if (await this.child.has(cid)) {
+      options.onProgress?.(new CustomProgressEvent<CID>('blocks:put:duplicate', cid))
+      return cid
+    }
+
+    if (this.bitswap?.isStarted() === true) {
+      options.onProgress?.(new CustomProgressEvent<CID>('blocks:put:bitswap:notify', cid))
+      this.bitswap.notify(cid, block, options)
+    }
+
+    options.onProgress?.(new CustomProgressEvent<CID>('blocks:put:blockstore:put', cid))
+
+    return this.child.put(cid, block, options)
+  }
+
+  /**
+   * Put a multiple blocks to the underlying datastore
+   */
+  async * putMany (blocks: AwaitIterable<{ cid: CID, block: Uint8Array }>, options: AbortOptions & ProgressOptions<PutManyBlocksProgressEvents> = {}): AsyncIterable<CID> {
+    const missingBlocks = filter(blocks, async ({ cid }): Promise<boolean> => {
+      const has = await this.child.has(cid)
+
+      if (has) {
+        options.onProgress?.(new CustomProgressEvent<CID>('blocks:put-many:duplicate', cid))
+      }
+
+      return !has
+    })
+
+    const notifyEach = forEach(missingBlocks, ({ cid, block }): void => {
+      options.onProgress?.(new CustomProgressEvent<CID>('blocks:put-many:bitswap:notify', cid))
+      this.bitswap?.notify(cid, block, options)
+    })
+
+    options.onProgress?.(new CustomProgressEvent('blocks:put-many:blockstore:put-many'))
+    yield * this.child.putMany(notifyEach, options)
+  }
+
+  /**
+   * Get a block by cid
+   */
+  async get (cid: CID, options: AbortOptions & ProgressOptions<GetBlockProgressEvents> = {}): Promise<Uint8Array> {
+    if (this.bitswap?.isStarted() != null && !(await this.child.has(cid))) {
+      options.onProgress?.(new CustomProgressEvent<CID>('blocks:get:bitswap:get', cid))
+      const block = await this.bitswap.want(cid, options)
+
+      options.onProgress?.(new CustomProgressEvent<CID>('blocks:get:blockstore:put', cid))
+      await this.child.put(cid, block, options)
+
+      return block
+    }
+
+    options.onProgress?.(new CustomProgressEvent<CID>('blocks:get:blockstore:get', cid))
+
+    return this.child.get(cid, options)
+  }
+
+  /**
+   * Get multiple blocks back from an (async) iterable of cids
+   */
+  async * getMany (cids: AwaitIterable<CID>, options: AbortOptions & ProgressOptions<GetManyBlocksProgressEvents> = {}): AsyncIterable<Pair> {
+    options.onProgress?.(new CustomProgressEvent('blocks:get-many:blockstore:get-many'))
+
+    yield * this.child.getMany(forEach(cids, async (cid): Promise<void> => {
+      if (this.bitswap?.isStarted() === true && !(await this.child.has(cid))) {
+        options.onProgress?.(new CustomProgressEvent<CID>('blocks:get-many:bitswap:get', cid))
+        const block = await this.bitswap.want(cid, options)
+        options.onProgress?.(new CustomProgressEvent<CID>('blocks:get-many:blockstore:put', cid))
+        await this.child.put(cid, block, options)
+      }
+    }))
+  }
+
+  /**
+   * Delete a block from the blockstore
+   */
+  async delete (cid: CID, options: AbortOptions & ProgressOptions<DeleteBlockProgressEvents> = {}): Promise<void> {
+    options.onProgress?.(new CustomProgressEvent<CID>('blocks:delete:blockstore:delete', cid))
+
+    await this.child.delete(cid, options)
+  }
+
+  /**
+   * Delete multiple blocks from the blockstore
+   */
+  async * deleteMany (cids: AwaitIterable<CID>, options: AbortOptions & ProgressOptions<DeleteManyBlocksProgressEvents> = {}): AsyncIterable<CID> {
+    options.onProgress?.(new CustomProgressEvent('blocks:delete-many:blockstore:delete-many'))
+    yield * this.child.deleteMany((async function * (): AsyncGenerator<CID> {
+      for await (const cid of cids) {
+        yield cid
+      }
+    }()), options)
+  }
+
+  async has (cid: CID, options: AbortOptions = {}): Promise<boolean> {
+    return this.child.has(cid, options)
+  }
+
+  async * getAll (options: AbortOptions & ProgressOptions<GetAllBlocksProgressEvents> = {}): AsyncIterable<Pair> {
+    options.onProgress?.(new CustomProgressEvent('blocks:get-all:blockstore:get-many'))
+    yield * this.child.getAll(options)
+  }
+}

--- a/packages/helia/test/fixtures/create-helia.ts
+++ b/packages/helia/test/fixtures/create-helia.ts
@@ -1,0 +1,30 @@
+import { webSockets } from '@libp2p/websockets'
+import * as Filters from '@libp2p/websockets/filters'
+import { circuitRelayTransport } from 'libp2p/circuit-relay'
+import { identifyService } from 'libp2p/identify'
+import { createHelia as createNode } from '../../src/index.js'
+import type { Helia } from '@helia/interface'
+
+export async function createHelia (): Promise<Helia> {
+  return createNode({
+    libp2p: {
+      addresses: {
+        listen: [
+          `${process.env.RELAY_SERVER}/p2p-circuit`
+        ]
+      },
+      transports: [
+        webSockets({
+          filter: Filters.all
+        }),
+        circuitRelayTransport()
+      ],
+      connectionGater: {
+        denyDialMultiaddr: async () => false
+      },
+      services: {
+        identify: identifyService()
+      }
+    }
+  })
+}

--- a/packages/helia/test/utils/networked-storage.spec.ts
+++ b/packages/helia/test/utils/networked-storage.spec.ts
@@ -1,0 +1,170 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { MemoryBlockstore } from 'blockstore-core'
+import delay from 'delay'
+import all from 'it-all'
+import drain from 'it-drain'
+import * as raw from 'multiformats/codecs/raw'
+import Sinon from 'sinon'
+import { type StubbedInstance, stubInterface } from 'sinon-ts'
+import { NetworkedStorage } from '../../src/utils/networked-storage.js'
+import { createBlock } from '../fixtures/create-block.js'
+import type { Blockstore } from 'interface-blockstore'
+import type { Bitswap } from 'ipfs-bitswap'
+import type { CID } from 'multiformats/cid'
+
+describe('storage', () => {
+  let storage: NetworkedStorage
+  let blockstore: Blockstore
+  let bitswap: StubbedInstance<Bitswap>
+  let blocks: Array<{ cid: CID, block: Uint8Array }>
+
+  beforeEach(async () => {
+    blocks = []
+
+    for (let i = 0; i < 10; i++) {
+      blocks.push(await createBlock(raw.code, Uint8Array.from([0, 1, 2, i])))
+    }
+
+    blockstore = new MemoryBlockstore()
+    bitswap = stubInterface<Bitswap>()
+    storage = new NetworkedStorage(blockstore, {
+      bitswap
+    })
+  })
+
+  it('gets a block from the blockstore', async () => {
+    const { cid, block } = blocks[0]
+    await blockstore.put(cid, block)
+
+    const retrieved = await storage.get(cid)
+    expect(retrieved).to.equalBytes(block)
+  })
+
+  it('gets a block from the blockstore with progress', async () => {
+    const { cid, block } = blocks[0]
+    await blockstore.put(cid, block)
+
+    const onProgress = Sinon.stub()
+
+    await storage.get(cid, {
+      onProgress
+    })
+    expect(onProgress.called).to.be.true()
+  })
+
+  it('gets many blocks from the blockstore', async () => {
+    const count = 5
+
+    for (let i = 0; i < count; i++) {
+      const { cid, block } = blocks[i]
+      await blockstore.put(cid, block)
+    }
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+  })
+
+  it('puts a block into the blockstore', async () => {
+    const { cid, block } = blocks[0]
+    await storage.put(cid, block)
+
+    const retrieved = await blockstore.get(cid)
+    expect(retrieved).to.equalBytes(block)
+  })
+
+  it('puts many blocks into the blockstore', async () => {
+    const count = 5
+
+    await drain(storage.putMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield { cid: blocks[i].cid, block: blocks[i].block }
+        await delay(10)
+      }
+    }()))
+
+    const retrieved = await all(blockstore.getMany(new Array(count).fill(0).map((_, i) => blocks[i].cid)))
+    expect(retrieved).to.deep.equal(retrieved)
+  })
+
+  it('gets a block from bitswap when it is not in the blockstore', async () => {
+    const { cid, block } = blocks[0]
+
+    bitswap.isStarted.returns(true)
+    bitswap.want.withArgs(cid).resolves(block)
+
+    expect(await blockstore.has(cid)).to.be.false()
+
+    const returned = await storage.get(cid)
+
+    expect(await blockstore.has(cid)).to.be.true()
+    expect(returned).to.equalBytes(block)
+    expect(bitswap.want.called).to.be.true()
+  })
+
+  it('gets many blocks from bitswap when they are not in the blockstore', async () => {
+    bitswap.isStarted.returns(true)
+
+    const count = 5
+
+    for (let i = 0; i < count; i++) {
+      const { cid, block } = blocks[i]
+      bitswap.want.withArgs(cid).resolves(block)
+
+      expect(await blockstore.has(cid)).to.be.false()
+    }
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+
+    for (let i = 0; i < count; i++) {
+      const { cid } = blocks[i]
+      expect(bitswap.want.calledWith(cid)).to.be.true()
+      expect(await blockstore.has(cid)).to.be.true()
+    }
+  })
+
+  it('gets some blocks from bitswap when they are not in the blockstore', async () => {
+    bitswap.isStarted.returns(true)
+
+    const count = 5
+
+    // blocks 0,1,3,4 are in the blockstore
+    await blockstore.put(blocks[0].cid, blocks[0].block)
+    await blockstore.put(blocks[1].cid, blocks[1].block)
+    await blockstore.put(blocks[3].cid, blocks[3].block)
+    await blockstore.put(blocks[4].cid, blocks[4].block)
+
+    // block #2 comes from bitswap but slowly
+    bitswap.want.withArgs(blocks[2].cid).callsFake(async () => {
+      await delay(100)
+      return blocks[2].block
+    })
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+
+    for (let i = 0; i < count; i++) {
+      expect(await blockstore.has(blocks[i].cid)).to.be.true()
+    }
+  })
+})

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -64,6 +64,7 @@
     "go-ipfs": "^0.20.0",
     "helia": "^1.0.0",
     "ipfsd-ctl": "^13.0.0",
+    "it-all": "^3.0.2",
     "it-to-buffer": "^4.0.1",
     "kubo-rpc-client": "^3.0.0",
     "libp2p": "^0.45.2",

--- a/packages/interop/test/pins.spec.ts
+++ b/packages/interop/test/pins.spec.ts
@@ -1,0 +1,65 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import all from 'it-all'
+import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { createHeliaNode } from './fixtures/create-helia.js'
+import { createKuboNode } from './fixtures/create-kubo.js'
+import type { Helia } from '@helia/interface'
+import type { Controller } from 'ipfsd-ctl'
+
+describe('pins', () => {
+  let helia: Helia
+  let kubo: Controller
+
+  beforeEach(async () => {
+    helia = await createHeliaNode()
+    kubo = await createKuboNode()
+
+    // connect the two nodes
+    await helia.libp2p.dial(kubo.peer.addresses)
+  })
+
+  afterEach(async () => {
+    if (helia != null) {
+      await helia.stop()
+    }
+
+    if (kubo != null) {
+      await kubo.stop()
+    }
+  })
+
+  it('pinning on kubo should pull from helia', async () => {
+    const input = Uint8Array.from([0, 1, 2, 3, 4])
+    const digest = await sha256.digest(input)
+    const cid = CID.createV1(raw.code, digest)
+
+    expect((await all(kubo.api.refs.local())).map(r => r.ref)).to.not.include(cid.toString())
+
+    await helia.blockstore.put(cid, input)
+
+    const pinned = await kubo.api.pin.add(cid)
+    expect(pinned.toString()).to.equal(cid.toString())
+
+    expect((await all(kubo.api.refs.local())).map(r => r.ref)).to.include(cid.toString())
+  })
+
+  it('pinning on helia should pull from kubo', async () => {
+    const input = Uint8Array.from([0, 1, 2, 3, 4])
+    const { cid } = await kubo.api.add({ content: input }, {
+      cidVersion: 1,
+      rawLeaves: true
+    })
+
+    await expect(helia.blockstore.has(cid)).to.eventually.be.false()
+
+    const output = await helia.pins.add(cid)
+
+    await expect(helia.blockstore.has(cid)).to.eventually.be.true()
+
+    expect(output.cid.toString()).to.equal(cid.toString())
+  })
+})


### PR DESCRIPTION
Creates a networked blockstore component that will pull missing blocks from the network when requested.

Passes this component to the pins component so when walking DAGs to pin blocks, and missing blocks will be fetched from peers.

Adds tests for the same.