### PR TITLE
fix: export libp2p service return type

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -29,13 +29,12 @@ import { createLibp2p } from './utils/libp2p.js'
 import { name, version } from './version.js'
 import type { Helia } from '@helia/interface'
 import type { Libp2p } from '@libp2p/interface'
-import type { PubSub } from '@libp2p/interface/pubsub'
-import type { DualKadDHT } from '@libp2p/kad-dht'
 import type { Blockstore } from 'interface-blockstore'
 import type { Datastore } from 'interface-datastore'
 import type { Libp2pOptions } from 'libp2p'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
+import type { DefaultLibp2pServices } from './utils/libp2p-defaults.js'
 
 // re-export interface types so people don't have to depend on @helia/interface
 // if they don't want to
@@ -119,7 +118,7 @@ export interface HeliaInit<T extends Libp2p = Libp2p> {
  * Create and return a Helia node
  */
 export async function createHelia <T extends Libp2p> (init: HeliaInit<T>): Promise<Helia<T>>
-export async function createHelia (init?: HeliaInit<Libp2p<{ dht: DualKadDHT, pubsub: PubSub }>>): Promise<Helia<Libp2p<{ dht: DualKadDHT, pubsub: PubSub }>>>
+export async function createHelia (init?: HeliaInit<Libp2p<DefaultLibp2pServices>>): Promise<Helia<Libp2p<DefaultLibp2pServices>>>
 export async function createHelia (init: HeliaInit = {}): Promise<Helia<unknown>> {
   const datastore = init.datastore ?? new MemoryDatastore()
   const blockstore = init.blockstore ?? new MemoryBlockstore()

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -27,6 +27,7 @@ import { MemoryDatastore } from 'datastore-core'
 import { HeliaImpl } from './helia.js'
 import { createLibp2p } from './utils/libp2p.js'
 import { name, version } from './version.js'
+import type { DefaultLibp2pServices } from './utils/libp2p-defaults.js'
 import type { Helia } from '@helia/interface'
 import type { Libp2p } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
@@ -34,7 +35,6 @@ import type { Datastore } from 'interface-datastore'
 import type { Libp2pOptions } from 'libp2p'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
-import type { DefaultLibp2pServices } from './utils/libp2p-defaults.js'
 
 // re-export interface types so people don't have to depend on @helia/interface
 // if they don't want to

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -13,12 +13,22 @@ import { ipnsValidator } from 'ipns/validator'
 import { autoNATService } from 'libp2p/autonat'
 import { circuitRelayTransport } from 'libp2p/circuit-relay'
 import { dcutrService } from 'libp2p/dcutr'
-import { identifyService } from 'libp2p/identify'
+import { type IdentifyService, identifyService } from 'libp2p/identify'
+import { pingService, type PingService } from 'libp2p/ping'
 import { bootstrapConfig } from './bootstrappers.js'
 import type { PubSub } from '@libp2p/interface/pubsub'
 import type { Libp2pOptions } from 'libp2p'
 
-export function libp2pDefaults (): Libp2pOptions<{ dht: DualKadDHT, pubsub: PubSub, identify: unknown, autoNAT: unknown, dcutr: unknown }> {
+export interface DefaultLibp2pServices extends Record<string, unknown> {
+  dht: DualKadDHT
+  pubsub: PubSub
+  identify: IdentifyService
+  autoNAT: unknown
+  dcutr: unknown
+  ping: PingService
+}
+
+export function libp2pDefaults (): Libp2pOptions<DefaultLibp2pServices> {
   return {
     addresses: {
       listen: [
@@ -60,7 +70,8 @@ export function libp2pDefaults (): Libp2pOptions<{ dht: DualKadDHT, pubsub: PubS
         selectors: {
           ipns: ipnsSelector
         }
-      })
+      }),
+      ping: pingService()
     }
   }
 }

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -13,13 +13,25 @@ import { ipnsValidator } from 'ipns/validator'
 import { autoNATService } from 'libp2p/autonat'
 import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from 'libp2p/circuit-relay'
 import { dcutrService } from 'libp2p/dcutr'
-import { identifyService } from 'libp2p/identify'
+import { type IdentifyService, identifyService } from 'libp2p/identify'
+import { pingService, type PingService } from 'libp2p/ping'
 import { uPnPNATService } from 'libp2p/upnp-nat'
 import { bootstrapConfig } from './bootstrappers.js'
 import type { PubSub } from '@libp2p/interface/pubsub'
 import type { Libp2pOptions } from 'libp2p'
 
-export function libp2pDefaults (): Libp2pOptions<{ dht: DualKadDHT, pubsub: PubSub, relay: CircuitRelayService, identify: unknown, autoNAT: unknown, upnp: unknown, dcutr: unknown }> {
+export interface DefaultLibp2pServices extends Record<string, unknown> {
+  dht: DualKadDHT
+  pubsub: PubSub
+  relay: CircuitRelayService
+  identify: IdentifyService
+  autoNAT: unknown
+  upnp: unknown
+  dcutr: unknown
+  ping: PingService
+}
+
+export function libp2pDefaults (): Libp2pOptions<DefaultLibp2pServices> {
   return {
     addresses: {
       listen: [
@@ -63,7 +75,8 @@ export function libp2pDefaults (): Libp2pOptions<{ dht: DualKadDHT, pubsub: PubS
       }),
       relay: circuitRelayServer({
         advertise: true
-      })
+      }),
+      ping: pingService()
     }
   }
 }

--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -1,17 +1,14 @@
 import { createLibp2p as create, type Libp2pOptions } from 'libp2p'
-import { libp2pDefaults } from './libp2p-defaults.js'
+import { type DefaultLibp2pServices, libp2pDefaults } from './libp2p-defaults.js'
 import type { Libp2p } from '@libp2p/interface'
-import type { PubSub } from '@libp2p/interface/pubsub'
-import type { DualKadDHT } from '@libp2p/kad-dht'
 import type { Datastore } from 'interface-datastore'
-import type { CircuitRelayService } from 'libp2p/circuit-relay'
 
 export interface CreateLibp2pOptions {
   datastore: Datastore
   start?: boolean
 }
 
-export async function createLibp2p (datastore: Datastore, options?: Libp2pOptions<any>): Promise<Libp2p<{ dht: DualKadDHT, pubsub: PubSub, relay: CircuitRelayService }>> {
+export async function createLibp2p (datastore: Datastore, options?: Libp2pOptions<any>): Promise<Libp2p<DefaultLibp2pServices>> {
   const defaults = libp2pDefaults()
   options = options ?? {}
 


### PR DESCRIPTION
Updates return type of default libp2p service hash to include all configured services.