### PR TITLE
fix: ignore libp2p start param in helia factory

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -64,8 +64,11 @@ export interface HeliaInit<T extends Libp2p = Libp2p> {
    * If node options are passed, they will be merged with the default
    * config for the current platform. In this case all passed config
    * keys will replace those from the default config.
+   *
+   * The libp2p `start` option is not supported, instead please pass `start` in
+   * the root of the HeliaInit object.
    */
-  libp2p?: T | Libp2pOptions
+  libp2p?: T | Omit<Libp2pOptions, 'start'>
 
   /**
    * The blockstore is where blocks are stored
@@ -152,7 +155,13 @@ export async function createHelia (init: HeliaInit = {}): Promise<HeliaLibp2p> {
   } else {
     libp2p = await createLibp2p<DefaultLibp2pServices>({
       ...init,
-      libp2p: init.libp2p,
+      libp2p: {
+        ...init.libp2p,
+
+        // ignore the libp2p start parameter as it should be on the main init
+        // object instead
+        start: undefined
+      },
       datastore
     })
   }

--- a/packages/helia/test/libp2p.spec.ts
+++ b/packages/helia/test/libp2p.spec.ts
@@ -44,4 +44,28 @@ describe('libp2p', () => {
 
     expect(helia.libp2p).to.equal(libp2p)
   })
+
+  it('ignores libp2p start param when it is false', async () => {
+    helia = await createHelia({
+      libp2p: {
+        // @ts-expect-error start is omitted from libp2p init type
+        start: false
+      },
+      start: true
+    })
+
+    expect(helia.libp2p.status).to.equal('started')
+  })
+
+  it('ignores libp2p start param when it is true', async () => {
+    helia = await createHelia({
+      libp2p: {
+        // @ts-expect-error start is omitted from libp2p init type
+        start: true
+      },
+      start: false
+    })
+
+    expect(helia.libp2p.status).to.equal('stopped')
+  })
 })


### PR DESCRIPTION
Omits the `start` key from the accepted libp2p init params, instead use only the `start` key in the main Helia init object.

Fixes #344