### PR TITLE
chore: publish with npm provenance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,11 +168,15 @@ jobs:
       test-electron-renderer
     ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
           command: manifest
           release-type: node
           manifest-file: .release-please-manifest.json

--- a/.release-please.json
+++ b/.release-please.json
@@ -1,6 +1,5 @@
 {
   "plugins": ["node-workspace"],
-  "group-pull-request-title-pattern": "chore: release ${component}",
   "packages": {
     "packages/helia": {},
     "packages/interface": {},

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -11,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/ipfs/helia/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "IPFS"
   ],

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -11,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/ipfs/helia/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "IPFS"
   ],

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -11,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/ipfs/helia/issues"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "IPFS"
   ],


### PR DESCRIPTION
To guard against supply chain attacks, publish with provenance.

Refs:
- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements