### PR TITLE
fix: respect the IPNS TTL field

### DIFF
--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -171,7 +171,7 @@
     "@libp2p/peer-id": "^4.0.7",
     "@multiformats/dns": "^1.0.1",
     "interface-datastore": "^8.2.11",
-    "ipns": "^9.0.0",
+    "ipns": "^9.1.0",
     "multiformats": "^13.1.0",
     "progress-events": "^1.0.0",
     "uint8arrays": "^5.0.2"

--- a/packages/ipns/src/routing/local-store.ts
+++ b/packages/ipns/src/routing/local-store.ts
@@ -1,8 +1,9 @@
 import { Record } from '@libp2p/kad-dht'
 import { type Datastore, Key } from 'interface-datastore'
 import { CustomProgressEvent, type ProgressEvent } from 'progress-events'
+import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import type { GetOptions, IPNSRouting, PutOptions } from '../routing'
+import type { GetOptions, PutOptions } from '../routing'
 import type { AbortOptions } from '@libp2p/interface'
 
 function dhtRoutingKey (key: Uint8Array): Key {
@@ -14,8 +15,16 @@ export type DatastoreProgressEvents =
   ProgressEvent<'ipns:routing:datastore:get'> |
   ProgressEvent<'ipns:routing:datastore:error', Error>
 
-export interface LocalStore extends IPNSRouting {
+export interface GetResult {
+  record: Uint8Array
+  created: Date
+}
+
+export interface LocalStore {
+  put(routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: PutOptions): Promise<void>
+  get(routingKey: Uint8Array, options?: GetOptions): Promise<GetResult>
   has(routingKey: Uint8Array, options?: AbortOptions): Promise<boolean>
+  delete(routingKey: Uint8Array, options?: AbortOptions): Promise<void>
 }
 
 /**
@@ -29,6 +38,21 @@ export function localStore (datastore: Datastore): LocalStore {
       try {
         const key = dhtRoutingKey(routingKey)
 
+        // don't overwrite existing, identical records as this will affect the
+        // TTL
+        try {
+          const existingBuf = await datastore.get(key)
+          const existingRecord = Record.deserialize(existingBuf)
+
+          if (uint8ArrayEquals(existingRecord.value, marshalledRecord)) {
+            return
+          }
+        } catch (err: any) {
+          if (err.code !== 'ERR_NOT_FOUND') {
+            throw err
+          }
+        }
+
         // Marshal to libp2p record as the DHT does
         const record = new Record(routingKey, marshalledRecord, new Date())
 
@@ -39,7 +63,7 @@ export function localStore (datastore: Datastore): LocalStore {
         throw err
       }
     },
-    async get (routingKey: Uint8Array, options: GetOptions = {}): Promise<Uint8Array> {
+    async get (routingKey: Uint8Array, options: GetOptions = {}): Promise<GetResult> {
       try {
         const key = dhtRoutingKey(routingKey)
 
@@ -49,7 +73,10 @@ export function localStore (datastore: Datastore): LocalStore {
         // Unmarshal libp2p record as the DHT does
         const record = Record.deserialize(buf)
 
-        return record.value
+        return {
+          record: record.value,
+          created: record.timeReceived
+        }
       } catch (err: any) {
         options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:datastore:error', err))
         throw err
@@ -58,6 +85,10 @@ export function localStore (datastore: Datastore): LocalStore {
     async has (routingKey: Uint8Array, options: AbortOptions = {}): Promise<boolean> {
       const key = dhtRoutingKey(routingKey)
       return datastore.has(key, options)
+    },
+    async delete (routingKey, options): Promise<void> {
+      const key = dhtRoutingKey(routingKey)
+      return datastore.delete(key, options)
     }
   }
 }

--- a/packages/ipns/src/routing/pubsub.ts
+++ b/packages/ipns/src/routing/pubsub.ts
@@ -72,7 +72,7 @@ class PubSubRouting implements IPNSRouting {
     await ipnsValidator(routingKey, message.data)
 
     if (await this.localStore.has(routingKey)) {
-      const currentRecord = await this.localStore.get(routingKey)
+      const { record: currentRecord } = await this.localStore.get(routingKey)
 
       if (uint8ArrayEquals(currentRecord, message.data)) {
         log('not storing record as we already have it')
@@ -128,7 +128,9 @@ class PubSubRouting implements IPNSRouting {
       }
 
       // chain through to local store
-      return await this.localStore.get(routingKey, options)
+      const { record } = await this.localStore.get(routingKey, options)
+
+      return record
     } catch (err: any) {
       options.onProgress?.(new CustomProgressEvent<Error>('ipns:pubsub:error', err))
       throw err

--- a/packages/ipns/test/publish.spec.ts
+++ b/packages/ipns/test/publish.spec.ts
@@ -44,7 +44,7 @@ describe('publish', () => {
     const ipnsEntry = await name.publish(key, cid)
 
     expect(ipnsEntry).to.have.property('sequence', 1n)
-    expect(ipnsEntry).to.have.property('ttl', 3600000000000n) // 1 hour
+    expect(ipnsEntry).to.have.property('ttl', 3_600_000_000_000n) // 1 hour
   })
 
   it('should publish an IPNS record with a custom ttl params', async function () {
@@ -55,7 +55,7 @@ describe('publish', () => {
     })
 
     expect(ipnsEntry).to.have.property('sequence', 1n)
-    expect(ipnsEntry).to.have.property('ttl', 3600000000000n)
+    expect(ipnsEntry).to.have.property('ttl', 3_600_000_000_000n)
 
     expect(heliaRouting.put.called).to.be.true()
     expect(customRouting.put.called).to.be.true()

--- a/packages/ipns/test/publish.spec.ts
+++ b/packages/ipns/test/publish.spec.ts
@@ -44,7 +44,7 @@ describe('publish', () => {
     const ipnsEntry = await name.publish(key, cid)
 
     expect(ipnsEntry).to.have.property('sequence', 1n)
-    expect(ipnsEntry).to.have.property('ttl', 8640000000000n) // 24 hours
+    expect(ipnsEntry).to.have.property('ttl', 3600000000000n) // 1 hour
   })
 
   it('should publish an IPNS record with a custom ttl params', async function () {
@@ -55,7 +55,7 @@ describe('publish', () => {
     })
 
     expect(ipnsEntry).to.have.property('sequence', 1n)
-    expect(ipnsEntry).to.have.property('ttl', BigInt(lifetime) * 100000n)
+    expect(ipnsEntry).to.have.property('ttl', 3600000000000n)
 
     expect(heliaRouting.put.called).to.be.true()
     expect(customRouting.put.called).to.be.true()


### PR DESCRIPTION
Uses the `@libp2p/record` `timeReceived` property and the `.ttl` field of the IPNS Record to calcuate the TTL of the record separately from the record EOL.

This was going to be a push to #473 but it was merged prematurely.

Fixes #479

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
