### PR TITLE
fix: do not append peer ids to provider multiaddrs

### DIFF
--- a/packages/utils/src/routing.ts
+++ b/packages/utils/src/routing.ts
@@ -64,14 +64,6 @@ export class Routing implements RoutingInterface, Startable {
         continue
       }
 
-      peer.multiaddrs = peer.multiaddrs.map(ma => {
-        if (ma.getPeerId() != null) {
-          return ma
-        }
-
-        return ma.encapsulate(`/p2p/${peer.id}`)
-      })
-
       // have to refresh peer info for this peer to get updated multiaddrs
       if (peer.multiaddrs.length === 0) {
         // already looking this peer up


### PR DESCRIPTION
When a routing returns a set of multiaddrs, honour them as returned instead of appending the peer id to them.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
