### PR TITLE
fix: log peer id as string not object

### DIFF
--- a/packages/utils/src/routing.ts
+++ b/packages/utils/src/routing.ts
@@ -89,7 +89,7 @@ export class Routing implements RoutingInterface, Startable {
 
             return provider
           } catch (err) {
-            this.log.error('could not load multiaddrs for peer', peer.id, err)
+            this.log.error('could not load multiaddrs for peer %p', peer.id, err)
             return null
           }
         }, {
@@ -97,7 +97,7 @@ export class Routing implements RoutingInterface, Startable {
           signal: options.signal
         })
           .catch(err => {
-            this.log.error('could not load multiaddrs for peer', peer.id, err)
+            this.log.error('could not load multiaddrs for peer %p', peer.id, err)
           })
       }
 


### PR DESCRIPTION
So we aren't logging buffers etc, log the peer id as a string when lookup fails.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
