### PR TITLE
fix: cancel in-flight block requests when racing brokers

### DIFF
--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -289,6 +289,9 @@ async function raceBlockRetrievers (cid: CID, blockBrokers: BlockBroker[], hashe
         })
     )
   } finally {
+    // we have the block from the fastest block retriever, abort any still
+    // in-flight retrieve attempts
+    controller.abort()
     signal.clear()
   }
 }


### PR DESCRIPTION
If multiple brokers are configured, when one resolves a block request,
cancel the outstanding requests to free up resources.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
