### PR TITLE
fix: add retries for dnslink

### DIFF
--- a/packages/ipns/src/dnslink.ts
+++ b/packages/ipns/src/dnslink.ts
@@ -12,7 +12,7 @@ async function recursiveResolveDnslink (domain: string, depth: number, dns: DNS,
     throw new Error('recursion limit exceeded')
   }
 
-  log('query %s for TXT and CNAME records', domain)
+  log('query %s for TXT records', domain)
   const txtRecordsResponse = await dns.query(domain, {
     ...options,
     types: [
@@ -76,9 +76,8 @@ async function recursiveResolveDnslink (domain: string, depth: number, dns: DNS,
     }
   }
 
-  // no dnslink records found, try CNAMEs
+  // see if there is a CNAME delegation
   log('no DNSLink records found for %s, falling back to CNAME', domain)
-
   const cnameRecordsResponse = await dns.query(domain, {
     ...options,
     types: [

--- a/packages/ipns/test/resolve-dnslink.spec.ts
+++ b/packages/ipns/test/resolve-dnslink.spec.ts
@@ -70,6 +70,23 @@ describe('resolveDNSLink', () => {
     expect(result.cid.toString()).to.equal('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
   })
 
+  it('should retry on failure', async () => {
+    dns.query.withArgs('foobar.baz')
+      .rejects(new CodeError('Not found', 'ENODATA'))
+
+    dns.query.withArgs('_dnslink.foobar.baz')
+      .onFirstCall().rejects(new CodeError('Not found', 'ENODATA'))
+      .onSecondCall().resolves(dnsResponse([{
+        name: '_dnslink.foobar.baz.',
+        TTL: 60,
+        type: RecordType.TXT,
+        data: 'dnslink=/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
+      }]))
+
+    const result = await name.resolveDNSLink('foobar.baz', { nocache: true, offline: true })
+    expect(result.cid.toString()).to.equal('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+  })
+
   it('should handle bad records', async () => {
     dns.query.withArgs('_dnslink.foobar.baz').resolves(dnsResponse([{
       name: 'foobar.baz.',


### PR DESCRIPTION
Hitting external services can be flaky as we see periodic failures in CI for `ipfs.io` and friends so add a retry.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
