### PR TITLE
fix: add a test for reading the peer id from the datastore

### DIFF
--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -5,7 +5,7 @@ import { createLibp2p as create } from 'libp2p'
 import { libp2pDefaults } from './libp2p-defaults.js'
 import type { DefaultLibp2pServices } from './libp2p-defaults.js'
 import type { ComponentLogger, Libp2p, PeerId } from '@libp2p/interface'
-import type { KeychainInit } from '@libp2p/keychain'
+import type { Keychain, KeychainInit } from '@libp2p/keychain'
 import type { Datastore } from 'interface-datastore'
 import type { Libp2pOptions } from 'libp2p'
 
@@ -23,31 +23,40 @@ export interface Libp2pDefaultsOptions {
 }
 
 export async function createLibp2p <T extends Record<string, unknown> = DefaultLibp2pServices> (options: CreateLibp2pOptions<T>): Promise<Libp2p<T>> {
-  let peerId = options.libp2p?.peerId
+  const peerId = options.libp2p?.peerId
   const logger = options.logger ?? defaultLogger()
+  const selfKey = new Key('/pkcs8/self')
+  let chain: Keychain | undefined
 
   // if no peer id was passed, try to load it from the keychain
-  if (peerId == null) {
-    const chain = keychain(options.keychain)({
+  if (peerId == null && options.datastore != null) {
+    chain = keychain(options.keychain)({
       datastore: options.datastore,
       logger
     })
 
-    const selfKey = new Key('/pkcs8/self')
-
     if (await options.datastore.has(selfKey)) {
       // load the peer id from the keychain
-      peerId = await chain.exportPeerId('self')
+      options.libp2p = options.libp2p ?? {}
+      options.libp2p.peerId = await chain.exportPeerId('self')
     }
   }
 
   const defaults = libp2pDefaults(options)
+  defaults.datastore = defaults.datastore ?? options.datastore
   options = options ?? {}
 
   // @ts-expect-error derived ServiceMap is not compatible with ServiceFactoryMap
-  return create({
+  const node = await create({
     ...defaults,
     ...options.libp2p,
     start: false
   })
+
+  if (peerId == null && chain != null && !await options.datastore.has(selfKey)) {
+    // persist the peer id in the keychain for next time
+    await chain.importPeer('self', node.peerId)
+  }
+
+  return node
 }


### PR DESCRIPTION
Adds a test to ensure that the peer id is stable when reusing the same datastore.