### PR TITLE
fix: Adjust filtering logic for secure contexts; improve tests

### DIFF
--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -20,6 +20,12 @@ export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure:
 
       return isPrivateIp(ma.toOptions().host) === false
     }
+    
+    // When allowInsecure is false and allowLocal is true, allow multiaddrs with "127.0.0.1", "localhost", or any subdomain ending with ".localhost"
+    if (!allowInsecure && allowLocal) {
+      if (ma.toOptions().host === '127.0.0.1' || ma.toOptions().host === 'localhost' || ma.toOptions().host.endsWith('.localhost'))
+        return true
+    }
 
     return false
   })

--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -20,11 +20,12 @@ export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure:
 
       return isPrivateIp(ma.toOptions().host) === false
     }
-    
+
     // When allowInsecure is false and allowLocal is true, allow multiaddrs with "127.0.0.1", "localhost", or any subdomain ending with ".localhost"
     if (!allowInsecure && allowLocal) {
-      if (ma.toOptions().host === '127.0.0.1' || ma.toOptions().host === 'localhost' || ma.toOptions().host.endsWith('.localhost'))
+      if (ma.toOptions().host === '127.0.0.1' || ma.toOptions().host === 'localhost' || ma.toOptions().host.endsWith('.localhost')) {
         return true
+      }
     }
 
     return false

--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -23,7 +23,8 @@ export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure:
 
     // When allowInsecure is false and allowLocal is true, allow multiaddrs with "127.0.0.1", "localhost", or any subdomain ending with ".localhost"
     if (!allowInsecure && allowLocal) {
-      if (ma.toOptions().host === '127.0.0.1' || ma.toOptions().host === 'localhost' || ma.toOptions().host.endsWith('.localhost')) {
+      const { host } = ma.toOptions()
+      if (host === '127.0.0.1' || host === 'localhost' || host.endsWith('.localhost')) {
         return true
       }
     }

--- a/packages/block-brokers/test/trustless-gateway-utils.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-utils.spec.ts
@@ -27,4 +27,28 @@ describe('trustless-gateway-block-broker-utils', () => {
 
     expect(filtered.length).to.deep.equal(0)
   })
+
+  it('filterNonHTTPMultiaddrs allows 127.0.0.1 when allowInsecure=false', async function () {
+    const localMaddr = uriToMultiaddr('http://127.0.0.1')
+
+    const filtered = filterNonHTTPMultiaddrs([localMaddr], false, true)
+
+    expect(filtered.length).to.deep.equal(1)
+  })
+
+  it('filterNonHTTPMultiaddrs allows localhost when allowInsecure=false', async function () {
+    const localMaddr = uriToMultiaddr('http://localhost')
+
+    const filtered = filterNonHTTPMultiaddrs([localMaddr], false, true)
+
+    expect(filtered.length).to.deep.equal(1)
+  })
+
+  it('filterNonHTTPMultiaddrs allows *.localhost when allowInsecure=false', async function () {
+    const localMaddr = uriToMultiaddr('http://example.localhost')
+
+    const filtered = filterNonHTTPMultiaddrs([localMaddr], false, true)
+
+    expect(filtered.length).to.deep.equal(1)
+  })
 })


### PR DESCRIPTION
## Title
fix: Update filtering logic to respect secure contexts and enhance related tests

## Description
This PR addresses issue #564 by modifying the multiaddr filtering logic in the trustless-gateway module to ensure that allowInsecure: false respects Secure Contexts.

## Changes Made:
IP Address Filtering:
Modified the filter to ensure that when allowInsecure is false, a multiaddr with "127.0.0.1" as the IP address will still be considered valid. This addresses the need to handle secure contexts properly even when allowInsecure is disabled.
Domain Filtering:
Adjusted the filter to ensure that when allowInsecure is false, a multiaddr with "localhost" as the domain will be treated as valid.
Updated the filter to handle domains with a parent domain of "localhost", such as example.localhost, foobar.localhost, and *.localhost.
```javascript
// When allowInsecure is false and allowLocal is true, allow multiaddrs with "127.0.0.1", "localhost", or any subdomain ending with ".localhost"
    if (!allowInsecure && allowLocal) {
      if (ma.toOptions().host === '127.0.0.1' || ma.toOptions().host === 'localhost' || ma.toOptions().host.endsWith('.localhost'))
        return true
    }
```


## Tests Added:
Added tests to verify that the changes work as intended:
IP Address Test: Ensures that "127.0.0.1" is treated correctly when allowInsecure is false.
Domain Test: Verifies that "localhost" and parent domains of "localhost" are handled correctly when allowInsecure is false.
Related: [GitHub Issue #564](https://github.com/ipfs/helia/issues/564)
```javascript

  it('filterNonHTTPMultiaddrs allows 127.0.0.1 when allowInsecure=false', async function () {
    const localMaddr = uriToMultiaddr('http://127.0.0.1')

    const filtered = filterNonHTTPMultiaddrs([localMaddr], false, true)

    expect(filtered.length).to.deep.equal(1)
  })

  it('filterNonHTTPMultiaddrs allows localhost when allowInsecure=false', async function () {
    const localMaddr = uriToMultiaddr('http://localhost')

    const filtered = filterNonHTTPMultiaddrs([localMaddr], false, true)

    expect(filtered.length).to.deep.equal(1)
  })

  it('filterNonHTTPMultiaddrs allows *.localhost when allowInsecure=false', async function () {
    const localMaddr = uriToMultiaddr('http://example.localhost')

    const filtered = filterNonHTTPMultiaddrs([localMaddr], false, true)

    expect(filtered.length).to.deep.equal(1)
  })
```


## Notes & open questions
None at the moment. The changes have been tested and are working as expected.


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works