### PR TITLE
fix: listen on ip6 addresses

### DIFF
--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -37,6 +37,7 @@ export function libp2pDefaults (): Libp2pOptions<DefaultLibp2pServices> {
     addresses: {
       listen: [
         '/ip4/0.0.0.0/tcp/0',
+        '/ip6/::/tcp/0',
         '/webrtc'
       ]
     },


### PR DESCRIPTION
Add libp2p config to listen on available IPv6 interfaces.