### PR TITLE
chore: use KeyType for key types

### DIFF
--- a/packages/interop/src/fixtures/key-types.ts
+++ b/packages/interop/src/fixtures/key-types.ts
@@ -1,6 +1,6 @@
-import type { PeerIdType } from '@libp2p/interface'
+import type { KeyType } from '@libp2p/interface'
 
-export const keyTypes: PeerIdType[] = [
+export const keyTypes: KeyType[] = [
   'Ed25519',
   'secp256k1',
   'RSA'


### PR DESCRIPTION
Instead of PeerIdType, use KeyType.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
