### PR TITLE
fix: helia init should extend base helia init

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -86,8 +86,8 @@ export interface HeliaLibp2p<T extends Libp2p = Libp2p<DefaultLibp2pServices>> e
 /**
  * Create and return a Helia node
  */
-export async function createHelia <T extends Libp2p> (init: HeliaInit<T>): Promise<HeliaLibp2p<T>>
-export async function createHelia (init?: HeliaInit<Libp2p<DefaultLibp2pServices>>): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>>
+export async function createHelia <T extends Libp2p> (init: Partial<HeliaInit<T>>): Promise<HeliaLibp2p<T>>
+export async function createHelia (init?: Partial<HeliaInit<Libp2p<DefaultLibp2pServices>>>): Promise<HeliaLibp2p<Libp2p<DefaultLibp2pServices>>>
 export async function createHelia (init: Partial<HeliaInit> = {}): Promise<HeliaLibp2p> {
   const datastore = init.datastore ?? new MemoryDatastore()
   const blockstore = init.blockstore ?? new MemoryBlockstore()


### PR DESCRIPTION
Similar to `@helia/http`'s init interface extends that from `@helia/utils`, reduce the duplication in `helia`'s init interface.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
