### PR TITLE
fix!: trustless gateway brokers no longer take a gateways arg

### DIFF
--- a/packages/block-brokers/.aegir.js
+++ b/packages/block-brokers/.aegir.js
@@ -4,7 +4,7 @@ import polka from 'polka'
 /** @type {import('aegir').PartialOptions} */
 const options = {
   test: {
-    async before (options) {
+    async before () {
       const goodGateway = polka({
         port: 0,
         host: '127.0.0.1'


### PR DESCRIPTION
The trustless gateway block broker should be used with a http gateway router which will supply a default set of gateways in a way usable by other consumers of the Helia routing.

This was mistakenly released in `@helia/block-brokers@2.1.2` which has been reverted, this PR will cause `@helia/block-brokers@3.0.0` to be released.

Before:

```js
import { createHelia } from 'helia'
import { trustlessGateway } from '@helia/block-brokers'
import { delegatedHTTPRouting } from '@helia/routers'

await createHelia({
  blockBrokers: [
    trustlessGateway({
      gateways: [
        'http://example.com'
      ]
    })
  ],
  routers: [
    delegatedHTTPRouting('https://delegated-ipfs.dev')
  ],
  //... other settings
})
```

After:

```js
import { createHelia } from 'helia'
import { trustlessGateway } from '@helia/block-brokers'
import { delegatedHTTPRouting, httpGatewayRouting } from '@helia/routers'

await createHelia({
  blockBrokers: [
    trustlessGateway()
  ],
  routers: [
    delegatedHTTPRouting('https://delegated-ipfs.dev'),
    httpGatewayRouting({
      gateways: [
        'http://example.com'
      ]
    })
  ],
  //... other settings
})
```

BREAKING CHANGE: the gateways init option has been removed from trustless gateway block brokers

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
