### PR TITLE
chore: allows to override kubo path

### DIFF
--- a/packages/interop/.aegir.js
+++ b/packages/interop/.aegir.js
@@ -12,7 +12,7 @@ export default {
           host: '127.0.0.1',
           port: ipfsdPort
         }, {
-          ipfsBin: (await import('go-ipfs')).default.path(),
+          ipfsBin: process.env.KUBO_BINARY ? process.env.KUBO_BINARY : (await import('go-ipfs')).default.path(),
           kuboRpcModule: kuboRpcClient,
           ipfsOptions: {
             config: {

--- a/packages/interop/.aegir.js
+++ b/packages/interop/.aegir.js
@@ -19,7 +19,8 @@ export default {
               Addresses: {
                 Swarm: [
                   "/ip4/0.0.0.0/tcp/0",
-                  "/ip4/0.0.0.0/tcp/0/ws"
+                  "/ip4/0.0.0.0/tcp/0/ws",
+                  "/ip4/0.0.0.0/udp/0/quic-v1/webtransport"
                 ]
               }
             }

--- a/packages/interop/test/fixtures/create-kubo.ts
+++ b/packages/interop/test/fixtures/create-kubo.ts
@@ -6,7 +6,7 @@ import * as kuboRpcClient from 'kubo-rpc-client'
 export async function createKuboNode (): Promise<Controller> {
   return createController({
     kuboRpcModule: kuboRpcClient,
-    ipfsBin: goIpfs.path(),
+    ipfsBin: process.env.KUBO_BINARY ? process.env.KUBO_BINARY : goIpfs.path(),
     test: true,
     ipfsOptions: {
       config: {

--- a/packages/interop/test/fixtures/create-kubo.ts
+++ b/packages/interop/test/fixtures/create-kubo.ts
@@ -13,7 +13,8 @@ export async function createKuboNode (): Promise<Controller> {
         Addresses: {
           Swarm: [
             '/ip4/0.0.0.0/tcp/0',
-            '/ip4/0.0.0.0/tcp/0/ws'
+            '/ip4/0.0.0.0/tcp/0/ws',
+            "/ip4/0.0.0.0/udp/0/quic-v1/webtransport"
           ]
         }
       }


### PR DESCRIPTION
I need this to use theses interop tests in Kubo (replacing js-ipfs's interop).