### PR TITLE
fix: Add GlobSourceResult to globSource return type in unixfs.

### DIFF
--- a/packages/unixfs/src/utils/glob-source.ts
+++ b/packages/unixfs/src/utils/glob-source.ts
@@ -5,7 +5,7 @@ import glob from 'it-glob'
 import { InvalidParametersError } from '../errors.js'
 import { toMtime } from './to-mtime.js'
 import type { MtimeLike } from 'ipfs-unixfs'
-import type { ImportCandidateStream } from 'ipfs-unixfs-importer'
+import type { ImportCandidate } from 'ipfs-unixfs-importer'
 
 export interface GlobSourceOptions {
   /**
@@ -49,7 +49,7 @@ export interface GlobSourceResult {
 /**
  * Create an async iterator that yields paths that match requested glob pattern
  */
-export async function * globSource (cwd: string, pattern: string, options: GlobSourceOptions = {}): ImportCandidateStream {
+export async function * globSource (cwd: string, pattern: string, options: GlobSourceOptions = {}): AsyncGenerator<ImportCandidate & GlobSourceResult> {
   if (typeof pattern !== 'string') {
     throw new InvalidParametersError('Pattern must be a string')
   }


### PR DESCRIPTION
## Title
fix: Add GlobSourceResult to globSource return type.

## Description

This is a small PR that modifies the return type on the `globSource` utility in `@helia/unixfs` to return the `GlobSourceResult` in addition to the `ImportCandidate` type. This means that the `path` property will be a `string` instead of `string | undefined`.

## Notes & open questions

This PR makes it a bit easier to use `globSource` since it is a bit annoying to have to check if `path` is defined when it always is.

Is there any reason why we had the `GlobSourceResult` type but `globSource` does not return it?

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
