### PR TITLE
chore: stub blocks interface in tests

### DIFF
--- a/packages/verified-fetch/package.json
+++ b/packages/verified-fetch/package.json
@@ -168,7 +168,6 @@
     "@types/sinon": "^17.0.2",
     "aegir": "^42.1.0",
     "helia": "^4.0.1",
-    "interface-blockstore": "^5.2.9",
     "sinon": "^17.0.1",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/verified-fetch/test/verified-fetch.spec.ts
+++ b/packages/verified-fetch/test/verified-fetch.spec.ts
@@ -12,10 +12,10 @@ import sinon, { type SinonStub } from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { VerifiedFetch } from '../src/verified-fetch.js'
 import type { PathWalkerFn } from '../src/utils/walk-path'
-import type { Helia } from '@helia/interface'
+import type { Blocks, Helia } from '@helia/interface'
 import type { Logger, ComponentLogger } from '@libp2p/interface'
-import type { Blockstore } from 'interface-blockstore'
 import type { UnixFSDirectory, UnixFSEntry } from 'ipfs-unixfs-exporter'
+
 const testCID = CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
 const anyOnProgressMatcher = sinon.match.any as unknown as () => void
 
@@ -102,10 +102,10 @@ describe('@helia/verifed-fetch', () => {
     let jsonStub: ReturnType<typeof stubInterface<HeliaJSON>>
     let dagCborStub: ReturnType<typeof stubInterface<DAGCBOR>>
     let pathWalkerStub: SinonStub<Parameters<PathWalkerFn>, ReturnType<PathWalkerFn>>
-    let blockstoreStub: ReturnType<typeof stubInterface<Blockstore>>
+    let blockstoreStub: ReturnType<typeof stubInterface<Blocks>>
 
     beforeEach(async () => {
-      blockstoreStub = stubInterface<Blockstore>()
+      blockstoreStub = stubInterface<Blocks>()
       unixfsStub = stubInterface<UnixFS>({
         cat: sinon.stub(),
         stat: sinon.stub()


### PR DESCRIPTION
The stub should be for the `Blocks` interface.