### PR TITLE
docs(version): ✨ Pulling version number from helia.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "release": "run-s build docs:no-publish npm:release docs",
     "npm:release": "aegir exec --bail false npm -- publish",
     "release:rc": "aegir release-rc",
-    "docs": "NODE_OPTIONS=--max_old_space_size=8192 aegir docs -- --exclude packages/interop --excludeExternals",
-    "docs:no-publish": "NODE_OPTIONS=--max_old_space_size=8192 aegir docs --publish false -- --exclude packages/interop"
+    "update:version": "node scripts/update-version.js",
+    "docs": "npm run update:version && NODE_OPTIONS=--max_old_space_size=8192 aegir docs -- --exclude packages/interop --excludeExternals",
+    "docs:no-publish": "npm run update:version && NODE_OPTIONS=--max_old_space_size=8192 aegir docs --publish false -- --exclude packages/interop"
   },
   "devDependencies": {
     "aegir": "^41.0.0",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,6 @@
+import heliaPkg from '../packages/helia/package.json' assert { type: 'json'}
+import rootPkg from '../package.json' assert { type: 'json'}
+import { writeFile } from 'fs/promises'
+
+rootPkg.version = heliaPkg.version
+await writeFile(new URL('../package.json', import.meta.url), `${JSON.stringify(rootPkg, null, 2)}\n`)


### PR DESCRIPTION
Fixes the package version on the docs hosted on helia.io.

- Pulls the latest version from `helia`.
- Updates the root `package.json`
- Builds the docs.

<img width="1676" alt="helia-version-doc" src="https://github.com/ipfs/helia/assets/1895906/0143a7e2-a354-4d7d-9477-cb9d2f857647">

This should fix the version in the next release.