### PR TITLE
chore: update changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,6 @@
 # Changelog
 
-## 1.0.0 (2023-03-20)
+Changelogs are available for monorepo projects at the following locations:
 
-
-### Features
-
-* add bitswap progress events ([#50](https://www.github.com/ipfs/helia/issues/50)) ([7460719](https://www.github.com/ipfs/helia/commit/7460719be44b4ff9bad629654efa29c56242e03a)), closes [#27](https://www.github.com/ipfs/helia/issues/27)
-* add pinning API ([#36](https://www.github.com/ipfs/helia/issues/36)) ([270bb98](https://www.github.com/ipfs/helia/commit/270bb988eb8aefc8afe68e3580c3ef18960b3188)), closes [#28](https://www.github.com/ipfs/helia/issues/28)
-* initial implementation ([#17](https://www.github.com/ipfs/helia/issues/17)) ([343d360](https://www.github.com/ipfs/helia/commit/343d36016b164ed45cec4eb670d7f74860166ce4))
-
-
-### Bug Fixes
-
-* extend blockstore interface ([#55](https://www.github.com/ipfs/helia/issues/55)) ([42308c0](https://www.github.com/ipfs/helia/commit/42308c0d75e81789d909470ded90ad81ee0f84c7))
-* make all helia args optional ([#37](https://www.github.com/ipfs/helia/issues/37)) ([d15d76c](https://www.github.com/ipfs/helia/commit/d15d76cdc40a31bd1e47ca09583cc685583243b9))
-* survive a cid causing an error during gc ([#38](https://www.github.com/ipfs/helia/issues/38)) ([5330188](https://www.github.com/ipfs/helia/commit/53301881dc6226ea3fc6823fd6e298e4d4796408))
-* update block events ([#58](https://www.github.com/ipfs/helia/issues/58)) ([d33be53](https://www.github.com/ipfs/helia/commit/d33be534972a4c238fc6d43c4284c6bd834ae218))
-* update blocks interface to align with interface-blockstore ([#54](https://www.github.com/ipfs/helia/issues/54)) ([202b966](https://www.github.com/ipfs/helia/commit/202b966df3866d449751f775ed3edc9c92e32f6a))
-* use release version of libp2p ([#59](https://www.github.com/ipfs/helia/issues/59)) ([a3a7c9c](https://www.github.com/ipfs/helia/commit/a3a7c9c2d81f2068fee85eeeca7425919f09e182))
+- [`/packages/interface`](./packages/interface/CHANGELOG.md) Helia API changelog
+- [`/packages/helia`](./packages/helia/CHANGELOG.md) Helia implementation changelog

--- a/packages/helia/CHANGELOG.md
+++ b/packages/helia/CHANGELOG.md
@@ -148,9 +148,7 @@
 * update interface-store to 5.x.x ([#63](https://github.com/ipfs/helia/issues/63)) ([5bf11d6](https://github.com/ipfs/helia/commit/5bf11d638eee423624ac49af97757d730744f384))
 * update sibling dependencies ([ac28d38](https://github.com/ipfs/helia/commit/ac28d3878f98a780fc57702921924fa92bd592a0))
 
-# Changelog
-
-## [0.1.0](https://www.github.com/ipfs/helia/compare/helia-v0.0.0...helia-v0.1.0) (2023-03-22)
+## helia-v0.1.0 (2023-03-22)
 
 
 ### Features
@@ -166,7 +164,6 @@
 * survive a cid causing an error during gc ([#38](https://www.github.com/ipfs/helia/issues/38)) ([5330188](https://www.github.com/ipfs/helia/commit/53301881dc6226ea3fc6823fd6e298e4d4796408))
 * update blocks interface to align with interface-blockstore ([#54](https://www.github.com/ipfs/helia/issues/54)) ([202b966](https://www.github.com/ipfs/helia/commit/202b966df3866d449751f775ed3edc9c92e32f6a))
 * use release version of libp2p ([#59](https://www.github.com/ipfs/helia/issues/59)) ([a3a7c9c](https://www.github.com/ipfs/helia/commit/a3a7c9c2d81f2068fee85eeeca7425919f09e182))
-
 
 
 ### Dependencies

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -50,9 +50,7 @@
 * update publish config ([913ab6a](https://github.com/ipfs/helia/commit/913ab6ae9a2970c4b908de04b8b6a236b931a3b0))
 * update release please config ([b52d5e3](https://github.com/ipfs/helia/commit/b52d5e3eecce41b10640426c339c99ad14ce874e))
 
-# Changelog
-
-## [0.1.0](https://www.github.com/ipfs/helia/compare/interface-v0.0.0...interface-v0.1.0) (2023-03-22)
+## @helia/interface-v0.1.0 (2023-03-22)
 
 
 ### Features


### PR DESCRIPTION
When switching between release please and semantic release the changelog format also changed so update to the semantic release format for consistency.