### PR TITLE
fix: try circuit relay transport first

### DIFF
--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -36,13 +36,13 @@ export function libp2pDefaults (): Libp2pOptions<DefaultLibp2pServices> {
       ]
     },
     transports: [
+      circuitRelayTransport({
+        discoverRelays: 1
+      }),
       webRTC(),
       webRTCDirect(),
       webTransport(),
-      webSockets(),
-      circuitRelayTransport({
-        discoverRelays: 1
-      })
+      webSockets()
     ],
     connectionEncryption: [
       noise()

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -7,6 +7,7 @@ import { type DualKadDHT, kadDHT } from '@libp2p/kad-dht'
 import { mdns } from '@libp2p/mdns'
 import { mplex } from '@libp2p/mplex'
 import { tcp } from '@libp2p/tcp'
+import { webRTC, webRTCDirect } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
 import { ipnsSelector } from 'ipns/selector'
 import { ipnsValidator } from 'ipns/validator'
@@ -35,15 +36,18 @@ export function libp2pDefaults (): Libp2pOptions<DefaultLibp2pServices> {
   return {
     addresses: {
       listen: [
-        '/ip4/0.0.0.0/tcp/0'
+        '/ip4/0.0.0.0/tcp/0',
+        '/webrtc'
       ]
     },
     transports: [
-      tcp(),
-      webSockets(),
       circuitRelayTransport({
         discoverRelays: 1
-      })
+      }),
+      tcp(),
+      webRTC(),
+      webRTCDirect(),
+      webSockets()
     ],
     connectionEncryption: [
       noise()


### PR DESCRIPTION
Make circuit relay the first transport to try so it will match addresses ahead of supporting transports.

E.g. where the address is `/<webtransport>/<circuit-relay>` get the circuit relay transport to dial first as it will strip off the relay part, hand control back to the transport manager and then run the circuit relay protocol over the newly created webtransport connection.

This is a tactical fix for a bug that needs to be addressed in libp2p.