### PR TITLE
deps: update it-glob

### DIFF
--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -170,7 +170,7 @@
     "ipfs-unixfs-exporter": "^13.5.0",
     "ipfs-unixfs-importer": "^15.2.4",
     "it-all": "^3.0.4",
-    "it-glob": "^2.0.6",
+    "it-glob": "^3.0.0",
     "it-last": "^3.0.4",
     "it-pipe": "^3.0.1",
     "merge-options": "^3.0.4",

--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -190,7 +190,7 @@
     "wherearewe": "^2.0.1"
   },
   "browser": {
-    "./dist/src/utils/glob-source.js": false,
+    "./dist/src/utils/glob-source.js": "./dist/src/utils/glob-source.browser.js",
     "fs": false,
     "path": false,
     "url": false

--- a/packages/unixfs/src/utils/glob-source.browser.ts
+++ b/packages/unixfs/src/utils/glob-source.browser.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line require-yield
+export async function * globSource (): AsyncGenerator<any> {
+  throw new Error('Not supported in browsers')
+}

--- a/packages/unixfs/src/utils/glob-source.ts
+++ b/packages/unixfs/src/utils/glob-source.ts
@@ -1,5 +1,6 @@
-import fs from 'fs'
-import fsp from 'fs/promises'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
 import Path from 'path'
 import glob from 'it-glob'
 import { InvalidParametersError } from '../errors.js'
@@ -59,6 +60,10 @@ export async function * globSource (cwd: string, pattern: string, options: GlobS
     cwd = Path.resolve(process.cwd(), cwd)
   }
 
+  if (os.platform() === 'win32') {
+    cwd = toPosix(cwd)
+  }
+
   const globOptions: Options = {
     onlyFiles: false,
     absolute: true,
@@ -87,7 +92,7 @@ export async function * globSource (cwd: string, pattern: string, options: GlobS
     }
 
     yield {
-      path: toPosix(p.replace(cwd, '')),
+      path: p.replace(cwd, ''),
       content: stat.isFile() ? fs.createReadStream(p) : undefined,
       mode,
       mtime: toMtime(mtime)


### PR DESCRIPTION
Updates it-glob to use fast-glob for a speedup vs minimatch.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
