### PR TITLE
feat: BlockBroker factory support

### DIFF
--- a/packages/helia/.aegir.js
+++ b/packages/helia/.aegir.js
@@ -11,8 +11,12 @@ const options = {
     before: async () => {
       // use dynamic import otherwise the source may not have been built yet
       const { createHelia } = await import('./dist/src/index.js')
+      const { BitswapBlockBrokerFactory } = await import('./dist/src/block-brokers/index.js')
 
       const helia = await createHelia({
+        blockBrokers: [
+          BitswapBlockBrokerFactory
+        ],
         libp2p: {
           addresses: {
             listen: [

--- a/packages/helia/src/block-brokers/bitswap-block-broker.ts
+++ b/packages/helia/src/block-brokers/bitswap-block-broker.ts
@@ -62,6 +62,6 @@ ProgressOptions<BitswapWantBlockProgressEvents>
  * A helper factory for users who want to override Helia `blockBrokers` but
  * still want to use the default `BitswapBlockBroker`.
  */
-export const BitSwapBlockBrokerFactory = (hashers: MultihashHasher[]): BlockBrokerFactoryFunction => (components): BitswapBlockBroker => {
-  return new BitswapBlockBroker(components.libp2p, components.blockstore, hashers)
+export const BitswapBlockBrokerFactory: BlockBrokerFactoryFunction = (components): BitswapBlockBroker => {
+  return new BitswapBlockBroker(components.libp2p, components.blockstore, components.hashers)
 }

--- a/packages/helia/src/block-brokers/bitswap-block-broker.ts
+++ b/packages/helia/src/block-brokers/bitswap-block-broker.ts
@@ -1,4 +1,5 @@
 import { createBitswap } from 'ipfs-bitswap'
+import type { BlockBrokerFactoryFunction } from '@helia/interface'
 import type { BlockAnnouncer, BlockRetriever } from '@helia/interface/blocks'
 import type { Libp2p } from '@libp2p/interface'
 import type { Startable } from '@libp2p/interface/startable'
@@ -55,4 +56,12 @@ ProgressOptions<BitswapWantBlockProgressEvents>
   async retrieve (cid: CID, options?: AbortOptions & ProgressOptions<BitswapWantBlockProgressEvents>): Promise<Uint8Array> {
     return this.bitswap.want(cid, options)
   }
+}
+
+/**
+ * A helper factory for users who want to override Helia `blockBrokers` but
+ * still want to use the default `BitswapBlockBroker`.
+ */
+export const BitSwapBlockBrokerFactory = (hashers: MultihashHasher[]): BlockBrokerFactoryFunction => (components): BitswapBlockBroker => {
+  return new BitswapBlockBroker(components.libp2p, components.blockstore, hashers)
 }

--- a/packages/helia/src/block-brokers/bitswap-block-broker.ts
+++ b/packages/helia/src/block-brokers/bitswap-block-broker.ts
@@ -1,10 +1,9 @@
 import { createBitswap } from 'ipfs-bitswap'
 import type { BlockBrokerFactoryFunction } from '@helia/interface'
-import type { BlockAnnouncer, BlockRetriever } from '@helia/interface/blocks'
+import type { BlockAnnouncer, BlockRetrievalOptions, BlockRetriever } from '@helia/interface/blocks'
 import type { Libp2p } from '@libp2p/interface'
 import type { Startable } from '@libp2p/interface/startable'
 import type { Blockstore } from 'interface-blockstore'
-import type { AbortOptions } from 'interface-store'
 import type { Bitswap, BitswapNotifyProgressEvents, BitswapWantBlockProgressEvents } from 'ipfs-bitswap'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
@@ -53,7 +52,7 @@ ProgressOptions<BitswapWantBlockProgressEvents>
     this.bitswap.notify(cid, block, options)
   }
 
-  async retrieve (cid: CID, options?: AbortOptions & ProgressOptions<BitswapWantBlockProgressEvents>): Promise<Uint8Array> {
+  async retrieve (cid: CID, { validateFn, ...options }: BlockRetrievalOptions<ProgressOptions<BitswapWantBlockProgressEvents>> = {}): Promise<Uint8Array> {
     return this.bitswap.want(cid, options)
   }
 }

--- a/packages/helia/src/block-brokers/index.ts
+++ b/packages/helia/src/block-brokers/index.ts
@@ -1,2 +1,2 @@
 export { BitswapBlockBroker, BitswapBlockBrokerFactory } from './bitswap-block-broker.js'
-export { TrustedGatewayBlockBroker } from './trustless-gateway-block-broker.js'
+export { TrustlessGatewayBlockBroker } from './trustless-gateway-block-broker.js'

--- a/packages/helia/src/block-brokers/index.ts
+++ b/packages/helia/src/block-brokers/index.ts
@@ -1,2 +1,2 @@
-export { BitswapBlockBroker } from './bitswap-block-broker.js'
+export { BitswapBlockBroker, BitswapBlockBrokerFactory } from './bitswap-block-broker.js'
 export { TrustedGatewayBlockBroker } from './trustless-gateway-block-broker.js'

--- a/packages/helia/src/helia.ts
+++ b/packages/helia/src/helia.ts
@@ -1,3 +1,4 @@
+import { type BlockBroker } from '@helia/interface/blocks'
 import { start, stop } from '@libp2p/interface/startable'
 import { logger } from '@libp2p/logger'
 import drain from 'it-drain'
@@ -19,6 +20,7 @@ const log = logger('helia')
 interface HeliaImplInit<T extends Libp2p = Libp2p> extends HeliaInit<T> {
   libp2p: T
   blockstore: Blockstore
+  blockBrokers: BlockBroker[]
   datastore: Datastore
 }
 

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -30,7 +30,7 @@ import { defaultHashers } from './utils/default-hashers.js'
 import { createLibp2p } from './utils/libp2p.js'
 import { name, version } from './version.js'
 import type { DefaultLibp2pServices } from './utils/libp2p-defaults.js'
-import type { Helia } from '@helia/interface'
+import type { Helia, BlockBrokerFactoryFunction } from '@helia/interface'
 import type { BlockBroker } from '@helia/interface/blocks'
 import type { Libp2p } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
@@ -98,7 +98,7 @@ export interface HeliaInit<T extends Libp2p = Libp2p> {
    * A list of strategies used to fetch blocks when they are not present in
    * the local blockstore
    */
-  blockBrokers?: BlockBroker[]
+  blockBrokers?: Array<BlockBroker | BlockBrokerFactoryFunction>
 
   /**
    * Pass `false` to not start the Helia node
@@ -159,7 +159,16 @@ export async function createHelia (init: HeliaInit = {}): Promise<Helia<unknown>
 
   const hashers = defaultHashers(init.hashers)
 
-  const blockBrokers = init.blockBrokers ?? [
+  const blockBrokers = init.blockBrokers?.map((blockBroker) => {
+    if (typeof blockBroker !== 'function') {
+      return blockBroker
+    }
+    return blockBroker({
+      blockstore,
+      datastore,
+      libp2p
+    })
+  }) ?? [
     new BitswapBlockBroker(libp2p, blockstore, hashers),
     new TrustedGatewayBlockBroker(DEFAULT_TRUSTLESS_GATEWAYS)
   ]

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -24,7 +24,7 @@
 import { logger } from '@libp2p/logger'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
-import { BitswapBlockBroker, TrustedGatewayBlockBroker } from './block-brokers/index.js'
+import { BitswapBlockBroker, TrustlessGatewayBlockBroker } from './block-brokers/index.js'
 import { HeliaImpl } from './helia.js'
 import { defaultHashers } from './utils/default-hashers.js'
 import { createLibp2p } from './utils/libp2p.js'
@@ -171,7 +171,7 @@ export async function createHelia (init: HeliaInit = {}): Promise<Helia<unknown>
     }) satisfies BlockBroker
   }) ?? [
     new BitswapBlockBroker(libp2p, blockstore, hashers),
-    new TrustedGatewayBlockBroker(DEFAULT_TRUSTLESS_GATEWAYS)
+    new TrustlessGatewayBlockBroker(DEFAULT_TRUSTLESS_GATEWAYS)
   ]
 
   const helia = new HeliaImpl({

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -159,15 +159,16 @@ export async function createHelia (init: HeliaInit = {}): Promise<Helia<unknown>
 
   const hashers = defaultHashers(init.hashers)
 
-  const blockBrokers = init.blockBrokers?.map((blockBroker) => {
+  const blockBrokers: BlockBroker[] = init.blockBrokers?.map((blockBroker: BlockBroker | BlockBrokerFactoryFunction): BlockBroker => {
     if (typeof blockBroker !== 'function') {
-      return blockBroker
+      return blockBroker satisfies BlockBroker
     }
     return blockBroker({
       blockstore,
       datastore,
-      libp2p
-    })
+      libp2p,
+      hashers
+    }) satisfies BlockBroker
   }) ?? [
     new BitswapBlockBroker(libp2p, blockstore, hashers),
     new TrustedGatewayBlockBroker(DEFAULT_TRUSTLESS_GATEWAYS)

--- a/packages/helia/test/block-brokers/block-broker.spec.ts
+++ b/packages/helia/test/block-brokers/block-broker.spec.ts
@@ -1,0 +1,136 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { MemoryBlockstore } from 'blockstore-core'
+import delay from 'delay'
+import all from 'it-all'
+import * as raw from 'multiformats/codecs/raw'
+import Sinon from 'sinon'
+import { type StubbedInstance, stubInterface } from 'sinon-ts'
+import { defaultHashers } from '../../src/utils/default-hashers.js'
+import { NetworkedStorage } from '../../src/utils/networked-storage.js'
+import { createBlock } from '../fixtures/create-block.js'
+import type { BitswapBlockBroker, TrustlessGatewayBlockBroker } from '../../src/block-brokers/index.js'
+import type { Blockstore } from 'interface-blockstore'
+import type { CID } from 'multiformats/cid'
+
+describe('block-provider', () => {
+  let storage: NetworkedStorage
+  let blockstore: Blockstore
+  let bitswapBlockBroker: StubbedInstance<BitswapBlockBroker>
+  let blocks: Array<{ cid: CID, block: Uint8Array }>
+  let gatewayBlockBroker: StubbedInstance<TrustlessGatewayBlockBroker>
+
+  beforeEach(async () => {
+    blocks = []
+
+    for (let i = 0; i < 10; i++) {
+      blocks.push(await createBlock(raw.code, Uint8Array.from([0, 1, 2, i])))
+    }
+
+    blockstore = new MemoryBlockstore()
+    bitswapBlockBroker = stubInterface<BitswapBlockBroker>()
+    gatewayBlockBroker = stubInterface<TrustlessGatewayBlockBroker>()
+    storage = new NetworkedStorage(blockstore, {
+      blockBrokers: [
+        bitswapBlockBroker,
+        gatewayBlockBroker
+      ],
+      hashers: defaultHashers()
+    })
+  })
+
+  it('gets a block from the gatewayBlockBroker when it is not in the blockstore', async () => {
+    const { cid, block } = blocks[0]
+
+    gatewayBlockBroker.retrieve.withArgs(cid, Sinon.match.any).resolves(block)
+
+    expect(await blockstore.has(cid)).to.be.false()
+
+    const returned = await storage.get(cid)
+
+    expect(await blockstore.has(cid)).to.be.true()
+    expect(returned).to.equalBytes(block)
+    expect(gatewayBlockBroker.retrieve.calledWith(cid)).to.be.true()
+  })
+
+  it('gets many blocks from gatewayBlockBroker when they are not in the blockstore', async () => {
+    const count = 5
+
+    for (let i = 0; i < count; i++) {
+      const { cid, block } = blocks[i]
+      gatewayBlockBroker.retrieve.withArgs(cid, Sinon.match.any).resolves(block)
+
+      expect(await blockstore.has(cid)).to.be.false()
+    }
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+
+    for (let i = 0; i < count; i++) {
+      const { cid } = blocks[i]
+      expect(gatewayBlockBroker.retrieve.calledWith(cid)).to.be.true()
+      expect(await blockstore.has(cid)).to.be.true()
+    }
+  })
+
+  it('gets some blocks from gatewayBlockBroker when they are not in the blockstore', async () => {
+    const count = 5
+
+    // blocks 0,1,3,4 are in the blockstore
+    await blockstore.put(blocks[0].cid, blocks[0].block)
+    await blockstore.put(blocks[1].cid, blocks[1].block)
+    await blockstore.put(blocks[3].cid, blocks[3].block)
+    await blockstore.put(blocks[4].cid, blocks[4].block)
+
+    // block #2 comes from gatewayBlockBroker but slowly
+    gatewayBlockBroker.retrieve.withArgs(blocks[2].cid).callsFake(async () => {
+      await delay(100)
+      return blocks[2].block
+    })
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+
+    for (let i = 0; i < count; i++) {
+      expect(await blockstore.has(blocks[i].cid)).to.be.true()
+    }
+  })
+
+  it('handles incorrect bytes from a gateway', async () => {
+    const { cid } = blocks[0]
+    const block = blocks[1].block
+    storage = new NetworkedStorage(blockstore, {
+      blockBrokers: [
+        gatewayBlockBroker
+      ],
+      hashers: defaultHashers()
+    })
+
+    gatewayBlockBroker.retrieve.withArgs(cid, Sinon.match.any).resolves(block)
+
+    expect(await blockstore.has(cid)).to.be.false()
+
+    try {
+      await storage.get(cid)
+      throw new Error('should have thrown')
+    } catch (err) {
+      const error = err as AggregateError & { errors: Error & { code: string } }
+      expect(error).to.be.an('error')
+      expect(error.errors).to.be.an('array').with.lengthOf(1)
+      expect(error.errors[0]).to.be.an('error').with.property('code', 'ERR_HASH_MISMATCH')
+    }
+  })
+})

--- a/packages/helia/test/block-brokers/trustless-gateway-block-broker.spec.ts
+++ b/packages/helia/test/block-brokers/trustless-gateway-block-broker.spec.ts
@@ -1,0 +1,151 @@
+/* eslint-env mocha */
+import { expect } from 'aegir/chai'
+import * as raw from 'multiformats/codecs/raw'
+import Sinon from 'sinon'
+import { type StubbedInstance, stubConstructor } from 'sinon-ts'
+import { TrustlessGatewayBlockBroker } from '../../src/block-brokers/index.js'
+import { TrustlessGateway } from '../../src/block-brokers/trustless-gateway-block-broker.js'
+import { createBlock } from '../fixtures/create-block.js'
+import type { CID } from 'multiformats/cid'
+
+describe('trustless-gateway-block-broker', () => {
+  let blocks: Array<{ cid: CID, block: Uint8Array }>
+  let gatewayBlockBroker: TrustlessGatewayBlockBroker
+  let gateways: Array<StubbedInstance<TrustlessGateway>>
+
+  // take a Record<gatewayIndex, (gateway: StubbedInstance<TrustlessGateway>) => void> and stub the gateways
+  // Record.default is the default handler
+  function stubGateways (handlers: Record<number, (gateway: StubbedInstance<TrustlessGateway>, index?: number) => void> & { default(gateway: StubbedInstance<TrustlessGateway>, index: number): void }): void {
+    for (let i = 0; i < gateways.length; i++) {
+      if (handlers[i] != null) {
+        handlers[i](gateways[i])
+        continue
+      }
+      handlers.default(gateways[i], i)
+    }
+  }
+
+  beforeEach(async () => {
+    blocks = []
+
+    for (let i = 0; i < 10; i++) {
+      blocks.push(await createBlock(raw.code, Uint8Array.from([0, 1, 2, i])))
+    }
+
+    gateways = [
+      stubConstructor(TrustlessGateway, 'http://localhost:8080'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8081'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8082'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8083')
+    ]
+    gatewayBlockBroker = new TrustlessGatewayBlockBroker(gateways)
+  })
+
+  it('tries all gateways before failing', async () => {
+    // stub all gateway responses to fail
+    for (const gateway of gateways) {
+      gateway.getRawBlock.rejects(new Error('failed'))
+    }
+    try {
+      await gatewayBlockBroker.retrieve(blocks[0].cid)
+      throw new Error('should have failed')
+    } catch (err: unknown) {
+      expect(err).to.exist()
+      expect(err).to.be.an.instanceOf(AggregateError)
+      expect((err as AggregateError).errors).to.have.lengthOf(gateways.length)
+    }
+    for (const gateway of gateways) {
+      expect(gateway.getRawBlock.calledWith(blocks[0].cid)).to.be.true()
+    }
+  })
+
+  it('prioritizes gateways based on reliability', async () => {
+    const callOrder: number[] = []
+
+    // stub all gateway responses to fail, and set reliabilities to known values.
+    stubGateways({
+      default: (gateway, i) => {
+        gateway.getRawBlock.withArgs(blocks[1].cid, Sinon.match.any).callsFake(async () => {
+          callOrder.push(i)
+          throw new Error('failed')
+        })
+        gateway.reliability.returns(i) // known reliability of 0, 1, 2, 3
+      }
+    })
+
+    try {
+      await gatewayBlockBroker.retrieve(blocks[1].cid)
+    } catch {
+      // ignore
+    }
+    // all gateways were called
+    expect(gateways[0].getRawBlock.calledWith(blocks[1].cid)).to.be.true()
+    expect(gateways[1].getRawBlock.calledWith(blocks[1].cid)).to.be.true()
+    expect(gateways[2].getRawBlock.calledWith(blocks[1].cid)).to.be.true()
+    expect(gateways[3].getRawBlock.calledWith(blocks[1].cid)).to.be.true()
+    // and in the correct order.
+    expect(callOrder).to.have.ordered.members([3, 2, 1, 0])
+  })
+
+  it('tries other gateways if it receives invalid blocks', async () => {
+    const { cid: cid1, block: block1 } = blocks[0]
+    const { block: block2 } = blocks[1]
+    stubGateways({
+      // return valid block for only one gateway
+      0: (gateway) => {
+        gateway.getRawBlock.withArgs(cid1, Sinon.match.any).resolves(block1)
+        gateway.reliability.returns(0) // make sure it's called last
+      },
+      // return invalid blocks for all other gateways
+      default: (gateway) => { // default stub function
+        gateway.getRawBlock.withArgs(cid1, Sinon.match.any).resolves(block2) // invalid block for the CID
+        gateway.reliability.returns(1) // make sure other gateways are called first
+      }
+    })
+    // try {
+    const block = await gatewayBlockBroker.retrieve(cid1, {
+      validateFn: async (block) => {
+        if (block !== block1) {
+          throw new Error('invalid block')
+        }
+      }
+    })
+    expect(block).to.equal(block1)
+
+    // expect that all gateways are called, because everyone returned invalid blocks except the last one
+    for (const gateway of gateways) {
+      expect(gateway.getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.true()
+    }
+  })
+
+  it('doesnt call other gateways if the first gateway returns a valid block', async () => {
+    const { cid: cid1, block: block1 } = blocks[0]
+    const { block: block2 } = blocks[1]
+
+    stubGateways({
+      // return valid block for only one gateway
+      3: (gateway) => {
+        gateway.getRawBlock.withArgs(cid1, Sinon.match.any).resolves(block1)
+        gateway.reliability.returns(1) // make sure it's called first
+      },
+      // return invalid blocks for all other gateways
+      default: (gateway) => { // default stub function
+        gateway.getRawBlock.withArgs(cid1, Sinon.match.any).resolves(block2) // invalid block for the CID
+        gateway.reliability.returns(0) // make sure other gateways are called last
+      }
+    })
+    const block = await gatewayBlockBroker.retrieve(cid1, {
+      validateFn: async (block) => {
+        if (block !== block1) {
+          throw new Error('invalid block')
+        }
+      }
+    })
+    expect(block).to.equal(block1)
+    expect(gateways[3].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.true()
+    // expect that other gateways are not called, because the first gateway returned a valid block
+    expect(gateways[0].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.false()
+    expect(gateways[1].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.false()
+    expect(gateways[2].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.false()
+  })
+})

--- a/packages/helia/test/fixtures/create-helia.ts
+++ b/packages/helia/test/fixtures/create-helia.ts
@@ -2,11 +2,15 @@ import { webSockets } from '@libp2p/websockets'
 import * as Filters from '@libp2p/websockets/filters'
 import { circuitRelayTransport } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
+import { BitswapBlockBrokerFactory } from '../../src/block-brokers/bitswap-block-broker.js'
 import { createHelia as createNode } from '../../src/index.js'
 import type { Helia } from '@helia/interface'
 
 export async function createHelia (): Promise<Helia> {
   return createNode({
+    blockBrokers: [
+      BitswapBlockBrokerFactory
+    ],
     libp2p: {
       addresses: {
         listen: [

--- a/packages/helia/test/fixtures/create-helia.ts
+++ b/packages/helia/test/fixtures/create-helia.ts
@@ -2,7 +2,7 @@ import { webSockets } from '@libp2p/websockets'
 import * as Filters from '@libp2p/websockets/filters'
 import { circuitRelayTransport } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
-import { BitswapBlockBrokerFactory } from '../../src/block-brokers/bitswap-block-broker.js'
+import { BitswapBlockBrokerFactory } from '../../src/block-brokers/index.js'
 import { createHelia as createNode } from '../../src/index.js'
 import type { Helia } from '@helia/interface'
 

--- a/packages/helia/test/pins.depth-limited.spec.ts
+++ b/packages/helia/test/pins.depth-limited.spec.ts
@@ -27,6 +27,7 @@ describe('pins (depth limited)', () => {
     dag = await createDag(codec, blockstore, MAX_DEPTH, 3)
 
     helia = await createHelia({
+      blockBrokers: [],
       datastore: new MemoryDatastore(),
       blockstore,
       libp2p: await createLibp2p({

--- a/packages/helia/test/pins.recursive.spec.ts
+++ b/packages/helia/test/pins.recursive.spec.ts
@@ -25,6 +25,7 @@ describe('pins (recursive)', () => {
     dag = await createDag(codec, blockstore, 2, 3)
 
     helia = await createHelia({
+      blockBrokers: [],
       datastore: new MemoryDatastore(),
       blockstore,
       libp2p: await createLibp2p({

--- a/packages/helia/test/utils/networked-storage.spec.ts
+++ b/packages/helia/test/utils/networked-storage.spec.ts
@@ -15,7 +15,7 @@ import type { BitswapBlockBroker } from '../../src/block-brokers/bitswap-block-b
 import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 
-describe('storage', () => {
+describe('networked-storage', () => {
   let storage: NetworkedStorage
   let blockstore: Blockstore
   let bitswap: StubbedInstance<BitswapBlockBroker>

--- a/packages/interface/src/blocks.ts
+++ b/packages/interface/src/blocks.ts
@@ -63,11 +63,21 @@ ProgressOptions<DeleteBlockProgressEvents>, ProgressOptions<DeleteManyBlocksProg
 
 }
 
+export type BlockRetrievalOptions<GetProgressOptions extends ProgressOptions = ProgressOptions> = AbortOptions & GetProgressOptions & {
+  /**
+   * A function that blockBrokers should call prior to returning a block to ensure it can maintain control
+   * of the block request flow. e.g. TrustedGatewayBlockBroker will use this to ensure that the block
+   * is valid from one of the gateways before assuming it's work is done. If the block is not valid, it should try another gateway
+   * and WILL consider the gateway that returned the invalid blocks completely unreliable.
+   */
+  validateFn?(block: Uint8Array): Promise<void>
+}
+
 export interface BlockRetriever<GetProgressOptions extends ProgressOptions = ProgressOptions> {
   /**
    * Retrieve a block from a source
    */
-  retrieve(cid: CID, options?: AbortOptions & GetProgressOptions): Promise<Uint8Array>
+  retrieve(cid: CID, options?: BlockRetrievalOptions<GetProgressOptions>): Promise<Uint8Array>
 }
 
 export interface BlockAnnouncer<NotifyProgressOptions extends ProgressOptions = ProgressOptions> {

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -19,6 +19,7 @@ import type { Pins } from './pins.js'
 import type { Libp2p, AbortOptions } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 import type { CID } from 'multiformats/cid'
+import type { MultihashHasher } from 'multiformats/hashes/interface'
 import type { ProgressEvent, ProgressOptions } from 'progress-events'
 
 export type { Await, AwaitIterable } from 'interface-store'
@@ -70,6 +71,9 @@ export type GcEvents =
 export interface GCOptions extends AbortOptions, ProgressOptions<GcEvents> {
 
 }
+export type BlockBrokerFactoryComponents = Pick<Helia, 'libp2p' | 'blockstore' | 'datastore'> & {
+  hashers: MultihashHasher[]
+}
 
 /**
  * A function that receives some {@link Helia} components and returns a
@@ -80,5 +84,5 @@ export interface GCOptions extends AbortOptions, ProgressOptions<GcEvents> {
  * scope.
  */
 export interface BlockBrokerFactoryFunction {
-  (heliaComponents: Pick<Helia, 'libp2p' | 'blockstore' | 'datastore'>): BlockBroker
+  (heliaComponents: BlockBrokerFactoryComponents): BlockBroker
 }

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -14,7 +14,7 @@
  * ```
  */
 
-import type { Blocks } from './blocks.js'
+import type { BlockBroker, Blocks } from './blocks.js'
 import type { Pins } from './pins.js'
 import type { Libp2p, AbortOptions } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
@@ -69,4 +69,16 @@ export type GcEvents =
 
 export interface GCOptions extends AbortOptions, ProgressOptions<GcEvents> {
 
+}
+
+/**
+ * A function that receives some {@link Helia} components and returns a
+ * {@link BlockBroker}.
+ *
+ * This is needed in order to re-use some of the internal components Helia
+ * constructs without having to hoist each required component into the top-level
+ * scope.
+ */
+export interface BlockBrokerFactoryFunction {
+  (heliaComponents: Pick<Helia, 'libp2p' | 'blockstore' | 'datastore'>): BlockBroker
 }

--- a/packages/interop/test/fixtures/create-helia.browser.ts
+++ b/packages/interop/test/fixtures/create-helia.browser.ts
@@ -5,6 +5,7 @@ import { all } from '@libp2p/websockets/filters'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type HeliaInit } from 'helia'
+import { BitswapBlockBrokerFactory } from 'helia/block-brokers'
 import { createLibp2p } from 'libp2p'
 import { identifyService } from 'libp2p/identify'
 import type { Helia } from '@helia/interface'
@@ -38,6 +39,9 @@ export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia
 
   const helia = await createHelia({
     libp2p,
+    blockBrokers: [
+      BitswapBlockBrokerFactory
+    ],
     blockstore,
     datastore,
     ...init

--- a/packages/interop/test/fixtures/create-helia.ts
+++ b/packages/interop/test/fixtures/create-helia.ts
@@ -4,6 +4,7 @@ import { tcp } from '@libp2p/tcp'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type HeliaInit } from 'helia'
+import { BitswapBlockBrokerFactory } from 'helia/block-brokers'
 import { createLibp2p } from 'libp2p'
 import { identifyService } from 'libp2p/identify'
 import type { Helia } from '@helia/interface'
@@ -35,6 +36,9 @@ export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia
 
   const helia = await createHelia({
     libp2p,
+    blockBrokers: [
+      BitswapBlockBrokerFactory
+    ],
     blockstore,
     datastore,
     ...init


### PR DESCRIPTION
Adds on to changes from https://github.com/ipfs/helia/pull/280 and https://github.com/ipfs/helia/pull/281

This makes it much easier to support constructing helia with custom blockBrokers while still allowing consumers easy access to the default BitswapBlockBroker. One particular use-case where this comes in handy: our tests.

Take the code in `packages/helia/test/fixtures/create-helia.ts` for example. Without these changes, you have to do something like:

```typescript
import { webSockets } from '@libp2p/websockets'
import * as Filters from '@libp2p/websockets/filters'
import { MemoryBlockstore } from 'blockstore-core' // new import
import { MemoryDatastore } from 'datastore-core' // new import
import { circuitRelayTransport } from 'libp2p/circuit-relay'
import { identifyService } from 'libp2p/identify'
import { BitswapBlockBroker } from '../../src/block-brokers/index.js' // new import
import { createHelia as createNode } from '../../src/index.js'
import { defaultHashers } from '../../src/utils/default-hashers.js' // new import
import { createLibp2p } from '../../src/utils/libp2p.js' // new import
import type { Helia } from '@helia/interface'

export async function createHelia (): Promise<Helia> {
  const datastore = new MemoryDatastore()
  const blockstore = new MemoryBlockstore()
  const libp2p = await createLibp2p(datastore, {
    addresses: {
      listen: [
        `${process.env.RELAY_SERVER}/p2p-circuit`
      ]
    },
    transports: [
      webSockets({
        filter: Filters.all
      }),
      circuitRelayTransport()
    ],
    connectionGater: {
      denyDialMultiaddr: async () => false
    },
    services: {
      identify: identifyService()
    }
  })
  return createNode({
    blockstore,
    blockBrokers: [
      new BitswapBlockBroker(libp2p, blockstore, defaultHashers())
    ],
    datastore,
    libp2p
  })
}
```

However, with these changes, we can now do this:

```typescript
import { webSockets } from '@libp2p/websockets'
import * as Filters from '@libp2p/websockets/filters'
import { circuitRelayTransport } from 'libp2p/circuit-relay'
import { identifyService } from 'libp2p/identify'
import { BitswapBlockBrokerFactory } from '../../src/block-brokers/bitswap-block-broker.js' // new import
import { createHelia as createNode } from '../../src/index.js'
import type { Helia } from '@helia/interface'

export async function createHelia (): Promise<Helia> {
  return createNode({
    blockBrokers: [
      BitswapBlockBrokerFactory
    ],
    libp2p: {
      addresses: {
        listen: [
        `${process.env.RELAY_SERVER}/p2p-circuit`
        ]
      },
      transports: [
        webSockets({
          filter: Filters.all
        }),
        circuitRelayTransport()
      ],
      connectionGater: {
        denyDialMultiaddr: async () => false
      },
      services: {
        identify: identifyService()
      }
    }
  })
}

```

---

Some key benefits:
1. No need to construct libp2p ourselves and pass to BlockBrokers
1. No need to construct our own blockstore for passing to `BitswapBlockBroker`
1. No need to construct our own datastore for passing to `createLibp2p`
1. additional hashers can be added easily to heliaInit config and passed to all blockBrokers.




