### PR TITLE
feat: add explicit support for subdomain gateways

### DIFF
--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -20,6 +20,11 @@ ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
     this.log = components.logger.forComponent('helia:trustless-gateway-block-broker')
     this.gateways = (init.gateways ?? DEFAULT_TRUSTLESS_GATEWAYS)
       .map((gw) => {
+        if(typeof gw === 'string' || gw instanceof URL) {
+          // backward compatibility defaults to path gateway
+          return new TrustlessGateway(gw, false)
+        }
+
         return new TrustlessGateway(gw.url, gw.isSubdomain)
       })
   }

--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -19,8 +19,8 @@ ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
   constructor (components: TrustlessGatewayComponents, init: TrustlessGatewayBlockBrokerInit = {}) {
     this.log = components.logger.forComponent('helia:trustless-gateway-block-broker')
     this.gateways = (init.gateways ?? DEFAULT_TRUSTLESS_GATEWAYS)
-      .map((gatewayOrUrl) => {
-        return new TrustlessGateway(gatewayOrUrl)
+      .map((gw) => {
+        return new TrustlessGateway(gw.url, gw.isSubdomain)
       })
   }
 

--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -22,10 +22,10 @@ ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
       .map((gw) => {
         if (typeof gw === 'string' || gw instanceof URL) {
           // backward compatibility defaults to path gateway
-          return new TrustlessGateway(gw, false)
+          return new TrustlessGateway(gw, { subdomainResolution: false })
         }
 
-        return new TrustlessGateway(gw.url, gw.supportsSubdomains)
+        return new TrustlessGateway(gw.url, { subdomainResolution: gw.subdomainResolution })
       })
   }
 

--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -20,12 +20,12 @@ ProgressOptions<TrustlessGatewayGetBlockProgressEvents>
     this.log = components.logger.forComponent('helia:trustless-gateway-block-broker')
     this.gateways = (init.gateways ?? DEFAULT_TRUSTLESS_GATEWAYS)
       .map((gw) => {
-        if(typeof gw === 'string' || gw instanceof URL) {
+        if (typeof gw === 'string' || gw instanceof URL) {
           // backward compatibility defaults to path gateway
           return new TrustlessGateway(gw, false)
         }
 
-        return new TrustlessGateway(gw.url, gw.isSubdomain)
+        return new TrustlessGateway(gw.url, gw.supportsSubdomains)
       })
   }
 

--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -3,22 +3,27 @@ import type { BlockRetriever } from '@helia/interface/src/blocks.js'
 import type { ComponentLogger } from '@libp2p/interface'
 import type { ProgressEvent } from 'progress-events'
 
-export const DEFAULT_TRUSTLESS_GATEWAYS = [
-  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
-  'https://trustless-gateway.link',
+export const DEFAULT_TRUSTLESS_GATEWAYS: TrustlessGatewayUrl[] = [
+  // 2024-02-20: IPNS and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
+  { url: 'https://trustless-gateway.link', isSubdomain: false },
 
-  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
-  'https://cloudflare-ipfs.com',
+  // 2024-02-20: IPNS and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
+  { url: 'https://cloudflare-ipfs.com', isSubdomain: false },
 
-  // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs-public-gateway-checker.on.fleek.co/
-  'https://4everland.io'
+  // 2024-02-20: IPNS, Origin, and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
+  { url: 'https://4everland.io', isSubdomain: true },
 ]
+
+interface TrustlessGatewayUrl {
+  url: string | URL
+  isSubdomain: boolean
+}
 
 export type TrustlessGatewayGetBlockProgressEvents =
   ProgressEvent<'trustless-gateway:get-block:fetch', URL>
 
 export interface TrustlessGatewayBlockBrokerInit {
-  gateways?: Array<string | URL>
+  gateways?: Array<TrustlessGatewayUrl>
 }
 
 export interface TrustlessGatewayComponents {

--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -5,18 +5,18 @@ import type { ProgressEvent } from 'progress-events'
 
 export const DEFAULT_TRUSTLESS_GATEWAYS: TrustlessGatewayUrl[] = [
   // 2024-02-20: IPNS and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
-  { url: 'https://trustless-gateway.link', isSubdomain: false },
+  { url: 'https://trustless-gateway.link', supportsSubdomains: false },
 
   // 2024-02-20: IPNS and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
-  { url: 'https://cloudflare-ipfs.com', isSubdomain: false },
+  { url: 'https://cloudflare-ipfs.com', supportsSubdomains: false },
 
   // 2024-02-20: IPNS, Origin, and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
-  { url: 'https://4everland.io', isSubdomain: true },
+  { url: 'https://4everland.io', supportsSubdomains: true }
 ]
 
 interface TrustlessGatewayUrl {
   url: string | URL
-  isSubdomain: boolean
+  supportsSubdomains: boolean
 }
 
 export type TrustlessGatewayGetBlockProgressEvents =

--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -5,18 +5,18 @@ import type { ProgressEvent } from 'progress-events'
 
 export const DEFAULT_TRUSTLESS_GATEWAYS: TrustlessGatewayUrl[] = [
   // 2024-02-20: IPNS and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
-  { url: 'https://trustless-gateway.link', supportsSubdomains: false },
+  { url: 'https://trustless-gateway.link', subdomainResolution: false },
 
   // 2024-02-20: IPNS and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
-  { url: 'https://cloudflare-ipfs.com', supportsSubdomains: false },
+  { url: 'https://cloudflare-ipfs.com', subdomainResolution: false },
 
   // 2024-02-20: IPNS, Origin, and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
-  { url: 'https://4everland.io', supportsSubdomains: true }
+  { url: 'https://4everland.io', subdomainResolution: true }
 ]
 
 interface TrustlessGatewayUrl {
   url: string | URL
-  supportsSubdomains: boolean
+  subdomainResolution: boolean
 }
 
 export type TrustlessGatewayGetBlockProgressEvents =

--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -23,7 +23,7 @@ export type TrustlessGatewayGetBlockProgressEvents =
   ProgressEvent<'trustless-gateway:get-block:fetch', URL>
 
 export interface TrustlessGatewayBlockBrokerInit {
-  gateways?: Array<TrustlessGatewayUrl>
+  gateways?: Array<string | URL | TrustlessGatewayUrl>
 }
 
 export interface TrustlessGatewayComponents {

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -51,7 +51,7 @@ export class TrustlessGateway {
    */
   #successes = 0
 
-  constructor (url: URL | string, { subdomainResolution }: TrustlessGatewayOpts = { subdomainResolution: false } ) {
+  constructor (url: URL | string, { subdomainResolution }: TrustlessGatewayOpts = { subdomainResolution: false }) {
     this.url = url instanceof URL ? url : new URL(url)
     this.subdomainResolution = subdomainResolution
   }

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -1,6 +1,14 @@
 import { base32 } from 'multiformats/bases/base32'
 import type { CID } from 'multiformats/cid'
 
+interface TrustlessGatewayOpts {
+
+  /**
+   * Determins whether the gateway supports subdomain resolution
+   */
+  subdomainResolution: boolean
+}
+
 /**
  * A `TrustlessGateway` keeps track of the number of attempts, errors, and
  * successes for a given gateway url so that we can prioritize gateways that
@@ -13,7 +21,7 @@ export class TrustlessGateway {
   /**
    * Whether this gateway is a subdomain resolution style gateway
    */
-  public supportsSubdomains: boolean
+  public subdomainResolution: boolean
 
   /**
    * The number of times this gateway has been attempted to be used to fetch a
@@ -43,9 +51,9 @@ export class TrustlessGateway {
    */
   #successes = 0
 
-  constructor (url: URL | string, supportsSubdomains: boolean = false) {
+  constructor (url: URL | string, { subdomainResolution }: TrustlessGatewayOpts = { subdomainResolution: false } ) {
     this.url = url instanceof URL ? url : new URL(url)
-    this.supportsSubdomains = supportsSubdomains
+    this.subdomainResolution = subdomainResolution
   }
 
   /**
@@ -97,7 +105,7 @@ export class TrustlessGateway {
   getGwUrl (cid: CID): URL {
     const gwUrl = new URL(this.url)
 
-    if (this.supportsSubdomains) {
+    if (this.subdomainResolution) {
       gwUrl.hostname = `${cid.toString(base32)}.ipfs.${gwUrl.hostname}`
     } else {
       gwUrl.pathname = `/ipfs/${cid.toString()}`

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -37,7 +37,7 @@ describe('trustless-gateway-block-broker', () => {
 
     gateways = [
       stubConstructor(TrustlessGateway, 'http://localhost:8080'),
-      stubConstructor(TrustlessGateway, 'http://localhost:8081'),
+      stubConstructor(TrustlessGateway, 'http://localhost:8081', true),
       stubConstructor(TrustlessGateway, 'http://localhost:8082'),
       stubConstructor(TrustlessGateway, 'http://localhost:8083')
     ]
@@ -149,5 +149,18 @@ describe('trustless-gateway-block-broker', () => {
     expect(gateways[0].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.false()
     expect(gateways[1].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.false()
     expect(gateways[2].getRawBlock.calledWith(cid1, Sinon.match.any)).to.be.false()
+  })
+
+  it('constructs the gateway url for the cid for both path and subdomain gateways', async () => {
+    const pathGw = new TrustlessGateway('http://localhost:8080')
+    const subdomainGw = new TrustlessGateway('https://dweb.link', true)
+
+    expect(pathGw.getGwUrl(blocks[0].cid).hostname).to.equal(`localhost`)
+    expect(pathGw.getGwUrl(blocks[0].cid).toString()).to.equal(`http://localhost:8080/ipfs/bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq`)
+    expect(pathGw.getGwUrl(blocks[1].cid).toString()).to.equal(`http://localhost:8080/ipfs/${blocks[1].cid.toString()}`)
+
+    expect(subdomainGw.getGwUrl(blocks[0].cid).hostname).to.equal(`bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq.ipfs.dweb.link`)
+    expect(subdomainGw.getGwUrl(blocks[0].cid).toString()).to.equal(`https://bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq.ipfs.dweb.link/`)
+    expect(subdomainGw.getGwUrl(blocks[1].cid).toString()).to.equal(`https://${blocks[1].cid.toString()}.ipfs.dweb.link/`)
   })
 })

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -37,7 +37,7 @@ describe('trustless-gateway-block-broker', () => {
 
     gateways = [
       stubConstructor(TrustlessGateway, 'http://localhost:8080'),
-      stubConstructor(TrustlessGateway, 'http://localhost:8081', true),
+      stubConstructor(TrustlessGateway, 'http://localhost:8081', { subdomainResolution: true }),
       stubConstructor(TrustlessGateway, 'http://localhost:8082'),
       stubConstructor(TrustlessGateway, 'http://localhost:8083')
     ]
@@ -153,7 +153,7 @@ describe('trustless-gateway-block-broker', () => {
 
   it('constructs the gateway url for the cid for both path and subdomain gateways', async () => {
     const pathGw = new TrustlessGateway('http://localhost:8080')
-    const subdomainGw = new TrustlessGateway('https://dweb.link', true)
+    const subdomainGw = new TrustlessGateway('https://dweb.link', { subdomainResolution: true })
 
     expect(pathGw.getGwUrl(blocks[0].cid).hostname).to.equal('localhost')
     expect(pathGw.getGwUrl(blocks[0].cid).toString()).to.equal('http://localhost:8080/ipfs/bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq')

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -155,12 +155,12 @@ describe('trustless-gateway-block-broker', () => {
     const pathGw = new TrustlessGateway('http://localhost:8080')
     const subdomainGw = new TrustlessGateway('https://dweb.link', true)
 
-    expect(pathGw.getGwUrl(blocks[0].cid).hostname).to.equal(`localhost`)
-    expect(pathGw.getGwUrl(blocks[0].cid).toString()).to.equal(`http://localhost:8080/ipfs/bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq`)
+    expect(pathGw.getGwUrl(blocks[0].cid).hostname).to.equal('localhost')
+    expect(pathGw.getGwUrl(blocks[0].cid).toString()).to.equal('http://localhost:8080/ipfs/bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq')
     expect(pathGw.getGwUrl(blocks[1].cid).toString()).to.equal(`http://localhost:8080/ipfs/${blocks[1].cid.toString()}`)
 
-    expect(subdomainGw.getGwUrl(blocks[0].cid).hostname).to.equal(`bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq.ipfs.dweb.link`)
-    expect(subdomainGw.getGwUrl(blocks[0].cid).toString()).to.equal(`https://bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq.ipfs.dweb.link/`)
+    expect(subdomainGw.getGwUrl(blocks[0].cid).hostname).to.equal('bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq.ipfs.dweb.link')
+    expect(subdomainGw.getGwUrl(blocks[0].cid).toString()).to.equal('https://bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq.ipfs.dweb.link/')
     expect(subdomainGw.getGwUrl(blocks[1].cid).toString()).to.equal(`https://${blocks[1].cid.toString()}.ipfs.dweb.link/`)
   })
 })


### PR DESCRIPTION
## Title

The main goal of this PR is to explicitly support subdomain gateways to avoid getting redirects like we currently do from [`https://4everland.io`](https://4everland.io/ipfs/bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m) which no longer supports path gateways.

Since the `TrustlessGatewayBlockBrokerInit` type has changed this is a breaking change

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
