### PR TITLE
fix: type error

### DIFF
--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -81,7 +81,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
     // this queue manages outgoing requests - as new peers are added to the
     // session they will be added to the queue so we can request the current
     // block from multiple peers as they are discovered
-    const queue = new Queue<Uint8Array, { provider: Provider, priority?: number }>({
+    const queue = new Queue<Uint8Array, { provider: Provider, priority?: number } & AbortOptions>({
       concurrency: this.maxProviders
     })
     queue.addEventListener('error', () => {})


### PR DESCRIPTION
Fixes an issue on queue generic: `Type '{ provider: Provider; priority?: number | undefined; }' has no properties in common with type 'AbortOptions'.ts(2559)`


## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
