### PR TITLE
feat: also check content-type with @sgtpooki/file-type

### DIFF
--- a/packages/verified-fetch/package.json
+++ b/packages/verified-fetch/package.json
@@ -155,6 +155,7 @@
     "@ipld/dag-pb": "^4.0.8",
     "@libp2p/interface": "^1.1.2",
     "@libp2p/peer-id": "^4.0.5",
+    "@sgtpooki/file-type": "^1.0.0-1e871f8",
     "hashlru": "^2.3.0",
     "ipfs-unixfs-exporter": "^13.4.0",
     "mime-types": "^2.1.35",

--- a/packages/verified-fetch/src/utils/get-content-type.ts
+++ b/packages/verified-fetch/src/utils/get-content-type.ts
@@ -1,3 +1,4 @@
+import { fileTypeFromBuffer } from '@sgtpooki/file-type'
 import mime from 'mime-types'
 
 interface TestInput {
@@ -20,6 +21,8 @@ const tests: Array<(input: TestInput) => TestOutput> = [
   async ({ bytes }): TestOutput => xmlRegex.test(new TextDecoder().decode(bytes.slice(0, 64)))
     ? 'image/svg+xml'
     : undefined,
+  // testing file-type from buffer
+  async ({ bytes }): TestOutput => (await fileTypeFromBuffer(bytes))?.mime,
   // testing file-type from path
   async ({ path }): TestOutput => {
     const mimeType = mime.lookup(path)


### PR DESCRIPTION
This PR adds an additional check for content-type via a fork of the `file-type` library, similar to how it's used in helia-http-gateway.

I forked https://github.com/sindresorhus/file-type because it doesn't currently support browsers due to direct or dependency consumption of node:stream, node:buffer, node:fs, or node:process.

The fork could still use some updates to support streams and confirm that memory usage is reasonable, but it's a start and confirmed working in helia-service-worker-gateway.

Using this fork, we would be able to remove the `file-type` dependency from helia-http-gateway and de-dupe the content-type checking code.

Related issues in the original repo:

* https://github.com/sindresorhus/file-type/issues/578
* https://github.com/sindresorhus/file-type/issues/617
