### PR TITLE
feat: use trustless-gateway.link by default

### DIFF
--- a/packages/helia/src/block-brokers/trustless-gateway/index.ts
+++ b/packages/helia/src/block-brokers/trustless-gateway/index.ts
@@ -15,8 +15,8 @@ export const DEFAULT_TRUSTLESS_GATEWAYS = [
   // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
   'https://w3s.link',
 
-  // 2023-10-03: IPNS, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
-  'https://cloudflare-ipfs.com'
+  // https://github.com/protocol/bifrost-community/issues/1
+  'https://trustless-gateway.link/'
 ]
 
 export type TrustlessGatewayGetBlockProgressEvents =


### PR DESCRIPTION
tested at https://codepen.io/SgtPooki/pen/JjxYpZX successfully.