### PR TITLE
fix!: remove gossipsub from default libp2p services

### DIFF
--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -54,7 +54,6 @@
     "prepublishOnly": "node scripts/update-version.js && npm run build"
   },
   "dependencies": {
-    "@chainsafe/libp2p-gossipsub": "^11.0.0",
     "@chainsafe/libp2p-noise": "^15.0.0",
     "@chainsafe/libp2p-yamux": "^6.0.1",
     "@helia/block-brokers": "^1.0.0",

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -1,4 +1,3 @@
-import { gossipsub } from '@chainsafe/libp2p-gossipsub'
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
@@ -20,7 +19,6 @@ import * as libp2pInfo from 'libp2p/version'
 import { name, version } from '../version.js'
 import { bootstrapConfig } from './bootstrappers.js'
 import type { Libp2pDefaultsOptions } from './libp2p.js'
-import type { PubSub } from '@libp2p/interface'
 import type { Libp2pOptions } from 'libp2p'
 
 export interface DefaultLibp2pServices extends Record<string, unknown> {
@@ -31,7 +29,6 @@ export interface DefaultLibp2pServices extends Record<string, unknown> {
   identify: Identify
   keychain: Keychain
   ping: PingService
-  pubsub: PubSub
 }
 
 export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> {
@@ -78,8 +75,7 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
         agentVersion: `${name}/${version} ${libp2pInfo.name}/${libp2pInfo.version} UserAgent=${globalThis.navigator.userAgent}`
       }),
       keychain: keychain(options.keychain),
-      ping: ping(),
-      pubsub: gossipsub()
+      ping: ping()
     }
   }
 }

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -1,4 +1,3 @@
-import { gossipsub } from '@chainsafe/libp2p-gossipsub'
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
@@ -22,7 +21,6 @@ import * as libp2pInfo from 'libp2p/version'
 import { name, version } from '../version.js'
 import { bootstrapConfig } from './bootstrappers.js'
 import type { Libp2pDefaultsOptions } from './libp2p.js'
-import type { PubSub } from '@libp2p/interface'
 import type { Libp2pOptions } from 'libp2p'
 
 export interface DefaultLibp2pServices extends Record<string, unknown> {
@@ -33,7 +31,6 @@ export interface DefaultLibp2pServices extends Record<string, unknown> {
   identify: Identify
   keychain: Keychain
   ping: PingService
-  pubsub: PubSub
   relay: CircuitRelayService
   upnp: unknown
 }
@@ -85,7 +82,6 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
       }),
       keychain: keychain(options.keychain),
       ping: ping(),
-      pubsub: gossipsub(),
       relay: circuitRelayServer({
         advertise: true
       }),

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -57,6 +57,7 @@
     "test:electron-main": "aegir test -t electron-main"
   },
   "dependencies": {
+    "@chainsafe/libp2p-gossipsub": "^11.1.0",
     "@helia/block-brokers": "^1.0.0",
     "@helia/car": "^2.0.1",
     "@helia/dag-cbor": "^2.0.1",
@@ -73,6 +74,7 @@
     "@ipld/dag-cbor": "^9.0.7",
     "@libp2p/interface": "^1.1.1",
     "@libp2p/kad-dht": "^12.0.2",
+    "@libp2p/keychain": "^4.0.7",
     "@libp2p/peer-id": "^4.0.5",
     "@libp2p/peer-id-factory": "^4.0.3",
     "@libp2p/websockets": "^8.0.10",
@@ -89,6 +91,7 @@
     "it-to-buffer": "^4.0.2",
     "kubo": "^0.25.0",
     "kubo-rpc-client": "^3.0.1",
+    "libp2p": "^1.2.0",
     "multiformats": "^13.0.0",
     "p-defer": "^4.0.0",
     "uint8arrays": "^5.0.1",

--- a/packages/interop/src/fixtures/connect.ts
+++ b/packages/interop/src/fixtures/connect.ts
@@ -5,7 +5,7 @@ import type { Controller } from 'ipfsd-ctl'
 /**
  * Connect the two nodes by dialing a protocol stream
  */
-export async function connect (helia: HeliaLibp2p, kubo: Controller, protocol: string): Promise<void> {
+export async function connect (helia: HeliaLibp2p<any>, kubo: Controller, protocol: string): Promise<void> {
   let connected = false
   for (const addr of kubo.peer.addresses) {
     try {

--- a/packages/interop/src/fixtures/create-helia.browser.ts
+++ b/packages/interop/src/fixtures/create-helia.browser.ts
@@ -7,8 +7,11 @@ import { sha3512 } from '@multiformats/sha3'
 import { createHelia, libp2pDefaults } from 'helia'
 import type { Libp2p } from '@libp2p/interface'
 import type { DefaultLibp2pServices, HeliaLibp2p } from 'helia'
+import type { Libp2pOptions } from 'libp2p'
 
-export async function createHeliaNode (): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>> {
+export async function createHeliaNode (): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>>
+export async function createHeliaNode <Services extends Record<string, unknown>> (libp2pOptions: Libp2pOptions<Services>): Promise<HeliaLibp2p<Libp2p<Services & DefaultLibp2pServices>>>
+export async function createHeliaNode (libp2pOptions?: Libp2pOptions): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>> {
   const defaults = libp2pDefaults()
 
   // allow dialing insecure WebSockets
@@ -28,6 +31,7 @@ export async function createHeliaNode (): Promise<HeliaLibp2p<Libp2p<DefaultLibp
   // use LAN DHT
   defaults.services = {
     ...(defaults.services ?? {}),
+    ...(libp2pOptions?.services ?? {}),
     dht: kadDHT({
       validators: {
         ipns: ipnsValidator

--- a/packages/interop/src/fixtures/create-helia.ts
+++ b/packages/interop/src/fixtures/create-helia.ts
@@ -5,8 +5,11 @@ import { sha3512 } from '@multiformats/sha3'
 import { createHelia, libp2pDefaults } from 'helia'
 import type { Libp2p } from '@libp2p/interface'
 import type { DefaultLibp2pServices, HeliaLibp2p } from 'helia'
+import type { Libp2pOptions } from 'libp2p'
 
-export async function createHeliaNode (): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>> {
+export async function createHeliaNode (): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>>
+export async function createHeliaNode <Services extends Record<string, unknown>> (libp2pOptions: Libp2pOptions<Services>): Promise<HeliaLibp2p<Libp2p<Services & DefaultLibp2pServices>>>
+export async function createHeliaNode (libp2pOptions?: Libp2pOptions): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>> {
   const defaults = libp2pDefaults()
   defaults.addresses = {
     listen: [
@@ -15,6 +18,7 @@ export async function createHeliaNode (): Promise<HeliaLibp2p<Libp2p<DefaultLibp
   }
   defaults.services = {
     ...(defaults.services ?? {}),
+    ...(libp2pOptions?.services ?? {}),
     dht: kadDHT({
       validators: {
         ipns: ipnsValidator

--- a/packages/interop/src/ipns-pubsub.spec.ts
+++ b/packages/interop/src/ipns-pubsub.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 5] */
 
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
 import { ipns } from '@helia/ipns'
 import { pubsub } from '@helia/ipns/routing'
 import { peerIdFromKeys } from '@libp2p/peer-id'
@@ -20,6 +21,8 @@ import { createKuboNode } from './fixtures/create-kubo.js'
 import { keyTypes } from './fixtures/key-types.js'
 import { waitFor } from './fixtures/wait-for.js'
 import type { IPNS } from '@helia/ipns'
+import type { Libp2p, PubSub } from '@libp2p/interface'
+import type { Keychain } from '@libp2p/keychain'
 import type { HeliaLibp2p } from 'helia'
 import type { Controller } from 'ipfsd-ctl'
 
@@ -30,12 +33,16 @@ const LIBP2P_KEY_CODEC = 0x72
 // resolution because Kubo will use the DHT as well
 keyTypes.filter(keyType => keyType !== 'RSA').forEach(keyType => {
   describe(`@helia/ipns - pubsub routing with ${keyType} keys`, () => {
-    let helia: HeliaLibp2p
+    let helia: HeliaLibp2p<Libp2p<{ pubsub: PubSub, keychain: Keychain }>>
     let kubo: Controller
     let name: IPNS
 
     beforeEach(async () => {
-      helia = await createHeliaNode()
+      helia = await createHeliaNode({
+        services: {
+          pubsub: gossipsub()
+        }
+      })
       kubo = await createKuboNode()
 
       // connect the two nodes

--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -61,12 +61,18 @@ and multiple peers are listening on the topic(s), otherwise update messages
 may fail to be published with "Insufficient peers" errors.
 
 ```typescript
-import { createHelia } from 'helia'
+import { createHelia, libp2pDefaults } from 'helia'
 import { ipns } from '@helia/ipns'
 import { pubsub } from '@helia/ipns/routing'
 import { unixfs } from '@helia/unixfs'
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
 
-const helia = await createHelia()
+const libp2pOptions = libp2pDefaults()
+libp2pOptions.services.pubsub = gossipsub()
+
+const helia = await createHelia({
+  libp2p: libp2pOptions
+})
 const name = ipns(helia, {
  routers: [
    pubsub(helia)

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -47,12 +47,18 @@
  * may fail to be published with "Insufficient peers" errors.
  *
  * ```typescript
- * import { createHelia } from 'helia'
+ * import { createHelia, libp2pDefaults } from 'helia'
  * import { ipns } from '@helia/ipns'
  * import { pubsub } from '@helia/ipns/routing'
  * import { unixfs } from '@helia/unixfs'
+ * import { gossipsub } from '@chainsafe/libp2p-gossipsub'
  *
- * const helia = await createHelia()
+ * const libp2pOptions = libp2pDefaults()
+ * libp2pOptions.services.pubsub = gossipsub()
+ *
+ * const helia = await createHelia({
+ *   libp2p: libp2pOptions
+ * })
  * const name = ipns(helia, {
  *  routers: [
  *    pubsub(helia)


### PR DESCRIPTION
It's not required to IPFS things, it's a large chunk of code and it's quite CPU intensive so do not bundle it by default.

People can still configure themselves if they need it.