### PR TITLE
test: test ipns ttl interop

### DIFF
--- a/packages/interop/src/ipns.spec.ts
+++ b/packages/interop/src/ipns.spec.ts
@@ -172,12 +172,16 @@ keyTypes.forEach(type => {
 
       expect(response).to.have.property('status', 200)
 
+      const oneHourNS = BigInt(60 * 60 * 1e+9)
+
       await kubo.api.name.publish(cid, {
-        key: keyName
+        key: keyName,
+        ttl: '1h'
       })
 
-      const { cid: resolvedCid } = await name.resolve(key)
+      const { cid: resolvedCid, record } = await name.resolve(key)
       expect(resolvedCid.toString()).to.equal(cid.toString())
+      expect(record.ttl).to.equal(oneHourNS)
     })
   })
 })


### PR DESCRIPTION
## Description

As per discussion in https://github.com/ipfs/helia-verified-fetch/pull/34#discussion_r1541129095 this adds a check to ensure correct TTL interop for IPNS records between @helia/ipns and Kubo.


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
