### PR TITLE
feat: blockBrokers can control block validation

### DIFF
--- a/packages/helia/.aegir.js
+++ b/packages/helia/.aegir.js
@@ -11,8 +11,12 @@ const options = {
     before: async () => {
       // use dynamic import otherwise the source may not have been built yet
       const { createHelia } = await import('./dist/src/index.js')
+      const { BitswapBlockBrokerFactory } = await import('./dist/src/block-brokers/index.js')
 
       const helia = await createHelia({
+        blockBrokers: [
+          BitswapBlockBrokerFactory
+        ],
         libp2p: {
           addresses: {
             listen: [

--- a/packages/helia/src/block-brokers/bitswap-block-broker.ts
+++ b/packages/helia/src/block-brokers/bitswap-block-broker.ts
@@ -1,10 +1,9 @@
 import { createBitswap } from 'ipfs-bitswap'
 import type { BlockBrokerFactoryFunction } from '@helia/interface'
-import type { BlockAnnouncer, BlockRetriever } from '@helia/interface/blocks'
+import type { BlockAnnouncer, BlockRetrievalOptions, BlockRetriever } from '@helia/interface/blocks'
 import type { Libp2p } from '@libp2p/interface'
 import type { Startable } from '@libp2p/interface/startable'
 import type { Blockstore } from 'interface-blockstore'
-import type { AbortOptions } from 'interface-store'
 import type { Bitswap, BitswapNotifyProgressEvents, BitswapWantBlockProgressEvents } from 'ipfs-bitswap'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
@@ -53,7 +52,7 @@ ProgressOptions<BitswapWantBlockProgressEvents>
     this.bitswap.notify(cid, block, options)
   }
 
-  async retrieve (cid: CID, options?: AbortOptions & ProgressOptions<BitswapWantBlockProgressEvents>): Promise<Uint8Array> {
+  async retrieve (cid: CID, { validateFn, ...options }: BlockRetrievalOptions<ProgressOptions<BitswapWantBlockProgressEvents>> = {}): Promise<Uint8Array> {
     return this.bitswap.want(cid, options)
   }
 }

--- a/packages/helia/src/block-brokers/index.ts
+++ b/packages/helia/src/block-brokers/index.ts
@@ -1,2 +1,2 @@
 export { BitswapBlockBroker, BitswapBlockBrokerFactory } from './bitswap-block-broker.js'
-export { TrustedGatewayBlockBroker } from './trustless-gateway-block-broker.js'
+export { TrustlessGatewayBlockBroker } from './trustless-gateway-block-broker.js'

--- a/packages/helia/src/block-brokers/trustless-gateway-block-broker.ts
+++ b/packages/helia/src/block-brokers/trustless-gateway-block-broker.ts
@@ -97,7 +97,7 @@ export class TrustlessGateway {
    * Unused gateways have 100% reliability; They will be prioritized over
    * gateways with a 100% success rate to ensure that we attempt all gateways.
    */
-  get reliability (): number {
+  reliability (): number {
     /**
      * if we have never tried to use this gateway, it is considered the most
      * reliable until we determine otherwise (prioritize unused gateways)
@@ -155,7 +155,7 @@ ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
 
   async retrieve (cid: CID, options: BlockRetrievalOptions<ProgressOptions<TrustlessGatewayGetBlockProgressEvents>> = {}): Promise<Uint8Array> {
     // Loop through the gateways until we get a block or run out of gateways
-    const sortedGateways = this.gateways.sort((a, b) => b.reliability - a.reliability)
+    const sortedGateways = this.gateways.sort((a, b) => b.reliability() - a.reliability())
     const aggregateErrors: Error[] = []
     for (const gateway of sortedGateways) {
       log('getting block for %c from %s', cid, gateway.url)

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -24,7 +24,7 @@
 import { logger } from '@libp2p/logger'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
-import { BitswapBlockBroker, TrustedGatewayBlockBroker } from './block-brokers/index.js'
+import { BitswapBlockBroker, TrustlessGatewayBlockBroker } from './block-brokers/index.js'
 import { HeliaImpl } from './helia.js'
 import { defaultHashers } from './utils/default-hashers.js'
 import { createLibp2p } from './utils/libp2p.js'
@@ -171,7 +171,7 @@ export async function createHelia (init: HeliaInit = {}): Promise<Helia<unknown>
     }) satisfies BlockBroker
   }) ?? [
     new BitswapBlockBroker(libp2p, blockstore, hashers),
-    new TrustedGatewayBlockBroker(DEFAULT_TRUSTLESS_GATEWAYS)
+    new TrustlessGatewayBlockBroker(DEFAULT_TRUSTLESS_GATEWAYS)
   ]
 
   const helia = new HeliaImpl({

--- a/packages/helia/test/block-broker.spec.ts
+++ b/packages/helia/test/block-broker.spec.ts
@@ -1,0 +1,115 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import { MemoryBlockstore } from 'blockstore-core'
+import delay from 'delay'
+import all from 'it-all'
+import * as raw from 'multiformats/codecs/raw'
+import Sinon from 'sinon'
+import { type StubbedInstance, stubInterface } from 'sinon-ts'
+import { defaultHashers } from '../src/utils/default-hashers.js'
+import { NetworkedStorage } from '../src/utils/networked-storage.js'
+import { createBlock } from './fixtures/create-block.js'
+import type { BitswapBlockBroker, TrustedGatewayBlockBroker } from '../src/block-brokers/index.js'
+import type { Blockstore } from 'interface-blockstore'
+import type { CID } from 'multiformats/cid'
+
+describe('block-provider', () => {
+  let storage: NetworkedStorage
+  let blockstore: Blockstore
+  let bitswapBlockBroker: StubbedInstance<BitswapBlockBroker>
+  let blocks: Array<{ cid: CID, block: Uint8Array }>
+  let gatewayBlockBroker: StubbedInstance<TrustedGatewayBlockBroker>
+
+  beforeEach(async () => {
+    blocks = []
+
+    for (let i = 0; i < 10; i++) {
+      blocks.push(await createBlock(raw.code, Uint8Array.from([0, 1, 2, i])))
+    }
+
+    blockstore = new MemoryBlockstore()
+    bitswapBlockBroker = stubInterface<BitswapBlockBroker>()
+    gatewayBlockBroker = stubInterface<TrustedGatewayBlockBroker>()
+    storage = new NetworkedStorage(blockstore, {
+      blockBrokers: [
+        bitswapBlockBroker,
+        gatewayBlockBroker
+      ],
+      hashers: defaultHashers()
+    })
+  })
+
+  it('gets a block from the gatewayBlockBroker when it is not in the blockstore', async () => {
+    const { cid, block } = blocks[0]
+
+    gatewayBlockBroker.retrieve.withArgs(cid, Sinon.match.any).resolves(block)
+
+    expect(await blockstore.has(cid)).to.be.false()
+
+    const returned = await storage.get(cid)
+
+    expect(await blockstore.has(cid)).to.be.true()
+    expect(returned).to.equalBytes(block)
+    expect(gatewayBlockBroker.retrieve.calledWith(cid)).to.be.true()
+  })
+
+  it('gets many blocks from gatewayBlockBroker when they are not in the blockstore', async () => {
+    const count = 5
+
+    for (let i = 0; i < count; i++) {
+      const { cid, block } = blocks[i]
+      gatewayBlockBroker.retrieve.withArgs(cid, Sinon.match.any).resolves(block)
+
+      expect(await blockstore.has(cid)).to.be.false()
+    }
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+
+    for (let i = 0; i < count; i++) {
+      const { cid } = blocks[i]
+      expect(gatewayBlockBroker.retrieve.calledWith(cid)).to.be.true()
+      expect(await blockstore.has(cid)).to.be.true()
+    }
+  })
+
+  it('gets some blocks from gatewayBlockBroker when they are not in the blockstore', async () => {
+    const count = 5
+
+    // blocks 0,1,3,4 are in the blockstore
+    await blockstore.put(blocks[0].cid, blocks[0].block)
+    await blockstore.put(blocks[1].cid, blocks[1].block)
+    await blockstore.put(blocks[3].cid, blocks[3].block)
+    await blockstore.put(blocks[4].cid, blocks[4].block)
+
+    // block #2 comes from gatewayBlockBroker but slowly
+    gatewayBlockBroker.retrieve.withArgs(blocks[2].cid).callsFake(async () => {
+      await delay(100)
+      return blocks[2].block
+    })
+
+    const retrieved = await all(storage.getMany(async function * () {
+      for (let i = 0; i < count; i++) {
+        yield blocks[i].cid
+        await delay(10)
+      }
+    }()))
+
+    expect(retrieved).to.deep.equal(new Array(count).fill(0).map((_, i) => blocks[i]))
+
+    for (let i = 0; i < count; i++) {
+      expect(await blockstore.has(blocks[i].cid)).to.be.true()
+    }
+  })
+
+  it('handles incorrect bytes from a gateway', async () => {})
+  it('tries all gateways before failing', async () => {})
+  it('prioritizes gateways based on reliability', async () => {})
+})

--- a/packages/helia/test/block-brokers/trustless-gateway-block-broker.spec.ts
+++ b/packages/helia/test/block-brokers/trustless-gateway-block-broker.spec.ts
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+import { expect } from 'aegir/chai'
+import * as raw from 'multiformats/codecs/raw'
+import { type StubbedInstance, stubConstructor } from 'sinon-ts'
+import { TrustlessGatewayBlockBroker } from '../../src/block-brokers/index.js'
+import { TrustlessGateway } from '../../src/block-brokers/trustless-gateway-block-broker.js'
+import { createBlock } from '../fixtures/create-block.js'
+import type { CID } from 'multiformats/cid'
+
+describe('trustless-gateway-block-broker', () => {
+  let blocks: Array<{ cid: CID, block: Uint8Array }>
+  let gatewayBlockBroker: TrustlessGatewayBlockBroker
+  let gateways: Array<StubbedInstance<TrustlessGateway>>
+  // let gateways: Array<TrustedGateway>
+
+  beforeEach(async () => {
+    blocks = []
+
+    for (let i = 0; i < 10; i++) {
+      blocks.push(await createBlock(raw.code, Uint8Array.from([0, 1, 2, i])))
+    }
+
+    gateways = [
+      stubConstructor(TrustlessGateway, 'http://localhost:8080'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8081'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8082'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8083')
+    ]
+    gatewayBlockBroker = new TrustlessGatewayBlockBroker(gateways)
+  })
+
+  it('tries all gateways before failing', async () => {
+    // stub all gateway responses to fail
+    for (const gateway of gateways) {
+      gateway.getRawBlock.rejects(new Error('failed'))
+    }
+    try {
+      await gatewayBlockBroker.retrieve(blocks[0].cid)
+      throw new Error('should have failed')
+    } catch (err: unknown) {
+      expect(err).to.exist()
+    }
+    for (const gateway of gateways) {
+      expect(gateway.getRawBlock.calledWith(blocks[0].cid)).to.be.true()
+    }
+  })
+
+  it('prioritizes gateways based on reliability', async () => {
+    // stub all gateway responses to fail
+    for (const gateway of gateways) {
+      gateway.getRawBlock.rejects(new Error('failed'))
+    }
+    // try to get a block
+    try {
+      await gatewayBlockBroker.retrieve(blocks[0].cid)
+      throw new Error('should have failed')
+    } catch (err: unknown) {
+      expect(err).to.exist()
+    }
+
+    for (const gateway of gateways) {
+      expect(gateway.getRawBlock.calledWith(blocks[0].cid)).to.be.true()
+    }
+    // stub the first gateway to succeed
+    gateways[0].getRawBlock.resolves(blocks[1].block)
+    // try to get a block and ensure the first gateway was called
+    await gatewayBlockBroker.retrieve(blocks[1].cid)
+    expect(gateways[0].getRawBlock.calledWith(blocks[1].cid)).to.be.true()
+    expect(gateways[1].getRawBlock.calledWith(blocks[1].cid)).to.be.false()
+    expect(gateways[2].getRawBlock.calledWith(blocks[1].cid)).to.be.false()
+    expect(gateways[3].getRawBlock.calledWith(blocks[1].cid)).to.be.false()
+  })
+})

--- a/packages/interface/src/blocks.ts
+++ b/packages/interface/src/blocks.ts
@@ -63,11 +63,21 @@ ProgressOptions<DeleteBlockProgressEvents>, ProgressOptions<DeleteManyBlocksProg
 
 }
 
+export type BlockRetrievalOptions<GetProgressOptions extends ProgressOptions = ProgressOptions> = AbortOptions & GetProgressOptions & {
+  /**
+   * A function that blockBrokers should call prior to returning a block to ensure it can maintain control
+   * of the block request flow. e.g. TrustedGatewayBlockBroker will use this to ensure that the block
+   * is valid from one of the gateways before assuming it's work is done. If the block is not valid, it should try another gateway
+   * and WILL consider the gateway that returned the invalid blocks completely unreliable.
+   */
+  validateFn?(block: Uint8Array): Promise<void>
+}
+
 export interface BlockRetriever<GetProgressOptions extends ProgressOptions = ProgressOptions> {
   /**
    * Retrieve a block from a source
    */
-  retrieve(cid: CID, options?: AbortOptions & GetProgressOptions): Promise<Uint8Array>
+  retrieve(cid: CID, options?: BlockRetrievalOptions<GetProgressOptions>): Promise<Uint8Array>
 }
 
 export interface BlockAnnouncer<NotifyProgressOptions extends ProgressOptions = ProgressOptions> {


### PR DESCRIPTION
- feat: blockBrokers can control block validation

Built on top of https://github.com/ipfs/helia/pull/281 & https://github.com/ipfs/helia/pull/284

This PR adds the `validateFn` option to `BlockRetriever.retrieve` options and slightly modifies
how `raceBlockRetrievers` inside of `NetworkedStorage` is handled. Some callouts:

* BlockBroker's are given a TRUSTED `validateFn` to call when they retrieve blocks, and MAY call this method prior to returning the block
* If they call `validateFn`, when
    * it doesn't throw, we consider the blocks to have been verified (since we own the inner `validateFn` and given MultihashHashers)
    * it throws, they can handle recourse within their `retrieve` method (e.g. try other gateways, other peers/transports/etc, whatever they want)
        * If they do not, we consider that blockBroker to have failed the `retrieve` method and other `BlockBrokers` will continue to `raceBlockRetrievers` as expected
* If they do not call `validateFn`, we will call it for them, and then
    * If it doesn't throw, we consider the blocks to have been verified (since we own the inner `validateFn` and given MultihashHashers)
    * If it throws, we consider that blockBroker to have failed the `retrieve` method and other `BlockBrokers` will continue to `raceBlockRetrievers` as expected
* The types of the `retrieve` method in `BitswapBlockBroker` were modified so a `validateFn` can be handled there, but no work towards that effort should be done until https://github.com/ipfs/js-ipfs-bitswap/issues/603 is handled.
