### PR TITLE
docs: fix grammar - it's -> its

### DIFF
--- a/packages/bitswap/README.md
+++ b/packages/bitswap/README.md
@@ -34,7 +34,7 @@ $ npm i @helia/bitswap
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaBitswap` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaBitswap` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/bitswap/dist/index.min.js"></script>

--- a/packages/block-brokers/README.md
+++ b/packages/block-brokers/README.md
@@ -21,7 +21,7 @@ $ npm i @helia/block-brokers
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaBlockBrokers` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaBlockBrokers` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/block-brokers/dist/index.min.js"></script>

--- a/packages/car/README.md
+++ b/packages/car/README.md
@@ -94,7 +94,7 @@ $ npm i @helia/car
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaCar` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaCar` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/car/dist/index.min.js"></script>

--- a/packages/dag-cbor/README.md
+++ b/packages/dag-cbor/README.md
@@ -59,7 +59,7 @@ $ npm i @helia/dag-cbor
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaDagCbor` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaDagCbor` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/dag-cbor/dist/index.min.js"></script>

--- a/packages/dag-json/README.md
+++ b/packages/dag-json/README.md
@@ -59,7 +59,7 @@ $ npm i @helia/dag-json
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaDagJson` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaDagJson` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/dag-json/dist/index.min.js"></script>

--- a/packages/helia/README.md
+++ b/packages/helia/README.md
@@ -55,7 +55,7 @@ $ npm i helia
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `Helia` in the global namespace.
+Loading this module through a script tag will make its exports available as `Helia` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/helia/dist/index.min.js"></script>

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -81,7 +81,7 @@ $ npm i @helia/http
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaHttp` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaHttp` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/http/dist/index.min.js"></script>

--- a/packages/interface/src/blocks.ts
+++ b/packages/interface/src/blocks.ts
@@ -84,7 +84,7 @@ export interface BlockRetrievalOptions <ProgressEvents extends ProgressEvent<any
   /**
    * A function that blockBrokers should call prior to returning a block to ensure it can maintain control
    * of the block request flow. e.g. TrustedGatewayBlockBroker will use this to ensure that the block
-   * is valid from one of the gateways before assuming it's work is done. If the block is not valid, it should try another gateway
+   * is valid from one of the gateways before assuming its work is done. If the block is not valid, it should try another gateway
    * and WILL consider the gateway that returned the invalid blocks completely unreliable.
    */
   validateFn?(block: Uint8Array): Promise<void>

--- a/packages/interop/README.md
+++ b/packages/interop/README.md
@@ -32,7 +32,7 @@ $ npm i @helia/interop
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaInterop` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaInterop` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/interop/dist/index.min.js"></script>

--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -263,7 +263,7 @@ $ npm i @helia/ipns
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaIpns` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaIpns` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/ipns/dist/index.min.js"></script>

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -59,7 +59,7 @@ $ npm i @helia/json
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaJson` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaJson` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/json/dist/index.min.js"></script>

--- a/packages/mfs/README.md
+++ b/packages/mfs/README.md
@@ -65,7 +65,7 @@ $ npm i @helia/mfs
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaMfs` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaMfs` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/mfs/dist/index.min.js"></script>

--- a/packages/routers/README.md
+++ b/packages/routers/README.md
@@ -40,7 +40,7 @@ $ npm i @helia/routers
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaRouters` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaRouters` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/routers/dist/index.min.js"></script>

--- a/packages/strings/README.md
+++ b/packages/strings/README.md
@@ -57,7 +57,7 @@ $ npm i @helia/strings
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaStrings` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaStrings` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/strings/dist/index.min.js"></script>

--- a/packages/unixfs/README.md
+++ b/packages/unixfs/README.md
@@ -79,7 +79,7 @@ $ npm i @helia/unixfs
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaUnixfs` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaUnixfs` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/unixfs/dist/index.min.js"></script>

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -53,7 +53,7 @@ $ npm i @helia/utils
 
 ## Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `HeliaUtils` in the global namespace.
+Loading this module through a script tag will make its exports available as `HeliaUtils` in the global namespace.
 
 ```html
 <script src="https://unpkg.com/@helia/utils/dist/index.min.js"></script>


### PR DESCRIPTION
## Title

Fix grammar: it's -> its

## Description

A few places use "it's" (= it is), when they should use the possessive "its" (the dog and its ball).

## Notes & open questions

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
