### PR TITLE
fix: relax unixfs blockstore input type

### DIFF
--- a/packages/unixfs/src/commands/add.ts
+++ b/packages/unixfs/src/commands/add.ts
@@ -1,7 +1,7 @@
 import { type ByteStream, type DirectoryCandidate, type FileCandidate, importBytes, importByteStream, type ImportCandidateStream, importDirectory, importer, type ImporterOptions, importFile, type ImportResult } from 'ipfs-unixfs-importer'
 import { fixedSize } from 'ipfs-unixfs-importer/chunker'
 import { balanced } from 'ipfs-unixfs-importer/layout'
-import type { Blockstore } from 'interface-blockstore'
+import type { PutStore } from '../unixfs.js'
 import type { CID } from 'multiformats/cid'
 
 /**
@@ -18,14 +18,14 @@ const defaultImporterSettings: ImporterOptions = {
   })
 }
 
-export async function * addAll (source: ImportCandidateStream, blockstore: Blockstore, options: Partial<ImporterOptions> = {}): AsyncGenerator<ImportResult, void, unknown> {
+export async function * addAll (source: ImportCandidateStream, blockstore: PutStore, options: Partial<ImporterOptions> = {}): AsyncGenerator<ImportResult, void, unknown> {
   yield * importer(source, blockstore, {
     ...defaultImporterSettings,
     ...options
   })
 }
 
-export async function addBytes (bytes: Uint8Array, blockstore: Blockstore, options: Partial<ImporterOptions> = {}): Promise<CID> {
+export async function addBytes (bytes: Uint8Array, blockstore: PutStore, options: Partial<ImporterOptions> = {}): Promise<CID> {
   const { cid } = await importBytes(bytes, blockstore, {
     ...defaultImporterSettings,
     ...options
@@ -34,7 +34,7 @@ export async function addBytes (bytes: Uint8Array, blockstore: Blockstore, optio
   return cid
 }
 
-export async function addByteStream (bytes: ByteStream, blockstore: Blockstore, options: Partial<ImporterOptions> = {}): Promise<CID> {
+export async function addByteStream (bytes: ByteStream, blockstore: PutStore, options: Partial<ImporterOptions> = {}): Promise<CID> {
   const { cid } = await importByteStream(bytes, blockstore, {
     ...defaultImporterSettings,
     ...options
@@ -43,7 +43,7 @@ export async function addByteStream (bytes: ByteStream, blockstore: Blockstore, 
   return cid
 }
 
-export async function addFile (file: FileCandidate, blockstore: Blockstore, options: Partial<ImporterOptions> = {}): Promise<CID> {
+export async function addFile (file: FileCandidate, blockstore: PutStore, options: Partial<ImporterOptions> = {}): Promise<CID> {
   const { cid } = await importFile(file, blockstore, {
     ...defaultImporterSettings,
     ...options
@@ -52,7 +52,7 @@ export async function addFile (file: FileCandidate, blockstore: Blockstore, opti
   return cid
 }
 
-export async function addDirectory (dir: Partial<DirectoryCandidate>, blockstore: Blockstore, options: Partial<ImporterOptions> = {}): Promise<CID> {
+export async function addDirectory (dir: Partial<DirectoryCandidate>, blockstore: PutStore, options: Partial<ImporterOptions> = {}): Promise<CID> {
   const { cid } = await importDirectory({
     ...dir,
     path: dir.path ?? '-'

--- a/packages/unixfs/src/commands/cat.ts
+++ b/packages/unixfs/src/commands/cat.ts
@@ -3,7 +3,7 @@ import mergeOpts from 'merge-options'
 import { NoContentError, NotAFileError } from '../errors.js'
 import { resolve } from './utils/resolve.js'
 import type { CatOptions } from '../index.js'
-import type { Blockstore } from 'interface-blockstore'
+import type { GetStore } from '../unixfs.js'
 import type { CID } from 'multiformats/cid'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
@@ -12,7 +12,7 @@ const defaultOptions: CatOptions = {
 
 }
 
-export async function * cat (cid: CID, blockstore: Blockstore, options: Partial<CatOptions> = {}): AsyncIterable<Uint8Array> {
+export async function * cat (cid: CID, blockstore: GetStore, options: Partial<CatOptions> = {}): AsyncIterable<Uint8Array> {
   const opts: CatOptions = mergeOptions(defaultOptions, options)
   const resolved = await resolve(cid, opts.path, blockstore, opts)
   const result = await exporter(resolved.cid, blockstore, opts)

--- a/packages/unixfs/src/commands/chmod.ts
+++ b/packages/unixfs/src/commands/chmod.ts
@@ -14,8 +14,8 @@ import { SHARD_SPLIT_THRESHOLD_BYTES } from './utils/constants.js'
 import { persist } from './utils/persist.js'
 import { resolve, updatePathCids } from './utils/resolve.js'
 import type { ChmodOptions } from '../index.js'
+import type { GetStore, PutStore } from '../unixfs.js'
 import type { PBNode, PBLink } from '@ipld/dag-pb'
-import type { Blockstore } from 'interface-blockstore'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
 const log = logger('helia:unixfs:chmod')
@@ -25,7 +25,7 @@ const defaultOptions: ChmodOptions = {
   shardSplitThresholdBytes: SHARD_SPLIT_THRESHOLD_BYTES
 }
 
-export async function chmod (cid: CID, mode: number, blockstore: Blockstore, options: Partial<ChmodOptions> = {}): Promise<CID> {
+export async function chmod (cid: CID, mode: number, blockstore: PutStore & GetStore, options: Partial<ChmodOptions> = {}): Promise<CID> {
   const opts: ChmodOptions = mergeOptions(defaultOptions, options)
   const resolved = await resolve(cid, opts.path, blockstore, options)
 

--- a/packages/unixfs/src/commands/cp.ts
+++ b/packages/unixfs/src/commands/cp.ts
@@ -6,7 +6,7 @@ import { cidToDirectory } from './utils/cid-to-directory.js'
 import { cidToPBLink } from './utils/cid-to-pblink.js'
 import { SHARD_SPLIT_THRESHOLD_BYTES } from './utils/constants.js'
 import type { CpOptions } from '../index.js'
-import type { Blockstore } from 'interface-blockstore'
+import type { GetStore, PutStore } from '../unixfs.js'
 import type { CID } from 'multiformats/cid'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
@@ -17,7 +17,7 @@ const defaultOptions: CpOptions = {
   shardSplitThresholdBytes: SHARD_SPLIT_THRESHOLD_BYTES
 }
 
-export async function cp (source: CID, target: CID, name: string, blockstore: Blockstore, options: Partial<CpOptions> = {}): Promise<CID> {
+export async function cp (source: CID, target: CID, name: string, blockstore: GetStore & PutStore, options: Partial<CpOptions> = {}): Promise<CID> {
   const opts: CpOptions = mergeOptions(defaultOptions, options)
 
   if (name.includes('/')) {

--- a/packages/unixfs/src/commands/ls.ts
+++ b/packages/unixfs/src/commands/ls.ts
@@ -3,7 +3,7 @@ import mergeOpts from 'merge-options'
 import { NoContentError, NotADirectoryError } from '../errors.js'
 import { resolve } from './utils/resolve.js'
 import type { LsOptions } from '../index.js'
-import type { Blockstore } from 'interface-blockstore'
+import type { GetStore } from '../unixfs.js'
 import type { CID } from 'multiformats/cid'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
@@ -12,7 +12,7 @@ const defaultOptions: LsOptions = {
 
 }
 
-export async function * ls (cid: CID, blockstore: Blockstore, options: Partial<LsOptions> = {}): AsyncIterable<UnixFSEntry> {
+export async function * ls (cid: CID, blockstore: GetStore, options: Partial<LsOptions> = {}): AsyncIterable<UnixFSEntry> {
   const opts: LsOptions = mergeOptions(defaultOptions, options)
   const resolved = await resolve(cid, opts.path, blockstore, opts)
   const result = await exporter(resolved.cid, blockstore)

--- a/packages/unixfs/src/commands/mkdir.ts
+++ b/packages/unixfs/src/commands/mkdir.ts
@@ -11,7 +11,7 @@ import { cidToDirectory } from './utils/cid-to-directory.js'
 import { cidToPBLink } from './utils/cid-to-pblink.js'
 import { SHARD_SPLIT_THRESHOLD_BYTES } from './utils/constants.js'
 import type { MkdirOptions } from '../index.js'
-import type { Blockstore } from 'interface-blockstore'
+import type { GetStore, PutStore } from '../unixfs.js'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
 const log = logger('helia:unixfs:mkdir')
@@ -22,7 +22,7 @@ const defaultOptions: MkdirOptions = {
   shardSplitThresholdBytes: SHARD_SPLIT_THRESHOLD_BYTES
 }
 
-export async function mkdir (parentCid: CID, dirname: string, blockstore: Blockstore, options: Partial<MkdirOptions> = {}): Promise<CID> {
+export async function mkdir (parentCid: CID, dirname: string, blockstore: GetStore & PutStore, options: Partial<MkdirOptions> = {}): Promise<CID> {
   const opts: MkdirOptions = mergeOptions(defaultOptions, options)
 
   if (dirname.includes('/')) {

--- a/packages/unixfs/src/commands/rm.ts
+++ b/packages/unixfs/src/commands/rm.ts
@@ -5,7 +5,7 @@ import { cidToDirectory } from './utils/cid-to-directory.js'
 import { SHARD_SPLIT_THRESHOLD_BYTES } from './utils/constants.js'
 import { removeLink } from './utils/remove-link.js'
 import type { RmOptions } from '../index.js'
-import type { Blockstore } from 'interface-blockstore'
+import type { GetStore, PutStore } from '../unixfs.js'
 import type { CID } from 'multiformats/cid'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
@@ -15,7 +15,7 @@ const defaultOptions: RmOptions = {
   shardSplitThresholdBytes: SHARD_SPLIT_THRESHOLD_BYTES
 }
 
-export async function rm (target: CID, name: string, blockstore: Blockstore, options: Partial<RmOptions> = {}): Promise<CID> {
+export async function rm (target: CID, name: string, blockstore: GetStore & PutStore, options: Partial<RmOptions> = {}): Promise<CID> {
   const opts: RmOptions = mergeOptions(defaultOptions, options)
 
   if (name.includes('/')) {

--- a/packages/unixfs/src/commands/stat.ts
+++ b/packages/unixfs/src/commands/stat.ts
@@ -7,8 +7,8 @@ import * as raw from 'multiformats/codecs/raw'
 import { InvalidPBNodeError, NotUnixFSError, UnknownError } from '../errors.js'
 import { resolve } from './utils/resolve.js'
 import type { StatOptions, UnixFSStats } from '../index.js'
+import type { GetStore, HasStore } from '../unixfs.js'
 import type { AbortOptions } from '@libp2p/interface'
-import type { Blockstore } from 'interface-blockstore'
 import type { Mtime } from 'ipfs-unixfs'
 import type { CID } from 'multiformats/cid'
 
@@ -19,7 +19,7 @@ const defaultOptions: StatOptions = {
 
 }
 
-export async function stat (cid: CID, blockstore: Blockstore, options: Partial<StatOptions> = {}): Promise<UnixFSStats> {
+export async function stat (cid: CID, blockstore: GetStore & HasStore, options: Partial<StatOptions> = {}): Promise<UnixFSStats> {
   const opts: StatOptions = mergeOptions(defaultOptions, options)
   const resolved = await resolve(cid, options.path, blockstore, opts)
 
@@ -93,7 +93,7 @@ interface InspectDagResults {
   blocks: number
 }
 
-async function inspectDag (cid: CID, blockstore: Blockstore, options: AbortOptions): Promise<InspectDagResults> {
+async function inspectDag (cid: CID, blockstore: GetStore & HasStore, options: AbortOptions): Promise<InspectDagResults> {
   const results = {
     localFileSize: 0,
     localDagSize: 0,

--- a/packages/unixfs/src/commands/touch.ts
+++ b/packages/unixfs/src/commands/touch.ts
@@ -14,8 +14,8 @@ import { SHARD_SPLIT_THRESHOLD_BYTES } from './utils/constants.js'
 import { persist } from './utils/persist.js'
 import { resolve, updatePathCids } from './utils/resolve.js'
 import type { TouchOptions } from '../index.js'
+import type { GetStore, PutStore } from '../unixfs.js'
 import type { PBNode, PBLink } from '@ipld/dag-pb'
-import type { Blockstore } from 'interface-blockstore'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
 const log = logger('helia:unixfs:touch')
@@ -25,7 +25,7 @@ const defaultOptions: TouchOptions = {
   shardSplitThresholdBytes: SHARD_SPLIT_THRESHOLD_BYTES
 }
 
-export async function touch (cid: CID, blockstore: Blockstore, options: Partial<TouchOptions> = {}): Promise<CID> {
+export async function touch (cid: CID, blockstore: GetStore & PutStore, options: Partial<TouchOptions> = {}): Promise<CID> {
   const opts: TouchOptions = mergeOptions(defaultOptions, options)
   const resolved = await resolve(cid, opts.path, blockstore, opts)
   const mtime = opts.mtime ?? {

--- a/packages/unixfs/src/commands/utils/add-link.ts
+++ b/packages/unixfs/src/commands/utils/add-link.ts
@@ -17,9 +17,9 @@ import {
 } from './hamt-utils.js'
 import { isOverShardThreshold } from './is-over-shard-threshold.js'
 import type { Directory } from './cid-to-directory.js'
+import type { GetStore, PutStore } from '../../unixfs.js'
 import type { PBNode, PBLink } from '@ipld/dag-pb/interface'
 import type { AbortOptions } from '@libp2p/interface'
-import type { Blockstore } from 'interface-blockstore'
 import type { ImportResult } from 'ipfs-unixfs-importer'
 
 const log = logger('helia:unixfs:components:utils:add-link')
@@ -35,7 +35,7 @@ export interface AddLinkOptions extends AbortOptions {
   cidVersion: Version
 }
 
-export async function addLink (parent: Directory, child: Required<PBLink>, blockstore: Blockstore, options: AddLinkOptions): Promise<AddLinkResult> {
+export async function addLink (parent: Directory, child: Required<PBLink>, blockstore: GetStore & PutStore, options: AddLinkOptions): Promise<AddLinkResult> {
   if (parent.node.Data == null) {
     throw new InvalidParametersError('Invalid parent passed to addLink')
   }
@@ -63,7 +63,7 @@ export async function addLink (parent: Directory, child: Required<PBLink>, block
   return result
 }
 
-const convertToShardedDirectory = async (parent: Directory, blockstore: Blockstore): Promise<ImportResult> => {
+const convertToShardedDirectory = async (parent: Directory, blockstore: PutStore): Promise<ImportResult> => {
   if (parent.node.Data == null) {
     throw new InvalidParametersError('Invalid parent passed to convertToShardedDirectory')
   }
@@ -85,7 +85,7 @@ const convertToShardedDirectory = async (parent: Directory, blockstore: Blocksto
   return result
 }
 
-const addToDirectory = async (parent: Directory, child: PBLink, blockstore: Blockstore, options: AddLinkOptions): Promise<AddLinkResult> => {
+const addToDirectory = async (parent: Directory, child: PBLink, blockstore: PutStore, options: AddLinkOptions): Promise<AddLinkResult> => {
   // Remove existing link if it exists
   const parentLinks = parent.node.Links.filter((link) => {
     const matches = link.Name === child.Name
@@ -137,7 +137,7 @@ const addToDirectory = async (parent: Directory, child: PBLink, blockstore: Bloc
   }
 }
 
-const addToShardedDirectory = async (parent: Directory, child: Required<PBLink>, blockstore: Blockstore, options: AddLinkOptions): Promise<AddLinkResult> => {
+const addToShardedDirectory = async (parent: Directory, child: Required<PBLink>, blockstore: GetStore & PutStore, options: AddLinkOptions): Promise<AddLinkResult> => {
   const { path, hash } = await recreateShardedDirectory(parent.cid, child.Name, blockstore, options)
   const finalSegment = path[path.length - 1]
 

--- a/packages/unixfs/src/commands/utils/cid-to-directory.ts
+++ b/packages/unixfs/src/commands/utils/cid-to-directory.ts
@@ -1,7 +1,7 @@
 import { exporter, type ExporterOptions } from 'ipfs-unixfs-exporter'
 import { NotADirectoryError } from '../../errors.js'
+import type { GetStore } from '../../unixfs.js'
 import type { PBNode } from '@ipld/dag-pb'
-import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 
 export interface Directory {
@@ -9,7 +9,7 @@ export interface Directory {
   node: PBNode
 }
 
-export async function cidToDirectory (cid: CID, blockstore: Blockstore, options: ExporterOptions = {}): Promise<Directory> {
+export async function cidToDirectory (cid: CID, blockstore: GetStore, options: ExporterOptions = {}): Promise<Directory> {
   const entry = await exporter(cid, blockstore, options)
 
   if (entry.type !== 'directory') {

--- a/packages/unixfs/src/commands/utils/cid-to-pblink.ts
+++ b/packages/unixfs/src/commands/utils/cid-to-pblink.ts
@@ -1,11 +1,11 @@
 import * as dagPb from '@ipld/dag-pb'
 import { exporter, type ExporterOptions } from 'ipfs-unixfs-exporter'
 import { NotUnixFSError } from '../../errors.js'
+import type { GetStore } from '../../unixfs.js'
 import type { PBNode, PBLink } from '@ipld/dag-pb'
-import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 
-export async function cidToPBLink (cid: CID, name: string, blockstore: Blockstore, options?: ExporterOptions): Promise<Required<PBLink>> {
+export async function cidToPBLink (cid: CID, name: string, blockstore: GetStore, options?: ExporterOptions): Promise<Required<PBLink>> {
   const sourceEntry = await exporter(cid, blockstore, options)
 
   if (sourceEntry.type !== 'directory' && sourceEntry.type !== 'file' && sourceEntry.type !== 'raw') {

--- a/packages/unixfs/src/commands/utils/dir-sharded.ts
+++ b/packages/unixfs/src/commands/utils/dir-sharded.ts
@@ -7,7 +7,7 @@ import {
   hamtHashFn
 } from './hamt-constants.js'
 import { persist, type PersistOptions } from './persist.js'
-import type { Blockstore } from 'interface-blockstore'
+import type { PutStore } from '../../unixfs.js'
 import type { Mtime } from 'ipfs-unixfs'
 
 interface InProgressImportResult extends ImportResult {
@@ -69,7 +69,7 @@ abstract class Dir {
   abstract put (name: string, value: InProgressImportResult | Dir): Promise<void>
   abstract get (name: string): Promise<InProgressImportResult | Dir | undefined>
   abstract eachChildSeries (): AsyncIterable<{ key: string, child: InProgressImportResult | Dir }>
-  abstract flush (blockstore: Blockstore): AsyncGenerator<ImportResult>
+  abstract flush (blockstore: PutStore): AsyncGenerator<ImportResult>
   abstract estimateNodeSize (): number
   abstract childCount (): number
 }
@@ -129,7 +129,7 @@ export class DirSharded extends Dir {
     return this.nodeSize
   }
 
-  async * flush (blockstore: Blockstore): AsyncGenerator<ImportResult> {
+  async * flush (blockstore: PutStore): AsyncGenerator<ImportResult> {
     for await (const entry of flush(this._bucket, blockstore, this, this.options)) {
       yield {
         ...entry,
@@ -139,7 +139,7 @@ export class DirSharded extends Dir {
   }
 }
 
-async function * flush (bucket: Bucket<Dir | InProgressImportResult>, blockstore: Blockstore, shardRoot: DirSharded | null, options: PersistOptions): AsyncIterable<ImportResult> {
+async function * flush (bucket: Bucket<Dir | InProgressImportResult>, blockstore: PutStore, shardRoot: DirSharded | null, options: PersistOptions): AsyncIterable<ImportResult> {
   const children = bucket._children
   const links: PBLink[] = []
   let childrenSize = 0n

--- a/packages/unixfs/src/commands/utils/hamt-utils.ts
+++ b/packages/unixfs/src/commands/utils/hamt-utils.ts
@@ -14,6 +14,7 @@ import {
 } from './hamt-constants.js'
 import { persist } from './persist.js'
 import type { PersistOptions } from './persist.js'
+import type { GetStore, PutStore } from '../../unixfs.js'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
 import type { Mtime } from 'ipfs-unixfs'
@@ -40,7 +41,7 @@ export interface CreateShardOptions {
   cidVersion: Version
 }
 
-export const createShard = async (blockstore: Blockstore, contents: Array<{ name: string, size: bigint, cid: CID }>, options: CreateShardOptions): Promise<ImportResult> => {
+export const createShard = async (blockstore: PutStore, contents: Array<{ name: string, size: bigint, cid: CID }>, options: CreateShardOptions): Promise<ImportResult> => {
   const shard = new DirSharded({
     root: true,
     dir: true,
@@ -75,7 +76,7 @@ export interface HAMTPath {
   node: dagPB.PBNode
 }
 
-export const updateShardedDirectory = async (path: HAMTPath[], blockstore: Blockstore, options: PersistOptions): Promise<{ cid: CID, node: dagPB.PBNode }> => {
+export const updateShardedDirectory = async (path: HAMTPath[], blockstore: GetStore & PutStore, options: PersistOptions): Promise<{ cid: CID, node: dagPB.PBNode }> => {
   // persist any metadata on the shard root
   const shardRoot = UnixFS.unmarshal(path[0].node.Data ?? new Uint8Array(0))
 
@@ -142,7 +143,7 @@ export const updateShardedDirectory = async (path: HAMTPath[], blockstore: Block
   return { cid, node }
 }
 
-export const recreateShardedDirectory = async (cid: CID, fileName: string, blockstore: Blockstore, options: AbortOptions): Promise<{ path: HAMTPath[], hash: InfiniteHash }> => {
+export const recreateShardedDirectory = async (cid: CID, fileName: string, blockstore: Pick<Blockstore, 'get'>, options: AbortOptions): Promise<{ path: HAMTPath[], hash: InfiniteHash }> => {
   const wrapped = wrapHash(hamtHashFn)
   const hash = wrapped(uint8ArrayFromString(fileName))
   const path: HAMTPath[] = []

--- a/packages/unixfs/src/commands/utils/is-over-shard-threshold.ts
+++ b/packages/unixfs/src/commands/utils/is-over-shard-threshold.ts
@@ -1,9 +1,9 @@
 import * as dagPb from '@ipld/dag-pb'
 import { UnixFS } from 'ipfs-unixfs'
 import { CID_V0, CID_V1 } from './dir-sharded.js'
+import type { GetStore } from '../../unixfs.js'
 import type { PBNode } from '@ipld/dag-pb'
 import type { AbortOptions } from '@libp2p/interface'
-import type { Blockstore } from 'interface-blockstore'
 
 /**
  * Estimate node size only based on DAGLink name and CID byte lengths
@@ -11,7 +11,7 @@ import type { Blockstore } from 'interface-blockstore'
  *
  * If the node is a hamt sharded directory the calculation is based on if it was a regular directory.
  */
-export async function isOverShardThreshold (node: PBNode, blockstore: Blockstore, threshold: number, options: AbortOptions): Promise<boolean> {
+export async function isOverShardThreshold (node: PBNode, blockstore: GetStore, threshold: number, options: AbortOptions): Promise<boolean> {
   if (node.Data == null) {
     throw new Error('DagPB node had no data')
   }
@@ -43,7 +43,7 @@ function estimateNodeSize (node: PBNode): number {
   return size
 }
 
-async function estimateShardSize (node: PBNode, current: number, max: number, blockstore: Blockstore, options: AbortOptions): Promise<number> {
+async function estimateShardSize (node: PBNode, current: number, max: number, blockstore: GetStore, options: AbortOptions): Promise<number> {
   if (current > max) {
     return max
   }

--- a/packages/unixfs/src/commands/utils/persist.ts
+++ b/packages/unixfs/src/commands/utils/persist.ts
@@ -1,7 +1,7 @@
 import * as dagPb from '@ipld/dag-pb'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import type { Blocks } from '@helia/interface/blocks'
+import type { PutStore } from '../../unixfs.js'
 import type { Version as CIDVersion } from 'multiformats/cid'
 import type { BlockCodec } from 'multiformats/codecs/interface'
 
@@ -10,8 +10,6 @@ export interface PersistOptions {
   cidVersion: CIDVersion
   signal?: AbortSignal
 }
-
-type PutStore = Pick<Blocks, 'put'>
 
 export const persist = async (buffer: Uint8Array, blockstore: PutStore, options: PersistOptions): Promise<CID> => {
   if (options.codec == null) {

--- a/packages/unixfs/src/commands/utils/remove-link.ts
+++ b/packages/unixfs/src/commands/utils/remove-link.ts
@@ -11,9 +11,9 @@ import {
 import { isOverShardThreshold } from './is-over-shard-threshold.js'
 import { persist } from './persist.js'
 import type { Directory } from './cid-to-directory.js'
+import type { GetStore, PutStore } from '../../unixfs.js'
 import type { PBNode } from '@ipld/dag-pb'
 import type { AbortOptions } from '@libp2p/interface'
-import type { Blockstore } from 'interface-blockstore'
 import type { CID, Version } from 'multiformats/cid'
 
 const log = logger('helia:unixfs:utils:remove-link')
@@ -28,7 +28,7 @@ export interface RemoveLinkResult {
   cid: CID
 }
 
-export async function removeLink (parent: Directory, name: string, blockstore: Blockstore, options: RmLinkOptions): Promise<RemoveLinkResult> {
+export async function removeLink (parent: Directory, name: string, blockstore: PutStore & GetStore, options: RmLinkOptions): Promise<RemoveLinkResult> {
   if (parent.node.Data == null) {
     throw new InvalidPBNodeError('Parent node had no data')
   }
@@ -54,7 +54,7 @@ export async function removeLink (parent: Directory, name: string, blockstore: B
   return removeFromDirectory(parent, name, blockstore, options)
 }
 
-const removeFromDirectory = async (parent: Directory, name: string, blockstore: Blockstore, options: AbortOptions): Promise<RemoveLinkResult> => {
+const removeFromDirectory = async (parent: Directory, name: string, blockstore: PutStore & GetStore, options: AbortOptions): Promise<RemoveLinkResult> => {
   // Remove existing link if it exists
   parent.node.Links = parent.node.Links.filter((link) => {
     return link.Name !== name
@@ -74,7 +74,7 @@ const removeFromDirectory = async (parent: Directory, name: string, blockstore: 
   }
 }
 
-const removeFromShardedDirectory = async (parent: Directory, name: string, blockstore: Blockstore, options: UpdateHamtDirectoryOptions): Promise<{ cid: CID, node: PBNode }> => {
+const removeFromShardedDirectory = async (parent: Directory, name: string, blockstore: PutStore & GetStore, options: UpdateHamtDirectoryOptions): Promise<{ cid: CID, node: PBNode }> => {
   const { path } = await recreateShardedDirectory(parent.cid, name, blockstore, options)
   const finalSegment = path[path.length - 1]
 
@@ -131,7 +131,7 @@ const removeFromShardedDirectory = async (parent: Directory, name: string, block
   return updateShardedDirectory(path, blockstore, options)
 }
 
-const convertToFlatDirectory = async (parent: Directory, blockstore: Blockstore, options: RmLinkOptions): Promise<RemoveLinkResult> => {
+const convertToFlatDirectory = async (parent: Directory, blockstore: PutStore & GetStore, options: RmLinkOptions): Promise<RemoveLinkResult> => {
   if (parent.node.Data == null) {
     throw new InvalidParametersError('Invalid parent passed to convertToFlatDirectory')
   }

--- a/packages/unixfs/src/commands/utils/resolve.ts
+++ b/packages/unixfs/src/commands/utils/resolve.ts
@@ -5,8 +5,8 @@ import { DoesNotExistError } from '../../errors.js'
 import { addLink } from './add-link.js'
 import { cidToDirectory } from './cid-to-directory.js'
 import { cidToPBLink } from './cid-to-pblink.js'
+import type { GetStore, PutStore } from '../../unixfs.js'
 import type { AbortOptions } from '@libp2p/interface'
-import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 
 const log = logger('helia:unixfs:components:utils:resolve')
@@ -33,7 +33,7 @@ export interface ResolveResult {
   segments?: Segment[]
 }
 
-export async function resolve (cid: CID, path: string | undefined, blockstore: Blockstore, options: AbortOptions): Promise<ResolveResult> {
+export async function resolve (cid: CID, path: string | undefined, blockstore: GetStore, options: AbortOptions): Promise<ResolveResult> {
   if (path == null || path === '') {
     return { cid }
   }
@@ -62,7 +62,7 @@ export interface UpdatePathCidsOptions extends AbortOptions {
  * Where we have descended into a DAG to update a child node, ascend up the DAG creating
  * new hashes and blocks for the changed content
  */
-export async function updatePathCids (cid: CID, result: ResolveResult, blockstore: Blockstore, options: UpdatePathCidsOptions): Promise<CID> {
+export async function updatePathCids (cid: CID, result: ResolveResult, blockstore: PutStore & GetStore, options: UpdatePathCidsOptions): Promise<CID> {
   if (result.segments == null || result.segments.length === 0) {
     return cid
   }

--- a/packages/unixfs/src/index.ts
+++ b/packages/unixfs/src/index.ts
@@ -43,15 +43,7 @@
  * ```
  */
 
-import { addAll, addBytes, addByteStream, addDirectory, addFile } from './commands/add.js'
-import { cat } from './commands/cat.js'
-import { chmod } from './commands/chmod.js'
-import { cp } from './commands/cp.js'
-import { ls } from './commands/ls.js'
-import { mkdir } from './commands/mkdir.js'
-import { rm } from './commands/rm.js'
-import { stat } from './commands/stat.js'
-import { touch } from './commands/touch.js'
+import { UnixFS as UnixFSClass } from './unixfs.js'
 import type { GetBlockProgressEvents, PutBlockProgressEvents } from '@helia/interface/blocks'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
@@ -62,7 +54,7 @@ import type { CID, Version } from 'multiformats/cid'
 import type { ProgressOptions } from 'progress-events'
 
 export interface UnixFSComponents {
-  blockstore: Blockstore
+  blockstore: Pick<Blockstore, 'get' | 'put' | 'has'>
 }
 
 export type AddEvents = PutBlockProgressEvents
@@ -554,71 +546,11 @@ export interface UnixFS {
   touch(cid: CID, options?: Partial<TouchOptions>): Promise<CID>
 }
 
-class DefaultUnixFS implements UnixFS {
-  private readonly components: UnixFSComponents
-
-  constructor (components: UnixFSComponents) {
-    this.components = components
-  }
-
-  async * addAll (source: ImportCandidateStream, options: Partial<AddOptions> = {}): AsyncIterable<ImportResult> {
-    yield * addAll(source, this.components.blockstore, options)
-  }
-
-  async addBytes (bytes: Uint8Array, options: Partial<AddOptions> = {}): Promise<CID> {
-    return addBytes(bytes, this.components.blockstore, options)
-  }
-
-  async addByteStream (bytes: ByteStream, options: Partial<AddOptions> = {}): Promise<CID> {
-    return addByteStream(bytes, this.components.blockstore, options)
-  }
-
-  async addFile (file: FileCandidate, options: Partial<AddOptions> = {}): Promise<CID> {
-    return addFile(file, this.components.blockstore, options)
-  }
-
-  async addDirectory (dir: Partial<DirectoryCandidate> = {}, options: Partial<AddOptions> = {}): Promise<CID> {
-    return addDirectory(dir, this.components.blockstore, options)
-  }
-
-  async * cat (cid: CID, options: Partial<CatOptions> = {}): AsyncIterable<Uint8Array> {
-    yield * cat(cid, this.components.blockstore, options)
-  }
-
-  async chmod (cid: CID, mode: number, options: Partial<ChmodOptions> = {}): Promise<CID> {
-    return chmod(cid, mode, this.components.blockstore, options)
-  }
-
-  async cp (source: CID, target: CID, name: string, options: Partial<CpOptions> = {}): Promise<CID> {
-    return cp(source, target, name, this.components.blockstore, options)
-  }
-
-  async * ls (cid: CID, options: Partial<LsOptions> = {}): AsyncIterable<UnixFSEntry> {
-    yield * ls(cid, this.components.blockstore, options)
-  }
-
-  async mkdir (cid: CID, dirname: string, options: Partial<MkdirOptions> = {}): Promise<CID> {
-    return mkdir(cid, dirname, this.components.blockstore, options)
-  }
-
-  async rm (cid: CID, path: string, options: Partial<RmOptions> = {}): Promise<CID> {
-    return rm(cid, path, this.components.blockstore, options)
-  }
-
-  async stat (cid: CID, options: Partial<StatOptions> = {}): Promise<UnixFSStats> {
-    return stat(cid, this.components.blockstore, options)
-  }
-
-  async touch (cid: CID, options: Partial<TouchOptions> = {}): Promise<CID> {
-    return touch(cid, this.components.blockstore, options)
-  }
-}
-
 /**
  * Create a {@link UnixFS} instance for use with {@link https://github.com/ipfs/helia Helia}
  */
-export function unixfs (helia: { blockstore: Blockstore }): UnixFS {
-  return new DefaultUnixFS(helia)
+export function unixfs (helia: { blockstore: Pick<Blockstore, 'get' | 'put' | 'has'> }): UnixFS {
+  return new UnixFSClass(helia)
 }
 
 export { globSource } from './utils/glob-source.js'

--- a/packages/unixfs/src/unixfs.ts
+++ b/packages/unixfs/src/unixfs.ts
@@ -1,0 +1,78 @@
+import { addAll, addBytes, addByteStream, addDirectory, addFile } from './commands/add.js'
+import { cat } from './commands/cat.js'
+import { chmod } from './commands/chmod.js'
+import { cp } from './commands/cp.js'
+import { ls } from './commands/ls.js'
+import { mkdir } from './commands/mkdir.js'
+import { rm } from './commands/rm.js'
+import { stat } from './commands/stat.js'
+import { touch } from './commands/touch.js'
+import type { AddOptions, CatOptions, ChmodOptions, CpOptions, LsOptions, MkdirOptions, RmOptions, StatOptions, TouchOptions, UnixFSComponents, UnixFS as UnixFSInterface, UnixFSStats } from './index.js'
+import type { Blockstore } from 'interface-blockstore'
+import type { UnixFSEntry } from 'ipfs-unixfs-exporter'
+import type { ByteStream, DirectoryCandidate, FileCandidate, ImportCandidateStream, ImportResult } from 'ipfs-unixfs-importer'
+import type { CID } from 'multiformats/cid'
+
+export type PutStore = Pick<Blockstore, 'put'>
+export type GetStore = Pick<Blockstore, 'get'>
+export type HasStore = Pick<Blockstore, 'has'>
+
+export class UnixFS implements UnixFSInterface {
+  private readonly components: UnixFSComponents
+
+  constructor (components: UnixFSComponents) {
+    this.components = components
+  }
+
+  async * addAll (source: ImportCandidateStream, options: Partial<AddOptions> = {}): AsyncIterable<ImportResult> {
+    yield * addAll(source, this.components.blockstore, options)
+  }
+
+  async addBytes (bytes: Uint8Array, options: Partial<AddOptions> = {}): Promise<CID> {
+    return addBytes(bytes, this.components.blockstore, options)
+  }
+
+  async addByteStream (bytes: ByteStream, options: Partial<AddOptions> = {}): Promise<CID> {
+    return addByteStream(bytes, this.components.blockstore, options)
+  }
+
+  async addFile (file: FileCandidate, options: Partial<AddOptions> = {}): Promise<CID> {
+    return addFile(file, this.components.blockstore, options)
+  }
+
+  async addDirectory (dir: Partial<DirectoryCandidate> = {}, options: Partial<AddOptions> = {}): Promise<CID> {
+    return addDirectory(dir, this.components.blockstore, options)
+  }
+
+  async * cat (cid: CID, options: Partial<CatOptions> = {}): AsyncIterable<Uint8Array> {
+    yield * cat(cid, this.components.blockstore, options)
+  }
+
+  async chmod (cid: CID, mode: number, options: Partial<ChmodOptions> = {}): Promise<CID> {
+    return chmod(cid, mode, this.components.blockstore, options)
+  }
+
+  async cp (source: CID, target: CID, name: string, options: Partial<CpOptions> = {}): Promise<CID> {
+    return cp(source, target, name, this.components.blockstore, options)
+  }
+
+  async * ls (cid: CID, options: Partial<LsOptions> = {}): AsyncIterable<UnixFSEntry> {
+    yield * ls(cid, this.components.blockstore, options)
+  }
+
+  async mkdir (cid: CID, dirname: string, options: Partial<MkdirOptions> = {}): Promise<CID> {
+    return mkdir(cid, dirname, this.components.blockstore, options)
+  }
+
+  async rm (cid: CID, path: string, options: Partial<RmOptions> = {}): Promise<CID> {
+    return rm(cid, path, this.components.blockstore, options)
+  }
+
+  async stat (cid: CID, options: Partial<StatOptions> = {}): Promise<UnixFSStats> {
+    return stat(cid, this.components.blockstore, options)
+  }
+
+  async touch (cid: CID, options: Partial<TouchOptions> = {}): Promise<CID> {
+    return touch(cid, this.components.blockstore, options)
+  }
+}


### PR DESCRIPTION
We only use the get/put/has methods from the blockstore interface so pick those methods to allow easy use from other codebases.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
