### PR TITLE
fix: @helia/verified-fetch init args are optional

### DIFF
--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -278,15 +278,15 @@ export interface VerifiedFetchInit extends RequestInit, ProgressOptions<BubbledP
 /**
  * Create and return a Helia node
  */
-export async function createVerifiedFetch (init: Helia | CreateVerifiedFetchWithOptions): Promise<VerifiedFetch> {
+export async function createVerifiedFetch (init?: Helia | CreateVerifiedFetchWithOptions): Promise<VerifiedFetch> {
   if (!isHelia(init)) {
     init = await createHeliaHTTP({
       blockBrokers: [
         trustlessGateway({
-          gateways: init.gateways
+          gateways: init?.gateways
         })
       ],
-      routers: init.routers?.map((routerUrl) => delegatedHTTPRouting(routerUrl))
+      routers: (init?.routers ?? ['https://delegated-ipfs.dev']).map((routerUrl) => delegatedHTTPRouting(routerUrl))
     })
   }
 

--- a/packages/verified-fetch/test/index.spec.ts
+++ b/packages/verified-fetch/test/index.spec.ts
@@ -38,4 +38,11 @@ describe('createVerifiedFetch', () => {
     expect(verifiedFetch).to.be.ok()
     await verifiedFetch.stop()
   })
+
+  it('can be constructed with no options', async () => {
+    const verifiedFetch = await createVerifiedFetch()
+
+    expect(verifiedFetch).to.be.ok()
+    await verifiedFetch.stop()
+  })
 })


### PR DESCRIPTION
To allow no-option, all-defaults construction of verified fetch

```TypeScript
import { createVerifiedFetch } from '@helia/verified-fetch'

const fetch = await createVerifiedFetch()

const resp = await fetch('ipfs://bafy...')
// ...
```