### PR TITLE
feat: re-export types from @helia/interface

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -37,6 +37,12 @@ import type { Libp2pOptions } from 'libp2p'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
 
+// re-export interface types so people don't have to depend on @helia/interface
+// if they don't want to
+export * from '@helia/interface'
+export * from '@helia/interface/blocks'
+export * from '@helia/interface/pins'
+
 const log = logger('helia')
 
 /**


### PR DESCRIPTION
`@helia/interface` lets us depend on the shape of a `Helia` without having to depend on `helia` directly which is useful when you are writing something lightweight and don't want to pull in libp2p etc during an `npm i`, but in some cases we will have a dep on `helia` so re-export the types from `@helia/interface` to not force people to have a dependency on both.