### PR TITLE
fix: remove is-ipfs from @helia/ipns dependencies

### DIFF
--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -174,7 +174,6 @@
     "hashlru": "^2.3.0",
     "interface-datastore": "^8.2.10",
     "ipns": "^9.0.0",
-    "is-ipfs": "^8.0.1",
     "multiformats": "^13.0.1",
     "p-queue": "^8.0.1",
     "progress-events": "^1.0.0",

--- a/packages/ipns/src/utils/dns.ts
+++ b/packages/ipns/src/utils/dns.ts
@@ -1,5 +1,5 @@
 import { CodeError } from '@libp2p/interface'
-import * as isIPFS from 'is-ipfs'
+import { CID } from 'multiformats/cid'
 import type { DNSResolver, ResolveDnsLinkOptions } from '../index.js'
 
 export interface Question {
@@ -91,14 +91,15 @@ export const recursiveResolveDnslink = async (domain: string, depth: number, res
   const result = dnslinkRecord.replace('dnslink=', '')
   // result is now a `/ipfs/<cid>` or `/ipns/<cid>` string
   const domainOrCID = result.split('/')[2] // e.g. ["", "ipfs", "<cid>"]
-  const isIPFSCID = isIPFS.cid(domainOrCID)
 
-  // if the result is a CID, or depth is 1, we've reached the end of the recursion
-  // if depth is 1, another recursive call will be made, but it would throw.
-  // we could return if depth is 1 and allow users to handle, but that may be a breaking change
-  if (isIPFSCID) {
+  try {
+    CID.parse(domainOrCID)
+
+    // if the result is a CID, or depth is 1, we've reached the end of the recursion
+    // if depth is 1, another recursive call will be made, but it would throw.
+    // we could return if depth is 1 and allow users to handle, but that may be a breaking change
     return result
-  }
+  } catch {}
 
   return recursiveResolveDnslink(domainOrCID, depth - 1, resolve, options)
 }


### PR DESCRIPTION
We only use `is-ipfs` to detect if a string contains a `CID`, just try to parse it instead to save a large depdendency.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
