### PR TITLE
fix: docs/example

### DIFF
--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -45,12 +45,12 @@ const helia = await createHelia()
 const name = ipns(helia)
 
 // create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
+const keyInfo = await helia.libp2p.services.keychain.createKey('my-key', 'RSA', 4096)
 const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
 
 // store some data to publish
 const fs = unixfs(helia)
-const cid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // publish the name
 await name.publish(peerId, cid)
@@ -75,18 +75,18 @@ const helia = await createHelia()
 const name = ipns(helia)
 
 // create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
+const keyInfo = await helia.libp2p.services.keychain.createKey('my-key', 'RSA', 4096)
 const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
 
 // store some data to publish
 const fs = unixfs(helia)
-const cid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // publish the name
 await name.publish(peerId, cid)
 
 // create another public key to re-publish the original record
-const recursiveKeyInfo = await helia.libp2p.services.keychain.createKey('my-recursive-key')
+const recursiveKeyInfo = await helia.libp2p.services.keychain.createKey('my-recursive-key', 'RSA', 4096)
 const recursivePeerId = await helia.libp2p.services.keychain.exportPeerId(recursiveKeyInfo.name)
 
 // publish the recursive name
@@ -110,12 +110,12 @@ const helia = await createHelia()
 const name = ipns(helia)
 
 // create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
+const keyInfo = await helia.libp2p.services.keychain.createKey('my-key', 'RSA', 4096)
 const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
 
 // store some data to publish
 const fs = unixfs(helia)
-const fileCid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const fileCid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // store the file in a directory
 const dirCid = await fs.mkdir()
@@ -166,12 +166,12 @@ const name = ipns(helia, {
 })
 
 // create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
+const keyInfo = await helia.libp2p.services.keychain.createKey('my-key', 'RSA', 4096)
 const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
 
 // store some data to publish
 const fs = unixfs(helia)
-const cid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // publish the name
 await name.publish(peerId, cid)


### PR DESCRIPTION
fs.add is not a function
"Invalid key type" key type must be specified

https://github.com/libp2p/js-libp2p/blob/main/packages/keychain/src/keychain.ts#L157

## fix: docs/example

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

## Description

Two function calls need to be modified for the examples to work.

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

## Notes & open questions

I will try to write tests that prove the issues

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
