### PR TITLE
fix: update attempt to add helia to identify agent version

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -143,12 +143,7 @@ export async function createHelia (init: HeliaInit = {}): Promise<Helia<unknown>
   }
 
   // add helia to agent version
-  try {
-    // @ts-expect-error identify may not be configured under the identify key
-    helia.libp2p.services.identify.host.agentVersion = `${name}/${version} ${helia.libp2p.services.identify.host.agentVersion}`
-  } catch (err) {
-    log.error('could not add Helia to agent version', err)
-  }
+  addHeliaToAgentVersion(helia)
 
   return helia
 }
@@ -163,4 +158,20 @@ function isLibp2p (obj: any): obj is Libp2p {
 
   // if these are all functions it's probably a libp2p object
   return funcs.every(m => typeof obj[m] === 'function')
+}
+
+function addHeliaToAgentVersion (helia: Helia<any>): void {
+  // add helia to agent version
+  try {
+    const existingAgentVersion = helia.libp2p.services.identify.host.agentVersion
+
+    if (existingAgentVersion.match(/js-libp2p\/\d+\.\d+\.\d+\sUserAgent=/) == null) {
+      // the user changed the agent version
+      return
+    }
+
+    helia.libp2p.services.identify.host.agentVersion = `${name}/${version} ${helia.libp2p.services.identify.host.agentVersion}`
+  } catch (err) {
+    log.error('could not add Helia to agent version', err)
+  }
 }

--- a/packages/helia/test/factory.spec.ts
+++ b/packages/helia/test/factory.spec.ts
@@ -42,11 +42,8 @@ describe('helia factory', () => {
   it('adds helia details to the AgentVersion', async () => {
     helia = await createHelia()
 
-    const peer = await helia.libp2p.peerStore.get(helia.libp2p.peerId)
-    const agentVersionBuf = peer.metadata.get('AgentVersion')
-    const agentVersion = new TextDecoder().decode(agentVersionBuf)
-
-    expect(agentVersion).to.include('helia/')
+    expect(helia).to.have.nested.property('libp2p.services.identify.host.agentVersion')
+      .that.includes('helia/')
   })
 
   it('does not add helia details to the AgentVersion when it has been overridden', async () => {
@@ -56,18 +53,15 @@ describe('helia factory', () => {
           webSockets()
         ],
         services: {
-          identity: identifyService({
+          identify: identifyService({
             agentVersion: 'my custom agent version'
           })
         }
       })
     })
 
-    const peer = await helia.libp2p.peerStore.get(helia.libp2p.peerId)
-    const agentVersionBuf = peer.metadata.get('AgentVersion')
-    const agentVersion = new TextDecoder().decode(agentVersionBuf)
-
-    expect(agentVersion).to.not.include('helia/')
+    expect(helia).to.have.nested.property('libp2p.services.identify.host.agentVersion')
+      .that.does.not.include('helia/')
   })
 
   it('does not add helia details to the AgentVersion when identify is not configured', async () => {


### PR DESCRIPTION
The identify service does not pull the agent string from the peer store any more so attempt to update it on the service directly.