### PR TITLE
chore: fix multiblock car file test

### DIFF
--- a/packages/car/test/index.spec.ts
+++ b/packages/car/test/index.spec.ts
@@ -68,11 +68,7 @@ describe('import/export car file', () => {
     const otherBlockstore = new MemoryBlockstore()
     const otherUnixFS = unixfs({ blockstore: otherBlockstore })
     const otherCar = car({ blockstore: otherBlockstore, dagWalkers })
-    const cid = await otherUnixFS.addBytes(largeFile, {
-      chunker: fixedSize({
-        chunkSize: 1024
-      })
-    })
+    const cid = await otherUnixFS.addBytes(largeFile)
 
     const writer = memoryCarWriter(cid)
     await otherCar.export(cid, writer)


### PR DESCRIPTION
The test introduces an artificially small block size to ensure we have a CAR file with lots of blocks but it's quite slow and often causes CI failures.

The large file being added to the CAR file is already big enough to be formed of multiple blocks so splitting it into many smaller blocks doesn't give us much.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
