### PR TITLE
fix: prevent duplicate trustless-gateway reqs

### DIFF
--- a/packages/block-brokers/.aegir.js
+++ b/packages/block-brokers/.aegir.js
@@ -17,6 +17,17 @@ const options = {
         })
         res.end(Uint8Array.from([0, 1, 2, 0]))
       })
+      server.all('/ipfs/bafkqabtimvwgy3yk', async (req, res) => {
+        // delay the response
+        await new Promise((resolve) => setTimeout(resolve, 500))
+
+        res.writeHead(200, {
+          'content-type': 'application/octet-stream',
+          'content-length': 5
+        })
+        // "hello"
+        res.end(Uint8Array.from([104, 101, 108, 108, 111]))
+      })
 
       await server.listen()
       const { port } = server.server.address()

--- a/packages/block-brokers/package.json
+++ b/packages/block-brokers/package.json
@@ -70,6 +70,7 @@
     "@libp2p/logger": "^4.0.7",
     "@libp2p/peer-id-factory": "^4.0.7",
     "@multiformats/uri-to-multiaddr": "^8.0.0",
+    "@types/polka": "^0.5.7",
     "@types/sinon": "^17.0.3",
     "aegir": "^42.2.5",
     "cors": "^2.8.5",

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -7,6 +7,7 @@ export interface TrustlessGatewayStats {
   errors: number
   invalidBlocks: number
   successes: number
+  pendingResponses?: number
 }
 
 /**
@@ -170,7 +171,8 @@ export class TrustlessGateway {
       attempts: this.#attempts,
       errors: this.#errors,
       invalidBlocks: this.#invalidBlocks,
-      successes: this.#successes
+      successes: this.#successes,
+      pendingResponses: this.#pendingResponses.size
     }
   }
 }

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -1,6 +1,13 @@
 import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
 
+export interface TrustlessGatewayStats {
+  attempts: number
+  errors: number
+  invalidBlocks: number
+  successes: number
+}
+
 /**
  * A `TrustlessGateway` keeps track of the number of attempts, errors, and
  * successes for a given gateway url so that we can prioritize gateways that
@@ -129,5 +136,14 @@ export class TrustlessGateway {
    */
   incrementInvalidBlocks (): void {
     this.#invalidBlocks++
+  }
+
+  getStats (): TrustlessGatewayStats {
+    return {
+      attempts: this.#attempts,
+      errors: this.#errors,
+      invalidBlocks: this.#invalidBlocks,
+      successes: this.#successes
+    }
   }
 }

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -105,6 +105,8 @@ export class TrustlessGateway {
       this.log.error('failed to get block for %c from %s', cid, gwUrl, cause)
       this.#errors++
       throw new Error(`unable to fetch raw block for CID ${cid}`)
+    } finally {
+      this.#pendingResponses.delete(gwUrl.toString())
     }
   }
 

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -191,7 +191,7 @@ describe('trustless-gateway-block-broker', () => {
     await expect(sessionBlockstore?.retrieve?.(blocks[0].cid)).to.eventually.deep.equal(blocks[0].block)
   })
 
-  it('does not trigger new network requests if the same block request is in-flight', async function () {
+  it('does not trigger new network requests if the same cid request is in-flight', async function () {
     // from .aegir.js polka server
     const cid = CID.parse('bafkqabtimvwgy3yk')
     if (process.env.TRUSTLESS_GATEWAY == null) {

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -5,6 +5,7 @@ import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { multiaddr } from '@multiformats/multiaddr'
 import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
 import { expect } from 'aegir/chai'
+import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
 import Sinon from 'sinon'
 import { type StubbedInstance, stubConstructor, stubInterface } from 'sinon-ts'
@@ -12,7 +13,6 @@ import { TrustlessGatewayBlockBroker } from '../src/trustless-gateway/broker.js'
 import { TrustlessGateway } from '../src/trustless-gateway/trustless-gateway.js'
 import { createBlock } from './fixtures/create-block.js'
 import type { Routing } from '@helia/interface'
-import type { CID } from 'multiformats/cid'
 
 describe('trustless-gateway-block-broker', () => {
   let blocks: Array<{ cid: CID, block: Uint8Array }>
@@ -189,5 +189,33 @@ describe('trustless-gateway-block-broker', () => {
     expect(sessionBlockstore).to.be.ok()
 
     await expect(sessionBlockstore?.retrieve?.(blocks[0].cid)).to.eventually.deep.equal(blocks[0].block)
+  })
+
+  it('does not trigger new network requests if the same block request is in-flight', async function () {
+    // from .aegir.js polka server
+    const cid = CID.parse('bafkqabtimvwgy3yk')
+    if (process.env.TRUSTLESS_GATEWAY == null) {
+      return this.skip()
+    }
+    const trustlessGateway = new TrustlessGateway(process.env.TRUSTLESS_GATEWAY, defaultLogger())
+
+    // Call getRawBlock multiple times with the same CID
+    const promises = Array.from({ length: 10 }, async () => trustlessGateway.getRawBlock(cid))
+
+    // Wait for both promises to resolve
+    const [block1, ...blocks] = await Promise.all(promises)
+
+    // Assert that all calls to getRawBlock returned the same block
+    for (const block of blocks) {
+      expect(block).to.deep.equal(block1)
+    }
+
+    expect(trustlessGateway.getStats()).to.deep.equal({
+      // attempt is only incremented when a new request is made
+      attempts: 1,
+      errors: 0,
+      invalidBlocks: 0,
+      successes: 1
+    })
   })
 })

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -215,7 +215,8 @@ describe('trustless-gateway-block-broker', () => {
       attempts: 1,
       errors: 0,
       invalidBlocks: 0,
-      successes: 1
+      successes: 1,
+      pendingResponses: 0 // the queue is empty
     })
   })
 })


### PR DESCRIPTION
- chore: add @types/polka
- feat: getStats() returns trustless gateway stats

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: prevent duplicate trustless-gateway reqs

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Fixes https://github.com/ipfs-shipyard/service-worker-gateway/issues/104

This PR fixes issues brought up in service-worker-gateway where sub-resources end up causing multiple requests to a trustless gateway for the root CID.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

I feel like the blockstore should handle this and ensure requests that depend on a root CID are deduped, but since trustless-gateways may be used outside of the context of blockstores, I believe we still need this improvement.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
