### PR TITLE
feat: add cache control to IPNS

### DIFF
--- a/packages/ipns/test/resolve-dnslink.spec.ts
+++ b/packages/ipns/test/resolve-dnslink.spec.ts
@@ -158,7 +158,7 @@ describe('resolveDNSLink', () => {
 
     await name.publish(key, cid)
 
-    const result = await name.resolveDNSLink('foobar.baz', { nocache: true })
+    const result = await name.resolveDNSLink('foobar.baz')
 
     if (result == null) {
       throw new Error('Did not resolve entry')
@@ -186,7 +186,7 @@ describe('resolveDNSLink', () => {
 
     await name.publish(key, cid)
 
-    const result = await name.resolveDNSLink('foobar.baz', { nocache: true })
+    const result = await name.resolveDNSLink('foobar.baz')
 
     if (result == null) {
       throw new Error('Did not resolve entry')
@@ -213,7 +213,7 @@ describe('resolveDNSLink', () => {
 
     await name.publish(key, cid)
 
-    const result = await name.resolveDNSLink('foobar.baz', { nocache: true })
+    const result = await name.resolveDNSLink('foobar.baz')
 
     if (result == null) {
       throw new Error('Did not resolve entry')
@@ -235,7 +235,7 @@ describe('resolveDNSLink', () => {
 
     await name.publish(key, cid)
 
-    const result = await name.resolveDNSLink('foobar.baz', { nocache: true })
+    const result = await name.resolveDNSLink('foobar.baz')
 
     if (result == null) {
       throw new Error('Did not resolve entry')


### PR DESCRIPTION
Adds a `nocache` option when resolving IPNS records similar to when resolving DNSLink records.

The record will be resolved from the local datastore and returned if it is valid (e.g. non-expired, correct key, etc).

If the record is not present it will be fetched from the routing and stored in the local datastore if it is valid.

- `nocache` will skip the datastore and use the routing.
- `offline` only uses the datastore and skips the routing.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
