### PR TITLE
fix: increase default listers on abort signals

### DIFF
--- a/packages/bitswap/src/bitswap.ts
+++ b/packages/bitswap/src/bitswap.ts
@@ -82,8 +82,8 @@ export class Bitswap implements BitswapInterface {
 
   async want (cid: CID, options: WantOptions = {}): Promise<Uint8Array> {
     const controller = new AbortController()
-    setMaxListeners(Infinity, controller.signal)
     const signal = anySignal([controller.signal, options.signal])
+    setMaxListeners(Infinity, controller.signal, signal)
 
     // find providers and connect to them
     this.network.findAndConnect(cid, {

--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -1,4 +1,4 @@
-import { CodeError, start, stop } from '@libp2p/interface'
+import { CodeError, setMaxListeners, start, stop } from '@libp2p/interface'
 import { anySignal } from 'any-signal'
 import { IdentityBlockstore } from 'blockstore-core/identity'
 import { TieredBlockstore } from 'blockstore-core/tiered'
@@ -250,6 +250,7 @@ async function raceBlockRetrievers (cid: CID, blockBrokers: BlockBroker[], hashe
 
   const controller = new AbortController()
   const signal = anySignal([controller.signal, options.signal])
+  setMaxListeners(Infinity, controller.signal, signal)
 
   const retrievers: Array<Required<Pick<BlockBroker, 'retrieve'>>> = []
 


### PR DESCRIPTION
To prevent spurious warnings appearing in the console, increase the number of listeners on created abort signals.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
