### PR TITLE
fix: typedoc landing page uses readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "release": "npm run docs:no-publish && aegir run release && npm run docs"
   },
   "devDependencies": {
-    "aegir": "^39.0.4"
+    "aegir": "^39.0.4",
+    "typedoc-plugin-mdn-links": "^3.0.3"
   },
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "generate": "aegir run generate",
     "build": "aegir run build",
     "lint": "aegir run lint",
-    "docs": "NODE_OPTIONS=--max_old_space_size=4096 aegir docs",
-    "docs:no-publish": "npm run docs -- --publish false",
+    "docs": "NODE_OPTIONS=--max_old_space_size=4096 aegir docs -- --name helia --titleLink './'",
+    "docs:no-publish": "NODE_OPTIONS=--max_old_space_size=4096 aegir docs --publish false -- --name helia --titleLink './'",
     "dep-check": "aegir run dep-check",
     "release": "npm run docs:no-publish && aegir run release && npm run docs"
   },


### PR DESCRIPTION
- fix: typedoc-plugin-mdn-links is available
- fix: typedoc landing page uses readme

fixes #176
