### PR TITLE
feat: stream car file bytes from @helia/car

### DIFF
--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -145,7 +145,6 @@
     "interface-blockstore": "^5.2.9",
     "it-drain": "^3.0.5",
     "it-map": "^3.0.5",
-    "it-merge": "^3.0.3",
     "multiformats": "^13.0.1",
     "p-defer": "^4.0.0",
     "p-queue": "^8.0.1",
@@ -157,7 +156,6 @@
     "aegir": "^42.2.2",
     "blockstore-core": "^4.4.0",
     "ipfs-unixfs-importer": "^15.2.4",
-    "it-to-buffer": "^4.0.5",
-    "sinon": "^17.0.1"
+    "it-to-buffer": "^4.0.5"
   }
 }

--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -145,6 +145,7 @@
     "interface-blockstore": "^5.2.9",
     "it-drain": "^3.0.5",
     "it-map": "^3.0.5",
+    "it-merge": "^3.0.3",
     "multiformats": "^13.0.1",
     "p-defer": "^4.0.0",
     "p-queue": "^8.0.1",
@@ -156,6 +157,7 @@
     "aegir": "^42.2.2",
     "blockstore-core": "^4.4.0",
     "ipfs-unixfs-importer": "^15.2.4",
-    "it-to-buffer": "^4.0.5"
+    "it-to-buffer": "^4.0.5",
+    "sinon": "^17.0.1"
   }
 }

--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -208,6 +208,8 @@ class DefaultCar implements Car {
     const { writer, out } = CarWriter.create(root)
     let exportError: Error | undefined
 
+    // has to be done async so we write to `writer` and read from `out` at the
+    // same time
     this.export(root, writer, options)
       .catch((err) => {
         exportError = err

--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -138,12 +138,9 @@ export interface Car {
    * @example
    *
    * ```typescript
-   * import fs from 'node:fs'
-   * import { Readable } from 'stream'
    * import { createHelia } from 'helia'
    * import { car } from '@helia/car
    * import { CID } from 'multiformats/cid'
-   * import pEvent from 'p-event'
    *
    * const helia = await createHelia()
    * const cid = CID.parse('QmFoo...')

--- a/packages/car/test/fixtures/dag-walkers.ts
+++ b/packages/car/test/fixtures/dag-walkers.ts
@@ -1,0 +1,27 @@
+import * as dagPb from '@ipld/dag-pb'
+import * as raw from 'multiformats/codecs/raw'
+import type { DAGWalker } from '@helia/interface'
+
+/**
+ * Dag walker for dag-pb CIDs
+ */
+const dagPbWalker: DAGWalker = {
+  codec: dagPb.code,
+  * walk (block) {
+    const node = dagPb.decode(block)
+
+    yield * node.Links.map(l => l.Hash)
+  }
+}
+
+const rawWalker: DAGWalker = {
+  codec: raw.code,
+  * walk () {
+    // no embedded CIDs in a raw block
+  }
+}
+
+export const dagWalkers = {
+  [dagPb.code]: dagPbWalker,
+  [raw.code]: rawWalker
+}

--- a/packages/car/test/index.spec.ts
+++ b/packages/car/test/index.spec.ts
@@ -2,49 +2,23 @@
 
 import { type UnixFS, unixfs } from '@helia/unixfs'
 import { CarReader } from '@ipld/car'
-import * as dagPb from '@ipld/dag-pb'
 import { expect } from 'aegir/chai'
 import { MemoryBlockstore } from 'blockstore-core'
 import { fixedSize } from 'ipfs-unixfs-importer/chunker'
 import toBuffer from 'it-to-buffer'
-import * as raw from 'multiformats/codecs/raw'
 import { car, type Car } from '../src/index.js'
+import { dagWalkers } from './fixtures/dag-walkers.js'
 import { largeFile, smallFile } from './fixtures/files.js'
 import { memoryCarWriter } from './fixtures/memory-car.js'
-import type { DAGWalker } from '@helia/interface'
 import type { Blockstore } from 'interface-blockstore'
-
-/**
- * Dag walker for dag-pb CIDs
- */
-const dagPbWalker: DAGWalker = {
-  codec: dagPb.code,
-  * walk (block) {
-    const node = dagPb.decode(block)
-
-    yield * node.Links.map(l => l.Hash)
-  }
-}
-
-const rawWalker: DAGWalker = {
-  codec: raw.code,
-  * walk () {
-    // no embedded CIDs in a raw block
-  }
-}
 
 describe('import/export car file', () => {
   let blockstore: Blockstore
   let c: Car
   let u: UnixFS
-  let dagWalkers: Record<number, DAGWalker>
 
   beforeEach(async () => {
     blockstore = new MemoryBlockstore()
-    dagWalkers = {
-      [dagPb.code]: dagPbWalker,
-      [raw.code]: rawWalker
-    }
 
     c = car({ blockstore, dagWalkers })
     u = unixfs({ blockstore })

--- a/packages/car/test/index.spec.ts
+++ b/packages/car/test/index.spec.ts
@@ -33,7 +33,7 @@ const rawWalker: DAGWalker = {
   }
 }
 
-describe('import', () => {
+describe('import/export car file', () => {
   let blockstore: Blockstore
   let c: Car
   let u: UnixFS

--- a/packages/car/test/stream.spec.ts
+++ b/packages/car/test/stream.spec.ts
@@ -1,48 +1,22 @@
 /* eslint-env mocha */
 
 import { type UnixFS, unixfs } from '@helia/unixfs'
-import * as dagPb from '@ipld/dag-pb'
 import { expect } from 'aegir/chai'
 import { MemoryBlockstore } from 'blockstore-core'
 import toBuffer from 'it-to-buffer'
-import * as raw from 'multiformats/codecs/raw'
 import { car, type Car } from '../src/index.js'
+import { dagWalkers } from './fixtures/dag-walkers.js'
 import { smallFile } from './fixtures/files.js'
 import { memoryCarWriter } from './fixtures/memory-car.js'
-import type { DAGWalker } from '@helia/interface'
 import type { Blockstore } from 'interface-blockstore'
-
-/**
- * Dag walker for dag-pb CIDs
- */
-const dagPbWalker: DAGWalker = {
-  codec: dagPb.code,
-  * walk (block) {
-    const node = dagPb.decode(block)
-
-    yield * node.Links.map(l => l.Hash)
-  }
-}
-
-const rawWalker: DAGWalker = {
-  codec: raw.code,
-  * walk () {
-    // no embedded CIDs in a raw block
-  }
-}
 
 describe('stream car file', () => {
   let blockstore: Blockstore
   let c: Car
   let u: UnixFS
-  let dagWalkers: Record<number, DAGWalker>
 
   beforeEach(async () => {
     blockstore = new MemoryBlockstore()
-    dagWalkers = {
-      [dagPb.code]: dagPbWalker,
-      [raw.code]: rawWalker
-    }
 
     c = car({ blockstore, dagWalkers })
     u = unixfs({ blockstore })

--- a/packages/car/test/stream.spec.ts
+++ b/packages/car/test/stream.spec.ts
@@ -4,9 +4,10 @@ import { type UnixFS, unixfs } from '@helia/unixfs'
 import { expect } from 'aegir/chai'
 import { MemoryBlockstore } from 'blockstore-core'
 import toBuffer from 'it-to-buffer'
+import Sinon from 'sinon'
 import { car, type Car } from '../src/index.js'
 import { dagWalkers } from './fixtures/dag-walkers.js'
-import { smallFile } from './fixtures/files.js'
+import { largeFile, smallFile } from './fixtures/files.js'
 import { memoryCarWriter } from './fixtures/memory-car.js'
 import type { Blockstore } from 'interface-blockstore'
 
@@ -33,5 +34,26 @@ describe('stream car file', () => {
     const streamed = await toBuffer(c.stream(cid))
 
     expect(bytes).to.equalBytes(streamed)
+  })
+
+  it('errors when streaming car file', async () => {
+    const exportSpy = Sinon.spy(c, 'export')
+    const cid = await u.addBytes(largeFile)
+    const iter = c.stream(cid)
+
+    // start stream moving so we can get at the CAR writer
+    await iter.next()
+
+    expect(exportSpy.called).to.be.true()
+
+    // make the next put error
+    const writer = exportSpy.getCall(0).args[1]
+    writer.put = async () => {
+      throw new Error('Urk!')
+    }
+
+    // iterator should throw error
+    await expect(toBuffer(iter)).to.eventually.be.rejected
+      .with.property('message', 'Urk!')
   })
 })

--- a/packages/car/test/stream.spec.ts
+++ b/packages/car/test/stream.spec.ts
@@ -4,10 +4,9 @@ import { type UnixFS, unixfs } from '@helia/unixfs'
 import { expect } from 'aegir/chai'
 import { MemoryBlockstore } from 'blockstore-core'
 import toBuffer from 'it-to-buffer'
-import Sinon from 'sinon'
 import { car, type Car } from '../src/index.js'
 import { dagWalkers } from './fixtures/dag-walkers.js'
-import { largeFile, smallFile } from './fixtures/files.js'
+import { smallFile } from './fixtures/files.js'
 import { memoryCarWriter } from './fixtures/memory-car.js'
 import type { Blockstore } from 'interface-blockstore'
 
@@ -34,22 +33,5 @@ describe('stream car file', () => {
     const streamed = await toBuffer(c.stream(cid))
 
     expect(bytes).to.equalBytes(streamed)
-  })
-
-  it('errors when writing during streaming car file', async () => {
-    const exportSpy = Sinon.spy(c, 'export')
-    const cid = await u.addBytes(largeFile)
-    const iter = c.stream(cid)
-
-    // start stream moving so we can get at the CAR writer
-    await iter.next()
-
-    expect(exportSpy.called).to.be.true()
-
-    // make the next write error
-    const writer = exportSpy.getCall(0).args[1]
-    writer.put = async () => {
-      throw new Error('Urk!')
-    }
   })
 })

--- a/packages/car/test/stream.spec.ts
+++ b/packages/car/test/stream.spec.ts
@@ -51,4 +51,5 @@ describe('stream car file', () => {
     writer.put = async () => {
       throw new Error('Urk!')
     }
+  })
 })

--- a/packages/car/test/stream.spec.ts
+++ b/packages/car/test/stream.spec.ts
@@ -36,7 +36,7 @@ describe('stream car file', () => {
     expect(bytes).to.equalBytes(streamed)
   })
 
-  it('errors when streaming car file', async () => {
+  it('errors when writing during streaming car file', async () => {
     const exportSpy = Sinon.spy(c, 'export')
     const cid = await u.addBytes(largeFile)
     const iter = c.stream(cid)
@@ -46,14 +46,9 @@ describe('stream car file', () => {
 
     expect(exportSpy.called).to.be.true()
 
-    // make the next put error
+    // make the next write error
     const writer = exportSpy.getCall(0).args[1]
     writer.put = async () => {
       throw new Error('Urk!')
     }
-
-    // iterator should throw error
-    await expect(toBuffer(iter)).to.eventually.be.rejected
-      .with.property('message', 'Urk!')
-  })
 })

--- a/packages/car/test/stream.spec.ts
+++ b/packages/car/test/stream.spec.ts
@@ -1,0 +1,63 @@
+/* eslint-env mocha */
+
+import { type UnixFS, unixfs } from '@helia/unixfs'
+import * as dagPb from '@ipld/dag-pb'
+import { expect } from 'aegir/chai'
+import { MemoryBlockstore } from 'blockstore-core'
+import toBuffer from 'it-to-buffer'
+import * as raw from 'multiformats/codecs/raw'
+import { car, type Car } from '../src/index.js'
+import { smallFile } from './fixtures/files.js'
+import { memoryCarWriter } from './fixtures/memory-car.js'
+import type { DAGWalker } from '@helia/interface'
+import type { Blockstore } from 'interface-blockstore'
+
+/**
+ * Dag walker for dag-pb CIDs
+ */
+const dagPbWalker: DAGWalker = {
+  codec: dagPb.code,
+  * walk (block) {
+    const node = dagPb.decode(block)
+
+    yield * node.Links.map(l => l.Hash)
+  }
+}
+
+const rawWalker: DAGWalker = {
+  codec: raw.code,
+  * walk () {
+    // no embedded CIDs in a raw block
+  }
+}
+
+describe('stream car file', () => {
+  let blockstore: Blockstore
+  let c: Car
+  let u: UnixFS
+  let dagWalkers: Record<number, DAGWalker>
+
+  beforeEach(async () => {
+    blockstore = new MemoryBlockstore()
+    dagWalkers = {
+      [dagPb.code]: dagPbWalker,
+      [raw.code]: rawWalker
+    }
+
+    c = car({ blockstore, dagWalkers })
+    u = unixfs({ blockstore })
+  })
+
+  it('streams car file', async () => {
+    const cid = await u.addBytes(smallFile)
+
+    const writer = memoryCarWriter(cid)
+    await c.export(cid, writer)
+
+    const bytes = await writer.bytes()
+
+    const streamed = await toBuffer(c.stream(cid))
+
+    expect(bytes).to.equalBytes(streamed)
+  })
+})


### PR DESCRIPTION
To better support streaming CAR files with a less confusing API, add a method to `@helia/car` that takes root CIDs and returns an AsyncGenerator that yields CAR file bytes.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
