### PR TITLE
fix: update circuit relay server args

### DIFF
--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -88,9 +88,7 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
       }),
       keychain: keychain(options.keychain),
       ping: ping(),
-      relay: circuitRelayServer({
-        advertise: true
-      }),
+      relay: circuitRelayServer(),
       upnp: uPnPNAT()
     }
   }


### PR DESCRIPTION
Circuit relay servers no longer advertise themselves.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
