### PR TITLE
fix: use CID object for verified-fetch progress events

### DIFF
--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -267,7 +267,7 @@ import type { ProgressEvent, ProgressOptions } from 'progress-events'
 export type Resource = string | CID
 
 export interface CIDDetail {
-  cid: string
+  cid: CID
   path: string
 }
 

--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -107,12 +107,12 @@ export class VerifiedFetch {
 
   private async handleDagJson ({ cid, path, options }: FetchHandlerFunctionArg): Promise<Response> {
     this.log.trace('fetching %c/%s', cid, path)
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid, path }))
     const result = await this.dagJson.get(cid, {
       signal: options?.signal,
       onProgress: options?.onProgress
     })
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid, path }))
     const response = new Response(JSON.stringify(result), { status: 200 })
     response.headers.set('content-type', 'application/json')
     return response
@@ -120,12 +120,12 @@ export class VerifiedFetch {
 
   private async handleJson ({ cid, path, options }: FetchHandlerFunctionArg): Promise<Response> {
     this.log.trace('fetching %c/%s', cid, path)
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid, path }))
     const result: Record<any, any> = await this.json.get(cid, {
       signal: options?.signal,
       onProgress: options?.onProgress
     })
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid, path }))
     const response = new Response(JSON.stringify(result), { status: 200 })
     response.headers.set('content-type', 'application/json')
     return response
@@ -133,12 +133,12 @@ export class VerifiedFetch {
 
   private async handleDagCbor ({ cid, path, options }: FetchHandlerFunctionArg): Promise<Response> {
     this.log.trace('fetching %c/%s', cid, path)
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid, path }))
     const result = await this.dagCbor.get<Uint8Array>(cid, {
       signal: options?.signal,
       onProgress: options?.onProgress
     })
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid, path }))
     const response = new Response(result, { status: 200 })
     await this.setContentType(result, path, response)
     return response
@@ -154,7 +154,7 @@ export class VerifiedFetch {
       const rootFilePath = 'index.html'
       try {
         this.log.trace('found directory at %c/%s, looking for index.html', cid, path)
-        options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: dirCid.toString(), path: rootFilePath }))
+        options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: dirCid, path: rootFilePath }))
         stat = await this.unixfs.stat(dirCid, {
           path: rootFilePath,
           signal: options?.signal,
@@ -168,16 +168,16 @@ export class VerifiedFetch {
         this.log('error loading path %c/%s', dirCid, rootFilePath, err)
         return new Response('Unable to find index.html for directory at given path. Support for directories with implicit root is not implemented', { status: 501 })
       } finally {
-        options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: dirCid.toString(), path: rootFilePath }))
+        options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: dirCid, path: rootFilePath }))
       }
     }
 
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: resolvedCID.toString(), path: '' }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: resolvedCID, path: '' }))
     const asyncIter = this.unixfs.cat(resolvedCID, {
       signal: options?.signal,
       onProgress: options?.onProgress
     })
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: resolvedCID.toString(), path: '' }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: resolvedCID, path: '' }))
     this.log('got async iterator for %c/%s', cid, path)
 
     const { stream, firstChunk } = await getStreamFromAsyncIterable(asyncIter, path ?? '', this.helia.logger, {
@@ -191,9 +191,9 @@ export class VerifiedFetch {
 
   private async handleRaw ({ cid, path, options }: FetchHandlerFunctionArg): Promise<Response> {
     this.log.trace('fetching %c/%s', cid, path)
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { cid, path }))
     const result = await this.helia.blockstore.get(cid)
-    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid: cid.toString(), path }))
+    options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:end', { cid, path }))
     const response = new Response(decode(result), { status: 200 })
     await this.setContentType(result, path, response)
     return response

--- a/packages/verified-fetch/test/verified-fetch.spec.ts
+++ b/packages/verified-fetch/test/verified-fetch.spec.ts
@@ -225,15 +225,15 @@ describe('@helia/verifed-fetch', () => {
 
       const onProgressEvents = onProgress.getCalls().map(call => call.args[0])
       expect(onProgressEvents[0]).to.include({ type: 'verified-fetch:request:start' }).and.to.have.property('detail').that.deep.equals({
-        cid: testCID.toString(),
+        cid: testCID,
         path: 'index.html'
       })
       expect(onProgressEvents[1]).to.include({ type: 'verified-fetch:request:end' }).and.to.have.property('detail').that.deep.equals({
-        cid: testCID.toString(),
+        cid: testCID,
         path: 'index.html'
       })
       expect(onProgressEvents[3]).to.include({ type: 'verified-fetch:request:end' }).and.to.have.property('detail').that.deep.equals({
-        cid: 'Qmc3zqKcwzbbvw3MQm3hXdg8BQoFjGdZiGdAfXAyAGGdLi',
+        cid: CID.parse('Qmc3zqKcwzbbvw3MQm3hXdg8BQoFjGdZiGdAfXAyAGGdLi'),
         path: ''
       })
       expect(onProgressEvents[4]).to.include({ type: 'verified-fetch:request:progress:chunk' }).and.to.have.property('detail').that.is.undefined()
@@ -294,12 +294,12 @@ describe('@helia/verifed-fetch', () => {
       const onProgressEvents = onProgress.getCalls().map(call => call.args[0])
       expect(onProgressEvents[0]).to.have.property('type', 'verified-fetch:request:start')
       expect(onProgressEvents[0]).to.have.property('detail').that.deep.equals({
-        cid: cid.toString(),
+        cid,
         path: ''
       })
       expect(onProgressEvents[1]).to.have.property('type', 'verified-fetch:request:end')
       expect(onProgressEvents[1]).to.have.property('detail').that.deep.equals({
-        cid: cid.toString(),
+        cid,
         path: ''
       })
       expect(resp).to.be.ok()
@@ -330,12 +330,12 @@ describe('@helia/verifed-fetch', () => {
       const onProgressEvents = onProgress.getCalls().map(call => call.args[0])
       expect(onProgressEvents[0]).to.have.property('type', 'verified-fetch:request:start')
       expect(onProgressEvents[0]).to.have.property('detail').that.deep.equals({
-        cid: cid.toString(),
+        cid,
         path: ''
       })
       expect(onProgressEvents[1]).to.have.property('type', 'verified-fetch:request:end')
       expect(onProgressEvents[1]).to.have.property('detail').that.deep.equals({
-        cid: cid.toString(),
+        cid,
         path: ''
       })
       const data = await resp.json()
@@ -362,12 +362,12 @@ describe('@helia/verifed-fetch', () => {
       const onProgressEvents = onProgress.getCalls().map(call => call.args[0])
       expect(onProgressEvents[0]).to.have.property('type', 'verified-fetch:request:start')
       expect(onProgressEvents[0]).to.have.property('detail').that.deep.equals({
-        cid: cid.toString(),
+        cid,
         path: ''
       })
       expect(onProgressEvents[1]).to.have.property('type', 'verified-fetch:request:end')
       expect(onProgressEvents[1]).to.have.property('detail').that.deep.equals({
-        cid: cid.toString(),
+        cid,
         path: ''
       })
       expect(resp).to.be.ok()


### PR DESCRIPTION
Do not stringify CIDs before using them as events.

The user can do this if they want, parsing them back to objects is not free.

## Notes & open questions

I'm not sure why these were strings in the first place.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
