### PR TITLE
fix: only traverse relevant part of HAMT

### DIFF
--- a/packages/unixfs/src/commands/utils/resolve.ts
+++ b/packages/unixfs/src/commands/utils/resolve.ts
@@ -82,7 +82,7 @@ export async function resolve (cid: CID, path: string | undefined, blockstore: B
   log('resolved %s to %c', path, lastCid)
 
   return {
-    cid,
+    cid:lastCid,
     path,
     segments
   }

--- a/packages/unixfs/src/commands/utils/resolve.ts
+++ b/packages/unixfs/src/commands/utils/resolve.ts
@@ -5,10 +5,10 @@ import { DoesNotExistError, InvalidParametersError } from '../../errors.js'
 import { addLink } from './add-link.js'
 import { cidToDirectory } from './cid-to-directory.js'
 import { cidToPBLink } from './cid-to-pblink.js'
+import type { PBNode } from '@ipld/dag-pb/interface'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
-import type { PBNode } from '@ipld/dag-pb/dist/src/interface.js'
 
 const log = logger('helia:unixfs:components:utils:resolve')
 


### PR DESCRIPTION
## Description

Switched the UnixFS resolver code to do resolve only the relevant part of a HAMT rather than potentially enumerating all of it.

Fixes: ipfs-shipyard/helia-service-worker-gateway#18

## Notes & open questions

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
