### PR TITLE
fix: support reading identity cids

### DIFF
--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -154,7 +154,7 @@
     "@helia/unixfs": "^3.0.0",
     "@ipld/dag-pb": "^4.0.8",
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10",
+    "blockstore-core": "^4.4.0",
     "ipfs-unixfs-importer": "^15.2.4",
     "it-to-buffer": "^4.0.5"
   }

--- a/packages/dag-cbor/package.json
+++ b/packages/dag-cbor/package.json
@@ -149,6 +149,6 @@
   },
   "devDependencies": {
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10"
+    "blockstore-core": "^4.4.0"
   }
 }

--- a/packages/dag-json/package.json
+++ b/packages/dag-json/package.json
@@ -148,6 +148,6 @@
   },
   "devDependencies": {
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10"
+    "blockstore-core": "^4.4.0"
   }
 }

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -78,7 +78,7 @@
     "@libp2p/webrtc": "^4.0.17",
     "@libp2p/websockets": "^8.0.13",
     "@libp2p/webtransport": "^4.0.17",
-    "blockstore-core": "^4.3.10",
+    "blockstore-core": "^4.4.0",
     "datastore-core": "^9.2.7",
     "interface-blockstore": "^5.2.9",
     "interface-datastore": "^8.2.10",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -57,7 +57,7 @@
     "@helia/interface": "^4.0.0",
     "@helia/routers": "^1.0.0",
     "@helia/utils": "^0.0.1",
-    "blockstore-core": "^4.3.10",
+    "blockstore-core": "^4.4.0",
     "datastore-core": "^9.2.7"
   },
   "devDependencies": {

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -147,6 +147,6 @@
   },
   "devDependencies": {
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10"
+    "blockstore-core": "^4.4.0"
   }
 }

--- a/packages/mfs/package.json
+++ b/packages/mfs/package.json
@@ -152,7 +152,7 @@
   "devDependencies": {
     "@ipld/dag-pb": "^4.0.8",
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10",
+    "blockstore-core": "^4.4.0",
     "datastore-core": "^9.2.7",
     "delay": "^6.0.0",
     "it-all": "^3.0.4",

--- a/packages/strings/package.json
+++ b/packages/strings/package.json
@@ -150,6 +150,6 @@
   },
   "devDependencies": {
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10"
+    "blockstore-core": "^4.4.0"
   }
 }

--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -180,7 +180,7 @@
   },
   "devDependencies": {
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10",
+    "blockstore-core": "^4.4.0",
     "delay": "^6.0.0",
     "iso-url": "^1.2.1",
     "it-all": "^3.0.4",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -62,6 +62,7 @@
     "@libp2p/peer-collections": "^5.1.5",
     "@libp2p/utils": "^5.2.3",
     "any-signal": "^4.1.1",
+    "blockstore-core": "^4.4.0",
     "cborg": "^4.0.8",
     "interface-blockstore": "^5.2.9",
     "interface-datastore": "^8.2.10",
@@ -78,7 +79,6 @@
   "devDependencies": {
     "@types/sinon": "^17.0.3",
     "aegir": "^42.2.2",
-    "blockstore-core": "^4.3.10",
     "datastore-core": "^9.2.7",
     "delay": "^6.0.0",
     "it-all": "^3.0.4",

--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -1,5 +1,7 @@
 import { CodeError, start, stop } from '@libp2p/interface'
 import { anySignal } from 'any-signal'
+import { IdentityBlockstore } from 'blockstore-core/identity'
+import { TieredBlockstore } from 'blockstore-core/tiered'
 import filter from 'it-filter'
 import forEach from 'it-foreach'
 import { CustomProgressEvent, type ProgressOptions } from 'progress-events'
@@ -47,7 +49,10 @@ export class NetworkedStorage implements Blocks, Startable {
    */
   constructor (components: NetworkedStorageComponents) {
     this.log = components.logger.forComponent('helia:networked-storage')
-    this.child = components.blockstore
+    this.child = new TieredBlockstore([
+      new IdentityBlockstore(),
+      components.blockstore
+    ])
     this.blockRetrievers = (components.blockBrokers ?? []).filter(isBlockRetriever)
     this.blockAnnouncers = (components.blockBrokers ?? []).filter(isBlockAnnouncer)
     this.hashers = components.hashers ?? {}

--- a/packages/utils/test/utils/networked-storage.spec.ts
+++ b/packages/utils/test/utils/networked-storage.spec.ts
@@ -6,15 +6,18 @@ import { MemoryBlockstore } from 'blockstore-core'
 import delay from 'delay'
 import all from 'it-all'
 import drain from 'it-drain'
+import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
+import { identity } from 'multiformats/hashes/identity'
 import Sinon from 'sinon'
 import { type StubbedInstance, stubInterface } from 'sinon-ts'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { defaultHashers } from '../../src/utils/default-hashers.js'
 import { NetworkedStorage } from '../../src/utils/networked-storage.js'
 import { createBlock } from '../fixtures/create-block.js'
 import type { BlockAnnouncer, BlockRetriever } from '@helia/interface/blocks'
 import type { Blockstore } from 'interface-blockstore'
-import type { CID } from 'multiformats/cid'
 
 describe('networked-storage', () => {
   let storage: NetworkedStorage
@@ -184,5 +187,13 @@ describe('networked-storage', () => {
     for (let i = 0; i < count; i++) {
       expect(await blockstore.has(blocks[i].cid)).to.be.true()
     }
+  })
+
+  it('supports identity CIDs', async () => {
+    const data = uint8ArrayFromString('hello world')
+    const cid = CID.createV1(identity.code, identity.digest(data))
+
+    const block = await storage.get(cid)
+    expect(uint8ArrayToString(block)).to.equal('hello world')
   })
 })


### PR DESCRIPTION
Use a tiered blockstore that combines an identity blockstore with the configured blockstore to support reading identity CIDs.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
