### PR TITLE
fix: bitswap check err.name in peer-want-lists/ledger

### DIFF
--- a/packages/bitswap/src/peer-want-lists/ledger.ts
+++ b/packages/bitswap/src/peer-want-lists/ledger.ts
@@ -125,7 +125,10 @@ export class Ledger {
           })
         }
       } catch (err: any) {
-        if (err.code !== 'ERR_NOT_FOUND') {
+        if (
+          (err.code !== undefined && err.code !== 'ERR_NOT_FOUND') ||
+          (err.name !== undefined && err.name !== 'NotFoundError')
+        ) {
           throw err
         }
 


### PR DESCRIPTION
## Description

Was hitting a weird edge case where `err.code` is not set. Adding an additional check for `err.name` fixes the issue.

I was only hitting the edge case with 3+ nodes using MemoryDatastore, 2 nodes seemed fine.


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
