### PR TITLE
fix: remove w3s.link default block-broker

### DIFF
--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -11,10 +11,7 @@ export const DEFAULT_TRUSTLESS_GATEWAYS = [
   'https://cf-ipfs.com',
 
   // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
-  'https://4everland.io',
-
-  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
-  'https://w3s.link'
+  'https://4everland.io'
 ]
 
 export type TrustlessGatewayGetBlockProgressEvents =


### PR DESCRIPTION
Note that w3s will only serve blocks that are uploaded to it.

For those that do use w3s for uploading files, they just need to pass the defaults + the gateways they want

```
// heliaInit config:
blockBrokers: [ 
	trustlessGateways({ 
		gateways: [
			...DEFAULT_TRUSTLESS_GATEWAYS, 
			'https://w3s.link'
		]
	})
]
```