### PR TITLE
chore: pull block to pin from relay server instead of peer

### DIFF
--- a/packages/helia/.aegir.js
+++ b/packages/helia/.aegir.js
@@ -1,6 +1,9 @@
 import { circuitRelayServer } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
 import { WebSockets } from '@multiformats/mafmt'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as raw from 'multiformats/codecs/raw'
 
 /** @type {import('aegir').PartialOptions} */
 const options = {
@@ -28,12 +31,18 @@ const options = {
         }
       })
 
+      const block = Uint8Array.from([0, 1, 2, 3])
+      const mh = await sha256.digest(block)
+      const cid = CID.createV1(raw.code, mh)
+      await helia.blockstore.put(cid, block)
+
       return {
         env: {
           RELAY_SERVER: helia.libp2p.getMultiaddrs()
             .filter(ma => WebSockets.matches(ma))
             .map(ma => ma.toString())
-            .pop()
+            .pop(),
+          BLOCK_CID: cid.toString()
         },
         helia
       }

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@multiformats/mafmt": "^12.1.5",
+    "@multiformats/multiaddr": "^12.1.7",
     "@types/sinon": "^10.0.14",
     "aegir": "^40.0.8",
     "delay": "^6.0.0",


### PR DESCRIPTION
We previously had a circuit relay connection to the peer in the test, but circuit relay connections are transient (e.g. time/data limited) so we can't run bitswap over it.

Instead pull the block from the relay server as we can have a regular (non-transient) websocket connection to that peer.