### PR TITLE
test: add test that shows directory stats are not correct

### DIFF
--- a/packages/unixfs/test/stat.spec.ts
+++ b/packages/unixfs/test/stat.spec.ts
@@ -135,7 +135,7 @@ describe('stat', function () {
     })
   })
 
-  it('should stat a directory', async function () {
+  it('should sstat a directory', async function () {
     await expect(fs.stat(emptyDirCid)).to.eventually.include({
       type: 'directory',
       blocks: 1,

--- a/packages/unixfs/test/stat.spec.ts
+++ b/packages/unixfs/test/stat.spec.ts
@@ -135,7 +135,7 @@ describe('stat', function () {
     })
   })
 
-  it('should sstat a directory', async function () {
+  it('should stat a directory', async function () {
     await expect(fs.stat(emptyDirCid)).to.eventually.include({
       type: 'directory',
       blocks: 1,
@@ -175,7 +175,7 @@ describe('stat', function () {
     })
   })
 
-  it('stats a sharded directory', async function () {
+  it('sstats a sharded directory', async function () {
     const mtime = {
       secs: 5n,
       nsecs: 0

--- a/packages/unixfs/test/stat.spec.ts
+++ b/packages/unixfs/test/stat.spec.ts
@@ -94,6 +94,20 @@ describe('stat', function () {
     })
   })
 
+  it('stats a directory with content', async () => {
+    const emptyDirCid = await fs.addDirectory()
+    const fileCid = await fs.addBytes(Buffer.from("Hello World!"))
+    const updateDirCid = await fs.cp(fileCid, emptyDirCid, 'foo1.txt')
+    const finalDirCid = await fs.cp(fileCid, updateDirCid, 'foo2.txt')
+
+    await expect(fs.stat(finalDirCid)).to.eventually.include({
+      fileSize: 0n,
+      dagSize: 134n,
+      blocks: 2,
+      type: 'directory'
+    })
+  })
+
   it('should stat file with mode', async () => {
     const mode = 0o644
     const cid = await fs.addFile({
@@ -161,7 +175,7 @@ describe('stat', function () {
     })
   })
 
-  it('sstats a sharded directory', async function () {
+  it('stats a sharded directory', async function () {
     const mtime = {
       secs: 5n,
       nsecs: 0


### PR DESCRIPTION
## Title

test: add test that shows directory stats are not correct

## Description

This PR is in progress, because the test is not yet passing.  Changes need to be made to inspect the DAG of a directory to resolve the correct values.

Related https://github.com/ipfs/helia/issues/580

## Notes & open questions

Will likely need assistance with ensuring correct values are consistently returned in testing.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [X] I have added tests that prove my fix is effective or that my feature works
