### PR TITLE
chore: increase record ttl in ipns test

### DIFF
--- a/packages/ipns/test/resolve.spec.ts
+++ b/packages/ipns/test/resolve.spec.ts
@@ -209,7 +209,7 @@ describe('resolve', () => {
 
     // create a record with a valid lifetime and a non-expired TTL
     const ipnsRecord = await create(key, cid, 1, Math.pow(2, 10), {
-      ttlNs: 10_000_000
+      ttlNs: 10_000_000_000
     })
     const dhtRecord = new Record(customRoutingKey, marshal(ipnsRecord), new Date(Date.now()))
 


### PR DESCRIPTION
Slow CI is slow so I think the TTL is expiring during the test leading to flaky CI.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
