### PR TITLE
fix: allow contentTypeParser with Helia instance

### DIFF
--- a/packages/interop/src/verified-fetch-json.spec.ts
+++ b/packages/interop/src/verified-fetch-json.spec.ts
@@ -21,8 +21,7 @@ describe('@helia/verified-fetch - json', () => {
       await loadFixtureDataCar(controller, 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr-tokens.uniswap.org-2024-01-18.car')
       verifiedFetch = await createVerifiedFetch({
         gateways: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`],
-        // Temporarily disabling delegated routers in browser until CORS issue is fixed. see https://github.com/ipshipyard/waterworks-community/issues/4
-        routers: process.env.RUNNER_ENV === 'node' ? [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`] : []
+        routers: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`]
       })
     })
 

--- a/packages/interop/src/verified-fetch-unixfs-dir.spec.ts
+++ b/packages/interop/src/verified-fetch-unixfs-dir.spec.ts
@@ -17,8 +17,7 @@ describe('@helia/verified-fetch - unixfs directory', () => {
 
     verifiedFetch = await createVerifiedFetch({
       gateways: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`],
-      // Temporarily disabling delegated routers in browser until CORS issue is fixed. see https://github.com/ipshipyard/waterworks-community/issues/4
-      routers: process.env.RUNNER_ENV === 'node' ? [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`] : []
+      routers: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`]
     })
   })
 
@@ -61,8 +60,8 @@ describe('@helia/verified-fetch - unixfs directory', () => {
       await verifiedFetch.stop()
       verifiedFetch = await createVerifiedFetch({
         gateways: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`],
-        // Temporarily disabling delegated routers in browser until CORS issue is fixed. see https://github.com/ipshipyard/waterworks-community/issues/4
-        routers: process.env.RUNNER_ENV === 'node' ? [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`] : [],
+        routers: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`]
+      }, {
         contentTypeParser: (bytes) => {
           return filetypemime(bytes)?.[0]
         }

--- a/packages/interop/src/verified-fetch-websites.spec.ts
+++ b/packages/interop/src/verified-fetch-websites.spec.ts
@@ -17,8 +17,7 @@ describe('@helia/verified-fetch - websites', () => {
       await loadFixtureDataCar(controller, 'QmbxpRxwKXxnJQjnPqm1kzDJSJ8YgkLxH23mcZURwPHjGv-helia-identify-website.car')
       verifiedFetch = await createVerifiedFetch({
         gateways: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`],
-        // Temporarily disabling delegated routers in browser until CORS issue is fixed. see https://github.com/ipshipyard/waterworks-community/issues/4
-        routers: process.env.RUNNER_ENV === 'node' ? [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`] : []
+        routers: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`]
       })
     })
 
@@ -65,8 +64,7 @@ describe('@helia/verified-fetch - websites', () => {
       await loadFixtureDataCar(controller, 'QmeiDMLtPUS3RT2xAcUwsNyZz169wPke2q7im9vZpVLSYw-fake-blog.libp2p.io.car')
       verifiedFetch = await createVerifiedFetch({
         gateways: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`],
-        // Temporarily disabling delegated routers in browser until CORS issue is fixed. see https://github.com/ipshipyard/waterworks-community/issues/4
-        routers: process.env.RUNNER_ENV === 'node' ? [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`] : []
+        routers: [`http://${controller.api.gatewayHost}:${controller.api.gatewayPort}`]
       })
     })
 

--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -128,7 +128,8 @@
  *
  * const fetch = await createVerifiedFetch({
  *  gateways: ['https://trustless-gateway.link'],
- *  routers: ['http://delegated-ipfs.dev'],
+ *  routers: ['http://delegated-ipfs.dev']
+ * }, {
  *  contentTypeParser: async (bytes) => {
  *    // call to some magic-byte recognition library like magic-bytes, file-type, or your own custom byte recognition
  *    const result = await fileTypeFromBuffer(bytes)
@@ -285,10 +286,12 @@ export interface VerifiedFetch {
  * Instead of passing a Helia instance, you can pass a list of gateways and
  * routers, and a HeliaHTTP instance will be created for you.
  */
-export interface CreateVerifiedFetchOptions {
+export interface CreateVerifiedFetchInit {
   gateways: string[]
   routers?: string[]
+}
 
+export interface CreateVerifiedFetchOptions {
   /**
    * A function to handle parsing content type from bytes. The function you
    * provide will be passed the first set of bytes we receive from the network,
@@ -338,11 +341,10 @@ export interface VerifiedFetchInit extends RequestInit, ProgressOptions<BubbledP
 /**
  * Create and return a Helia node
  */
-export async function createVerifiedFetch (init?: Helia | CreateVerifiedFetchOptions): Promise<VerifiedFetch> {
-  let contentTypeParser: ContentTypeParser | undefined
+export async function createVerifiedFetch (init?: Helia | CreateVerifiedFetchInit, options?: CreateVerifiedFetchOptions): Promise<VerifiedFetch> {
+  const contentTypeParser: ContentTypeParser | undefined = options?.contentTypeParser
 
   if (!isHelia(init)) {
-    contentTypeParser = init?.contentTypeParser
     init = await createHeliaHTTP({
       blockBrokers: [
         trustlessGateway({


### PR DESCRIPTION
fixes an issue where createVerifiedFetch would not allow both:

- a custom Helia instance
- a custom contentTypeParser
