### PR TITLE
feat: add `record`/`answer` fields to IPNS results

### DIFF
--- a/packages/ipns/test/resolve-dnslink.spec.ts
+++ b/packages/ipns/test/resolve-dnslink.spec.ts
@@ -221,4 +221,26 @@ describe('resolveDNSLink', () => {
 
     expect(result.cid.toString()).to.equal(cid.toV1().toString())
   })
+
+  it('should include DNS Answer in result', async () => {
+    const cid = CID.parse('bafybeifcaqowoyito3qvsmbwbiugsu4umlxn4ehu223hvtubbfvwyuxjoe')
+    const key = await createEd25519PeerId()
+    const answer = {
+      name: '_dnslink.foobar.baz.',
+      TTL: 60,
+      type: RecordType.TXT,
+      data: 'dnslink=/ipfs/bafybeifcaqowoyito3qvsmbwbiugsu4umlxn4ehu223hvtubbfvwyuxjoe'
+    }
+    dns.query.withArgs('_dnslink.foobar.baz').resolves(dnsResponse([answer]))
+
+    await name.publish(key, cid)
+
+    const result = await name.resolveDNSLink('foobar.baz', { nocache: true })
+
+    if (result == null) {
+      throw new Error('Did not resolve entry')
+    }
+
+    expect(result).to.have.deep.property('answer', answer)
+  })
 })


### PR DESCRIPTION
Adds fields to IPNS results:

`record`: present in the return from `ipns.resolve` - contains the resolved IPNS record.

`answer`: present in the return from `ipns.resolveDNSLink` - contains the resolved DNS Answer.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
