### PR TITLE
refactor: use functions for block broker creation

### DIFF
--- a/packages/helia/.aegir.js
+++ b/packages/helia/.aegir.js
@@ -11,11 +11,11 @@ const options = {
     before: async () => {
       // use dynamic import otherwise the source may not have been built yet
       const { createHelia } = await import('./dist/src/index.js')
-      const { BitswapBlockBrokerFactory } = await import('./dist/src/block-brokers/index.js')
+      const { bitswap } = await import('./dist/src/block-brokers/index.js')
 
       const helia = await createHelia({
         blockBrokers: [
-          BitswapBlockBrokerFactory
+          bitswap()
         ],
         libp2p: {
           addresses: {

--- a/packages/helia/src/block-brokers/bitswap.ts
+++ b/packages/helia/src/block-brokers/bitswap.ts
@@ -1,21 +1,32 @@
 import { createBitswap } from 'ipfs-bitswap'
-import type { BlockBrokerFactoryFunction } from '@helia/interface'
-import type { BlockAnnouncer, BlockRetrievalOptions, BlockRetriever } from '@helia/interface/blocks'
+import type { BlockAnnouncer, BlockBroker, BlockRetrievalOptions, BlockRetriever } from '@helia/interface/blocks'
 import type { Libp2p } from '@libp2p/interface'
 import type { Startable } from '@libp2p/interface/startable'
 import type { Blockstore } from 'interface-blockstore'
-import type { Bitswap, BitswapNotifyProgressEvents, BitswapWantBlockProgressEvents } from 'ipfs-bitswap'
+import type { Bitswap, BitswapNotifyProgressEvents, BitswapOptions, BitswapWantBlockProgressEvents } from 'ipfs-bitswap'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
 import type { ProgressOptions } from 'progress-events'
 
-export class BitswapBlockBroker implements BlockAnnouncer<ProgressOptions<BitswapNotifyProgressEvents>>, BlockRetriever<
+interface BitswapComponents {
+  libp2p: Libp2p
+  blockstore: Blockstore
+  hashers: MultihashHasher[]
+}
+
+export interface BitswapInit extends BitswapOptions {
+
+}
+
+class BitswapBlockBroker implements BlockAnnouncer<ProgressOptions<BitswapNotifyProgressEvents>>, BlockRetriever<
 ProgressOptions<BitswapWantBlockProgressEvents>
 >, Startable {
   private readonly bitswap: Bitswap
   private started: boolean
 
-  constructor (libp2p: Libp2p, blockstore: Blockstore, hashers: MultihashHasher[]) {
+  constructor (components: BitswapComponents, init: BitswapInit = {}) {
+    const { libp2p, blockstore, hashers } = components
+
     this.bitswap = createBitswap(libp2p, blockstore, {
       hashLoader: {
         getHasher: async (codecOrName: string | number): Promise<MultihashHasher<number>> => {
@@ -29,7 +40,8 @@ ProgressOptions<BitswapWantBlockProgressEvents>
 
           throw new Error(`Could not load hasher for code/name "${codecOrName}"`)
         }
-      }
+      },
+      ...init
     })
     this.started = false
   }
@@ -61,6 +73,6 @@ ProgressOptions<BitswapWantBlockProgressEvents>
  * A helper factory for users who want to override Helia `blockBrokers` but
  * still want to use the default `BitswapBlockBroker`.
  */
-export const BitswapBlockBrokerFactory: BlockBrokerFactoryFunction = (components): BitswapBlockBroker => {
-  return new BitswapBlockBroker(components.libp2p, components.blockstore, components.hashers)
+export function bitswap (init: BitswapInit = {}): (components: BitswapComponents) => BlockBroker {
+  return (components) => new BitswapBlockBroker(components, init)
 }

--- a/packages/helia/src/block-brokers/index.ts
+++ b/packages/helia/src/block-brokers/index.ts
@@ -1,2 +1,2 @@
-export { BitswapBlockBroker, BitswapBlockBrokerFactory } from './bitswap-block-broker.js'
-export { TrustlessGatewayBlockBroker } from './trustless-gateway-block-broker.js'
+export { bitswap } from './bitswap.js'
+export { trustlessGateway } from './trustless-gateway/index.js'

--- a/packages/helia/src/block-brokers/trustless-gateway/broker.ts
+++ b/packages/helia/src/block-brokers/trustless-gateway/broker.ts
@@ -1,0 +1,65 @@
+import { logger } from '@libp2p/logger'
+import { TrustlessGateway } from './trustless-gateway.js'
+import { DEFAULT_TRUSTLESS_GATEWAYS } from './index.js'
+import type { TrustlessGatewayBlockBrokerInit, TrustlessGatewayGetBlockProgressEvents } from './index.js'
+import type { BlockRetrievalOptions, BlockRetriever } from '@helia/interface/blocks'
+import type { CID } from 'multiformats/cid'
+import type { ProgressOptions } from 'progress-events'
+
+const log = logger('helia:trustless-gateway-block-broker')
+
+/**
+ * A class that accepts a list of trustless gateways that are queried
+ * for blocks.
+ */
+export class TrustlessGatewayBlockBroker implements BlockRetriever<
+ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
+> {
+  private readonly gateways: TrustlessGateway[]
+
+  constructor (init: TrustlessGatewayBlockBrokerInit = {}) {
+    this.gateways = (init.gateways ?? DEFAULT_TRUSTLESS_GATEWAYS)
+      .map((gatewayOrUrl) => {
+        return new TrustlessGateway(gatewayOrUrl)
+      })
+  }
+
+  async retrieve (cid: CID, options: BlockRetrievalOptions<ProgressOptions<TrustlessGatewayGetBlockProgressEvents>> = {}): Promise<Uint8Array> {
+    // Loop through the gateways until we get a block or run out of gateways
+    // TODO: switch to toSorted when support is better
+    const sortedGateways = this.gateways.sort((a, b) => b.reliability() - a.reliability())
+    const aggregateErrors: Error[] = []
+
+    for (const gateway of sortedGateways) {
+      log('getting block for %c from %s', cid, gateway.url)
+      try {
+        const block = await gateway.getRawBlock(cid, options.signal)
+        log.trace('got block for %c from %s', cid, gateway.url)
+        try {
+          await options.validateFn?.(block)
+        } catch (err) {
+          log.error('failed to validate block for %c from %s', cid, gateway.url, err)
+          gateway.incrementInvalidBlocks()
+
+          throw new Error(`unable to validate block for CID ${cid} from gateway ${gateway.url}`)
+        }
+
+        return block
+      } catch (err: unknown) {
+        log.error('failed to get block for %c from %s', cid, gateway.url, err)
+        if (err instanceof Error) {
+          aggregateErrors.push(err)
+        } else {
+          aggregateErrors.push(new Error(`unable to fetch raw block for CID ${cid} from gateway ${gateway.url}`))
+        }
+        // if signal was aborted, exit the loop
+        if (options.signal?.aborted === true) {
+          log.trace('request aborted while fetching raw block for CID %c from gateway %s', cid, gateway.url)
+          break
+        }
+      }
+    }
+
+    throw new AggregateError(aggregateErrors, `unable to fetch raw block for CID ${cid} from any gateway`)
+  }
+}

--- a/packages/helia/src/block-brokers/trustless-gateway/index.ts
+++ b/packages/helia/src/block-brokers/trustless-gateway/index.ts
@@ -1,0 +1,31 @@
+import { TrustlessGatewayBlockBroker } from './broker.js'
+import type { BlockRetriever } from '@helia/interface/src/blocks.js'
+import type { ProgressEvent } from 'progress-events'
+
+export const DEFAULT_TRUSTLESS_GATEWAYS = [
+  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
+  'https://dweb.link',
+
+  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
+  'https://cf-ipfs.com',
+
+  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
+  'https://4everland.io',
+
+  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
+  'https://w3s.link',
+
+  // 2023-10-03: IPNS, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
+  'https://cloudflare-ipfs.com'
+]
+
+export type TrustlessGatewayGetBlockProgressEvents =
+  ProgressEvent<'trustless-gateway:get-block:fetch', URL>
+
+export interface TrustlessGatewayBlockBrokerInit {
+  gateways?: Array<string | URL>
+}
+
+export function trustlessGateway (init: TrustlessGatewayBlockBrokerInit = {}): () => BlockRetriever {
+  return () => new TrustlessGatewayBlockBroker(init)
+}

--- a/packages/helia/src/block-brokers/trustless-gateway/trustless-gateway.ts
+++ b/packages/helia/src/block-brokers/trustless-gateway/trustless-gateway.ts
@@ -1,9 +1,4 @@
-import { logger } from '@libp2p/logger'
-import type { BlockRetrievalOptions, BlockRetriever } from '@helia/interface/blocks'
 import type { CID } from 'multiformats/cid'
-import type { ProgressEvent, ProgressOptions } from 'progress-events'
-
-const log = logger('helia:trustless-gateway-block-broker')
 
 /**
  * A `TrustlessGateway` keeps track of the number of attempts, errors, and
@@ -127,66 +122,5 @@ export class TrustlessGateway {
    */
   incrementInvalidBlocks (): void {
     this.#invalidBlocks++
-  }
-}
-
-export type TrustlessGatewayGetBlockProgressEvents =
-  ProgressEvent<'trustless-gateway:get-block:fetch', URL>
-
-/**
- * A class that accepts a list of trustless gateways that are queried
- * for blocks.
- */
-export class TrustlessGatewayBlockBroker implements BlockRetriever<
-ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
-> {
-  private readonly gateways: TrustlessGateway[]
-
-  constructor (gatewaysOrUrls: Array<string | URL | TrustlessGateway>) {
-    this.gateways = gatewaysOrUrls.map((gatewayOrUrl) => {
-      if (gatewayOrUrl instanceof TrustlessGateway || Object.prototype.hasOwnProperty.call(gatewayOrUrl, 'getRawBlock')) {
-        return gatewayOrUrl as TrustlessGateway
-      }
-      // eslint-disable-next-line no-console
-      console.trace('creating new TrustlessGateway for %s', gatewayOrUrl)
-      return new TrustlessGateway(gatewayOrUrl)
-    })
-  }
-
-  async retrieve (cid: CID, options: BlockRetrievalOptions<ProgressOptions<TrustlessGatewayGetBlockProgressEvents>> = {}): Promise<Uint8Array> {
-    // Loop through the gateways until we get a block or run out of gateways
-    const sortedGateways = this.gateways.sort((a, b) => b.reliability() - a.reliability())
-    const aggregateErrors: Error[] = []
-    for (const gateway of sortedGateways) {
-      log('getting block for %c from %s', cid, gateway.url)
-      try {
-        const block = await gateway.getRawBlock(cid, options.signal)
-        log.trace('got block for %c from %s', cid, gateway.url)
-        try {
-          await options.validateFn?.(block)
-        } catch (err) {
-          log.error('failed to validate block for %c from %s', cid, gateway.url, err)
-          gateway.incrementInvalidBlocks()
-
-          throw new Error(`unable to validate block for CID ${cid} from gateway ${gateway.url}`)
-        }
-
-        return block
-      } catch (err: unknown) {
-        log.error('failed to get block for %c from %s', cid, gateway.url, err)
-        if (err instanceof Error) {
-          aggregateErrors.push(err)
-        } else {
-          aggregateErrors.push(new Error(`unable to fetch raw block for CID ${cid} from gateway ${gateway.url}`))
-        }
-        // if signal was aborted, exit the loop
-        if (options.signal?.aborted === true) {
-          log.trace('request aborted while fetching raw block for CID %c from gateway %s', cid, gateway.url)
-          break
-        }
-      }
-    }
-
-    throw new AggregateError(aggregateErrors, `unable to fetch raw block for CID ${cid} from any gateway`)
   }
 }

--- a/packages/helia/test/block-brokers/block-broker.spec.ts
+++ b/packages/helia/test/block-brokers/block-broker.spec.ts
@@ -10,16 +10,16 @@ import { type StubbedInstance, stubInterface } from 'sinon-ts'
 import { defaultHashers } from '../../src/utils/default-hashers.js'
 import { NetworkedStorage } from '../../src/utils/networked-storage.js'
 import { createBlock } from '../fixtures/create-block.js'
-import type { BitswapBlockBroker, TrustlessGatewayBlockBroker } from '../../src/block-brokers/index.js'
+import type { BlockBroker, BlockRetriever } from '@helia/interface/blocks'
 import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 
-describe('block-provider', () => {
+describe('block-broker', () => {
   let storage: NetworkedStorage
   let blockstore: Blockstore
-  let bitswapBlockBroker: StubbedInstance<BitswapBlockBroker>
+  let bitswapBlockBroker: StubbedInstance<Required<BlockBroker>>
   let blocks: Array<{ cid: CID, block: Uint8Array }>
-  let gatewayBlockBroker: StubbedInstance<TrustlessGatewayBlockBroker>
+  let gatewayBlockBroker: StubbedInstance<Required<BlockRetriever>>
 
   beforeEach(async () => {
     blocks = []
@@ -29,8 +29,8 @@ describe('block-provider', () => {
     }
 
     blockstore = new MemoryBlockstore()
-    bitswapBlockBroker = stubInterface<BitswapBlockBroker>()
-    gatewayBlockBroker = stubInterface<TrustlessGatewayBlockBroker>()
+    bitswapBlockBroker = stubInterface()
+    gatewayBlockBroker = stubInterface()
     storage = new NetworkedStorage(blockstore, {
       blockBrokers: [
         bitswapBlockBroker,

--- a/packages/helia/test/fixtures/create-helia.ts
+++ b/packages/helia/test/fixtures/create-helia.ts
@@ -2,14 +2,14 @@ import { webSockets } from '@libp2p/websockets'
 import * as Filters from '@libp2p/websockets/filters'
 import { circuitRelayTransport } from 'libp2p/circuit-relay'
 import { identifyService } from 'libp2p/identify'
-import { BitswapBlockBrokerFactory } from '../../src/block-brokers/index.js'
+import { bitswap } from '../../src/block-brokers/index.js'
 import { createHelia as createNode } from '../../src/index.js'
 import type { Helia } from '@helia/interface'
 
 export async function createHelia (): Promise<Helia> {
   return createNode({
     blockBrokers: [
-      BitswapBlockBrokerFactory
+      bitswap()
     ],
     libp2p: {
       addresses: {

--- a/packages/helia/test/utils/networked-storage.spec.ts
+++ b/packages/helia/test/utils/networked-storage.spec.ts
@@ -11,14 +11,14 @@ import { type StubbedInstance, stubInterface } from 'sinon-ts'
 import { defaultHashers } from '../../src/utils/default-hashers.js'
 import { NetworkedStorage } from '../../src/utils/networked-storage.js'
 import { createBlock } from '../fixtures/create-block.js'
-import type { BitswapBlockBroker } from '../../src/block-brokers/bitswap-block-broker.js'
+import type { BlockAnnouncer, BlockRetriever } from '@helia/interface/blocks'
 import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 
 describe('networked-storage', () => {
   let storage: NetworkedStorage
   let blockstore: Blockstore
-  let bitswap: StubbedInstance<BitswapBlockBroker>
+  let bitswap: StubbedInstance<Required<BlockRetriever & BlockAnnouncer>>
   let blocks: Array<{ cid: CID, block: Uint8Array }>
 
   beforeEach(async () => {
@@ -29,7 +29,7 @@ describe('networked-storage', () => {
     }
 
     blockstore = new MemoryBlockstore()
-    bitswap = stubInterface<BitswapBlockBroker>()
+    bitswap = stubInterface()
     storage = new NetworkedStorage(blockstore, {
       blockBrokers: [
         bitswap
@@ -117,7 +117,6 @@ describe('networked-storage', () => {
   it('gets a block from bitswap when it is not in the blockstore', async () => {
     const { cid, block } = blocks[0]
 
-    bitswap.isStarted.returns(true)
     bitswap.retrieve.withArgs(cid).resolves(block)
 
     expect(await blockstore.has(cid)).to.be.false()
@@ -130,8 +129,6 @@ describe('networked-storage', () => {
   })
 
   it('gets many blocks from bitswap when they are not in the blockstore', async () => {
-    bitswap.isStarted.returns(true)
-
     const count = 5
 
     for (let i = 0; i < count; i++) {
@@ -158,8 +155,6 @@ describe('networked-storage', () => {
   })
 
   it('gets some blocks from bitswap when they are not in the blockstore', async () => {
-    bitswap.isStarted.returns(true)
-
     const count = 5
 
     // blocks 0,1,3,4 are in the blockstore

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -14,12 +14,11 @@
  * ```
  */
 
-import type { BlockBroker, Blocks } from './blocks.js'
+import type { Blocks } from './blocks.js'
 import type { Pins } from './pins.js'
 import type { Libp2p, AbortOptions } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 import type { CID } from 'multiformats/cid'
-import type { MultihashHasher } from 'multiformats/hashes/interface'
 import type { ProgressEvent, ProgressOptions } from 'progress-events'
 
 export type { Await, AwaitIterable } from 'interface-store'
@@ -70,19 +69,4 @@ export type GcEvents =
 
 export interface GCOptions extends AbortOptions, ProgressOptions<GcEvents> {
 
-}
-export type BlockBrokerFactoryComponents = Pick<Helia, 'libp2p' | 'blockstore' | 'datastore'> & {
-  hashers: MultihashHasher[]
-}
-
-/**
- * A function that receives some {@link Helia} components and returns a
- * {@link BlockBroker}.
- *
- * This is needed in order to re-use some of the internal components Helia
- * constructs without having to hoist each required component into the top-level
- * scope.
- */
-export interface BlockBrokerFactoryFunction {
-  (heliaComponents: BlockBrokerFactoryComponents): BlockBroker
 }

--- a/packages/interop/test/fixtures/create-helia.browser.ts
+++ b/packages/interop/test/fixtures/create-helia.browser.ts
@@ -5,7 +5,7 @@ import { all } from '@libp2p/websockets/filters'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type HeliaInit } from 'helia'
-import { BitswapBlockBrokerFactory } from 'helia/block-brokers'
+import { bitswap } from 'helia/block-brokers'
 import { createLibp2p } from 'libp2p'
 import { identifyService } from 'libp2p/identify'
 import type { Helia } from '@helia/interface'
@@ -40,7 +40,7 @@ export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia
   const helia = await createHelia({
     libp2p,
     blockBrokers: [
-      BitswapBlockBrokerFactory
+      bitswap()
     ],
     blockstore,
     datastore,

--- a/packages/interop/test/fixtures/create-helia.ts
+++ b/packages/interop/test/fixtures/create-helia.ts
@@ -4,7 +4,7 @@ import { tcp } from '@libp2p/tcp'
 import { MemoryBlockstore } from 'blockstore-core'
 import { MemoryDatastore } from 'datastore-core'
 import { createHelia, type HeliaInit } from 'helia'
-import { BitswapBlockBrokerFactory } from 'helia/block-brokers'
+import { bitswap } from 'helia/block-brokers'
 import { createLibp2p } from 'libp2p'
 import { identifyService } from 'libp2p/identify'
 import type { Helia } from '@helia/interface'
@@ -37,7 +37,7 @@ export async function createHeliaNode (init?: Partial<HeliaInit>): Promise<Helia
   const helia = await createHelia({
     libp2p,
     blockBrokers: [
-      BitswapBlockBrokerFactory
+      bitswap()
     ],
     blockstore,
     datastore,


### PR DESCRIPTION
This approach is consistent with libp2p components, unixfs, ipns, etc.

Since #281 and #284 were merged without review, this PR implements suggestions that would have been in the review of those PRs.

1. Creation of block brokers is done by exported function. If your broker takes arguments, pass them to the factory function.  The factory then returns a function that accepts helia components and returns the broker.
2. Removes BitswapBlockBrokerFactory variable in favour of `bitswap` function
3. Removes BlockBrokerFactoryComponents interface in favour of brokers declaring their own component requirements
4. Define DEFAULT_TRUSTLESS_GATEWAYS in trustless gateway code
5. Use `await expect(promise).to.eventually.be.rejected` in tests instead of `try/catch` blocks
6. Remove use of console

The internal API may need some more work but the external API should be relatively stable.