### PR TITLE
fix: update js-libp2p types

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -65,7 +65,7 @@ export interface HeliaInit<T extends Libp2p = Libp2p> extends HeliaClassInit {
    * The libp2p `start` option is not supported, instead please pass `start` in
    * the root of the HeliaInit object.
    */
-  libp2p?: T | Omit<Libp2pOptions, 'start'>
+  libp2p?: T | Omit<Libp2pOptions<any>, 'start'>
 
   /**
    * Pass `false` to not start the Helia node

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -31,7 +31,7 @@ export interface DefaultLibp2pServices extends Record<string, unknown> {
   ping: PingService
 }
 
-export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> {
+export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> & Required<Pick<Libp2pOptions<DefaultLibp2pServices>, 'services'>> {
   const agentVersion = `${name}/${version} ${libp2pInfo.name}/${libp2pInfo.version} UserAgent=${globalThis.navigator.userAgent}`
 
   return {

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -35,7 +35,7 @@ export interface DefaultLibp2pServices extends Record<string, unknown> {
   upnp: unknown
 }
 
-export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> {
+export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> & Required<Pick<Libp2pOptions<DefaultLibp2pServices>, 'services'>> {
   const agentVersion = `${name}/${version} ${libp2pInfo.name}/${libp2pInfo.version} UserAgent=${process.version}`
 
   return {

--- a/packages/helia/test/libp2p.spec.ts
+++ b/packages/helia/test/libp2p.spec.ts
@@ -25,6 +25,8 @@ describe('libp2p', () => {
 
   it('allows overriding libp2p config', async () => {
     const config = {
+      addresses: {},
+      transports: [],
       services: {}
     }
 

--- a/packages/interop/src/fixtures/create-helia.browser.ts
+++ b/packages/interop/src/fixtures/create-helia.browser.ts
@@ -52,8 +52,11 @@ export async function createHeliaNode (libp2pOptions?: Libp2pOptions): Promise<H
   defaults.peerDiscovery = []
 
   // remove services that are not used in tests
+  // @ts-expect-error services.autoNAT is not optional
   delete defaults.services.autoNAT
+  // @ts-expect-error services.dcutr is not optional
   delete defaults.services.dcutr
+  // @ts-expect-error services.delegatedRouting is not optional
   delete defaults.services.delegatedRouting
 
   return createHelia<Libp2p<DefaultLibp2pServices>>({

--- a/packages/interop/src/fixtures/create-helia.ts
+++ b/packages/interop/src/fixtures/create-helia.ts
@@ -39,8 +39,11 @@ export async function createHeliaNode (libp2pOptions?: Libp2pOptions): Promise<H
   defaults.peerDiscovery = []
 
   // remove services that are not used in tests
+  // @ts-expect-error services.autoNAT is not optional
   delete defaults.services.autoNAT
+  // @ts-expect-error services.dcutr is not optional
   delete defaults.services.dcutr
+  // @ts-expect-error services.delegatedRouting is not optional
   delete defaults.services.delegatedRouting
 
   return createHelia<Libp2p<DefaultLibp2pServices>>({


### PR DESCRIPTION
After the last js-libp2p release, tsc now decides that the service factory map has a type and libp2p itself is better at detecting invalid configurations so we need to be stricter about how we create libp2p options.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
