### PR TITLE
fix: do not depend on external domains in dnslink tests

### DIFF
--- a/packages/interop/src/ipns-dnslink.spec.ts
+++ b/packages/interop/src/ipns-dnslink.spec.ts
@@ -7,17 +7,9 @@ import type { IPNS } from '@helia/ipns'
 import type { HeliaLibp2p } from 'helia'
 
 const TEST_DOMAINS: string[] = [
-  'ipfs.io',
+  'ipfs.tech',
   'docs.ipfs.tech',
-  'en.wikipedia-on-ipfs.org',
-  'blog.libp2p.io',
-  'consensuslab.world',
-  'n0.computer',
-  'protocol.ai',
-  'research.protocol.ai',
-  'probelab.io',
-  'singularity.storage',
-  'saturn.tech'
+  'en.wikipedia-on-ipfs.org'
 ]
 
 describe('@helia/ipns - dnslink', () => {


### PR DESCRIPTION
Dependency on third-party domains means  that over time CI will break, like it did in
https://github.com/ipfs/kubo/actions/runs/9214249430/job/25364989609?pr=10429#step:9:63

```
Error: queryCname ENODATA singularity.storage
```

The three domains I left are stable and under IPFS Foundation / Shipyard control.

Ideally, CI would not depend on internet DNS, and have static fixtures and custom localhost DNS server, but this PR should be good enough to stop breaking CI on other project's PRs like https://github.com/ipfs/kubo/pull/10429


<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
