### PR TITLE
fix: add doc-check script and export types used by functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 package-lock.json
 yarn.lock
 .vscode
+.tmp-compiled-docs
+tsconfig-doc-check.aegir.json

--- a/benchmarks/add-dir/package.json
+++ b/benchmarks/add-dir/package.json
@@ -9,6 +9,7 @@
     "build": "aegir build --bundle false",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "start": "npm run build && node dist/src/index.js"
   },
   "dependencies": {

--- a/benchmarks/gc/package.json
+++ b/benchmarks/gc/package.json
@@ -7,6 +7,7 @@
     "build": "aegir build --bundle false",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "start": "npm run build && node dist/src/index.js"
   },
   "dependencies": {

--- a/benchmarks/pinning/package.json
+++ b/benchmarks/pinning/package.json
@@ -7,6 +7,7 @@
     "build": "aegir build --bundle false",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "start": "npm run build && node dist/src/index.js"
   },
   "dependencies": {

--- a/benchmarks/transfer/package.json
+++ b/benchmarks/transfer/package.json
@@ -9,6 +9,7 @@
     "build": "aegir build --bundle false",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "start": "npm run build && node dist/src/index.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "aegir run build",
     "lint": "aegir run lint",
     "dep-check": "aegir run dep-check",
+    "doc-check": "aegir run doc-check",
     "release": "run-s build docs:no-publish npm:release docs",
     "npm:release": "aegir exec --bail false npm -- publish",
     "release:rc": "aegir release-rc",

--- a/packages/bitswap/src/index.ts
+++ b/packages/bitswap/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { Bitswap as BitswapClass } from './bitswap.js'
-import type { BitswapNetworkNotifyProgressEvents, BitswapNetworkWantProgressEvents } from './network.js'
+import type { BitswapNetworkNotifyProgressEvents, BitswapNetworkWantProgressEvents, BitswapNetworkProgressEvents } from './network.js'
 import type { WantType } from './pb/message.js'
 import type { BlockBroker, CreateSessionOptions } from '@helia/interface'
 import type { Routing } from '@helia/interface/routing'
@@ -27,6 +27,11 @@ export type BitswapWantBlockProgressEvents =
   ProgressEvent<'bitswap:want-block:unwant', CID> |
   ProgressEvent<'bitswap:want-block:block', CID> |
   BitswapNetworkWantProgressEvents
+
+export type { BitswapNetworkNotifyProgressEvents }
+export type { BitswapNetworkWantProgressEvents }
+export type { BitswapNetworkProgressEvents }
+export type { WantType }
 
 export interface WantListEntry {
   cid: CID

--- a/packages/block-brokers/package.json
+++ b/packages/block-brokers/package.json
@@ -43,6 +43,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/block-brokers/src/bitswap.ts
+++ b/packages/block-brokers/src/bitswap.ts
@@ -6,7 +6,7 @@ import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
 
-interface BitswapComponents {
+export interface BitswapBlockBrokerComponents {
   libp2p: Libp2p
   blockstore: Blockstore
   routing: Routing
@@ -14,7 +14,7 @@ interface BitswapComponents {
   getHasher: HasherLoader
 }
 
-export interface BitswapInit extends BitswapOptions {
+export interface BitswapBlockBrokerInit extends BitswapOptions {
 
 }
 
@@ -22,7 +22,7 @@ class BitswapBlockBroker implements BlockBroker<BitswapWantBlockProgressEvents, 
   private readonly bitswap: Bitswap
   private started: boolean
 
-  constructor (components: BitswapComponents, init: BitswapInit = {}) {
+  constructor (components: BitswapBlockBrokerComponents, init: BitswapBlockBrokerInit = {}) {
     const { getHasher } = components
 
     this.bitswap = createBitswap(components, {
@@ -77,6 +77,6 @@ class BitswapBlockBroker implements BlockBroker<BitswapWantBlockProgressEvents, 
  * A helper factory for users who want to override Helia `blockBrokers` but
  * still want to use the default `BitswapBlockBroker`.
  */
-export function bitswap (init: BitswapInit = {}): (components: BitswapComponents) => BlockBroker {
+export function bitswap (init: BitswapBlockBrokerInit = {}): (components: BitswapBlockBrokerComponents) => BlockBroker {
   return (components) => new BitswapBlockBroker(components, init)
 }

--- a/packages/block-brokers/src/index.ts
+++ b/packages/block-brokers/src/index.ts
@@ -1,2 +1,4 @@
 export { bitswap } from './bitswap.js'
+export type { BitswapBlockBrokerInit, BitswapBlockBrokerComponents } from './bitswap.js'
 export { trustlessGateway } from './trustless-gateway/index.js'
+export type { TrustlessGatewayBlockBrokerInit, TrustlessGatewayBlockBrokerComponents, TrustlessGatewayGetBlockProgressEvents } from './trustless-gateway/index.js'

--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -1,7 +1,7 @@
 import { createTrustlessGatewaySession } from './session.js'
 import { findHttpGatewayProviders } from './utils.js'
 import { DEFAULT_ALLOW_INSECURE, DEFAULT_ALLOW_LOCAL } from './index.js'
-import type { TrustlessGatewayBlockBrokerInit, TrustlessGatewayComponents, TrustlessGatewayGetBlockProgressEvents } from './index.js'
+import type { TrustlessGatewayBlockBrokerInit, TrustlessGatewayBlockBrokerComponents, TrustlessGatewayGetBlockProgressEvents } from './index.js'
 import type { Routing, BlockRetrievalOptions, BlockBroker, CreateSessionOptions } from '@helia/interface'
 import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
@@ -35,7 +35,7 @@ export class TrustlessGatewayBlockBroker implements BlockBroker<TrustlessGateway
   private readonly log: Logger
   private readonly logger: ComponentLogger
 
-  constructor (components: TrustlessGatewayComponents, init: TrustlessGatewayBlockBrokerInit = {}) {
+  constructor (components: TrustlessGatewayBlockBrokerComponents, init: TrustlessGatewayBlockBrokerInit = {}) {
     this.log = components.logger.forComponent('helia:trustless-gateway-block-broker')
     this.logger = components.logger
     this.routing = components.routing

--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -27,11 +27,11 @@ export interface TrustlessGatewayBlockBrokerInit {
   allowLocal?: boolean
 }
 
-export interface TrustlessGatewayComponents {
+export interface TrustlessGatewayBlockBrokerComponents {
   routing: Routing
   logger: ComponentLogger
 }
 
-export function trustlessGateway (init: TrustlessGatewayBlockBrokerInit = {}): (components: TrustlessGatewayComponents) => BlockBroker<TrustlessGatewayGetBlockProgressEvents> {
+export function trustlessGateway (init: TrustlessGatewayBlockBrokerInit = {}): (components: TrustlessGatewayBlockBrokerComponents) => BlockBroker<TrustlessGatewayGetBlockProgressEvents> {
   return (components) => new TrustlessGatewayBlockBroker(components, init)
 }

--- a/packages/car/README.md
+++ b/packages/car/README.md
@@ -46,13 +46,13 @@ import { CarWriter } from '@ipld/car'
 import { Readable } from 'node:stream'
 import nodeFs from 'node:fs'
 
-const helia = createHelia({
+const helia = await createHelia({
   // ... helia config
 })
 const fs = unixfs(helia)
 
 // add some UnixFS data
-const cid = await fs.addBytes(fileData1)
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // export it as a Car
 const c = car(helia)
@@ -75,7 +75,7 @@ import { CarReader } from '@ipld/car'
 import { Readable } from 'node:stream'
 import nodeFs from 'node:fs'
 
-const helia = createHelia({
+const helia = await createHelia({
   // ... helia config
 })
 
@@ -83,6 +83,7 @@ const helia = createHelia({
 const inStream = nodeFs.createReadStream('example.car')
 const reader = await CarReader.fromIterable(inStream)
 
+const c = car(helia)
 await c.import(reader)
 ```
 

--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -128,6 +128,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -17,13 +17,13 @@
  * import { Readable } from 'node:stream'
  * import nodeFs from 'node:fs'
  *
- * const helia = createHelia({
+ * const helia = await createHelia({
  *   // ... helia config
  * })
  * const fs = unixfs(helia)
  *
  * // add some UnixFS data
- * const cid = await fs.addBytes(fileData1)
+ * const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
  *
  * // export it as a Car
  * const c = car(helia)
@@ -46,7 +46,7 @@
  * import { Readable } from 'node:stream'
  * import nodeFs from 'node:fs'
  *
- * const helia = createHelia({
+ * const helia = await createHelia({
  *   // ... helia config
  * })
  *
@@ -54,6 +54,7 @@
  * const inStream = nodeFs.createReadStream('example.car')
  * const reader = await CarReader.fromIterable(inStream)
  *
+ * const c = car(helia)
  * await c.import(reader)
  * ```
  */

--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -79,7 +79,7 @@ export interface CarComponents {
   getCodec: CodecLoader
 }
 
-interface ExportCarOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents> {
+export interface ExportCarOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents> {
   /**
    * If a filter is passed it will be used to deduplicate blocks exported in the car file
    */

--- a/packages/dag-cbor/README.md
+++ b/packages/dag-cbor/README.md
@@ -41,8 +41,10 @@ import { createHelia } from 'helia'
 import { dagCbor } from '@helia/dag-cbor'
 import { CID } from 'multiformats/cid'
 
+const helia = await createHelia()
+
 const d = dagCbor(helia)
-const cid = await d.put({
+const cid = await d.add({
   hello: 'world'
 })
 const obj = await d.get(cid)

--- a/packages/dag-cbor/package.json
+++ b/packages/dag-cbor/package.json
@@ -128,6 +128,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "docs": "aegir docs",
     "test": "aegir test",

--- a/packages/dag-cbor/src/index.ts
+++ b/packages/dag-cbor/src/index.ts
@@ -12,8 +12,10 @@
  * import { dagCbor } from '@helia/dag-cbor'
  * import { CID } from 'multiformats/cid'
  *
+ * const helia = await createHelia()
+ *
  * const d = dagCbor(helia)
- * const cid = await d.put({
+ * const cid = await d.add({
  *   hello: 'world'
  * })
  * const obj = await d.get(cid)
@@ -75,8 +77,11 @@ export interface DAGCBOR {
    * @example
    *
    * ```typescript
+   * import { createHelia } from 'helia'
    * import { dagCbor } from '@helia/dag-cbor'
    * import { CID } from 'multiformats/cid'
+   *
+   * const helia = await createHelia()
    *
    * const d = dagCbor(helia)
    * const cid = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')

--- a/packages/dag-json/README.md
+++ b/packages/dag-json/README.md
@@ -38,11 +38,13 @@ See the DAGJSON interface for all available operations.
 
 ```typescript
 import { createHelia } from 'helia'
-import { json } from '@helia/dag-json'
+import { dagJson } from '@helia/dag-json'
 import { CID } from 'multiformats/cid'
 
-const j = json(helia)
-const cid = await j.put({
+const helia = await createHelia()
+const j = dagJson(helia)
+
+const cid = await j.add({
   hello: 'world'
 })
 const obj = await j.get(cid)

--- a/packages/dag-json/package.json
+++ b/packages/dag-json/package.json
@@ -128,6 +128,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/dag-json/src/index.ts
+++ b/packages/dag-json/src/index.ts
@@ -9,11 +9,13 @@
  *
  * ```typescript
  * import { createHelia } from 'helia'
- * import { json } from '@helia/dag-json'
+ * import { dagJson } from '@helia/dag-json'
  * import { CID } from 'multiformats/cid'
  *
- * const j = json(helia)
- * const cid = await j.put({
+ * const helia = await createHelia()
+ * const j = dagJson(helia)
+ *
+ * const cid = await j.add({
  *   hello: 'world'
  * })
  * const obj = await j.get(cid)
@@ -57,9 +59,12 @@ export interface DAGJSON {
    * @example
    *
    * ```typescript
-   * import { json } from '@helia/dag-json'
+   * import { createHelia } from 'helia'
+   * import { dagJson } from '@helia/dag-json'
    *
-   * const j = json(helia)
+   * const helia = await createHelia()
+   * const j = dagJson(helia)
+   *
    * const cid = await str.add({ hello: 'world' })
    *
    * console.info(cid)
@@ -75,10 +80,13 @@ export interface DAGJSON {
    * @example
    *
    * ```typescript
-   * import { json } from '@helia/dag-json'
+   * import { createHelia } from 'helia'
+   * import { dagJson } from '@helia/dag-json'
    * import { CID } from 'multiformats/cid'
    *
-   * const j = json(helia)
+   * const helia = await createHelia()
+   * const j = dagJson(helia)
+   *
    * const cid = CID.parse('baguqeerasords4njcts6vs7qvdjfcvgnume4hqohf65zsfguprqphs3icwea')
    * const obj = await j.get(cid)
    *

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -43,6 +43,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -27,6 +27,7 @@ import { HeliaP2P } from './helia-p2p.js'
 import { libp2pDefaults } from './utils/libp2p-defaults.js'
 import { createLibp2p } from './utils/libp2p.js'
 import type { DefaultLibp2pServices } from './utils/libp2p-defaults.js'
+import type { Libp2pDefaultsOptions } from './utils/libp2p.js'
 import type { Helia } from '@helia/interface'
 import type { HeliaInit as HeliaClassInit } from '@helia/utils'
 import type { Libp2p } from '@libp2p/interface'
@@ -38,7 +39,7 @@ import type { CID } from 'multiformats/cid'
 // if they don't want to
 export * from '@helia/interface'
 
-export type { DefaultLibp2pServices }
+export type { DefaultLibp2pServices, Libp2pDefaultsOptions }
 export { libp2pDefaults }
 
 /**

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -54,18 +54,19 @@ fs.cat(CID.parse('bafyFoo'))
 ```typescript
 import { createHeliaHTTP } from '@helia/http'
 import { trustlessGateway } from '@helia/block-brokers'
-import { delegatedHTTPRouting } from '@helia/routers'
+import { delegatedHTTPRouting, httpGatewayRouting } from '@helia/routers'
 import { unixfs } from '@helia/unixfs'
 import { CID } from 'multiformats/cid'
 
 const helia = await createHeliaHTTP({
   blockBrokers: [
-    trustlessGateway({
-      gateways: ['https://cloudflare-ipfs.com', 'https://ipfs.io'],
-    }),
+    trustlessGateway()
   ],
   routers: [
-    delegatedHTTPRouting('https://delegated-ipfs.dev')
+    delegatedHTTPRouting('https://delegated-ipfs.dev'),
+    httpGatewayRouting({
+      gateways: ['https://cloudflare-ipfs.com', 'https://ipfs.io']
+    })
   ]
 })
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -43,6 +43,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -23,18 +23,19 @@
  * ```typescript
  * import { createHeliaHTTP } from '@helia/http'
  * import { trustlessGateway } from '@helia/block-brokers'
- * import { delegatedHTTPRouting } from '@helia/routers'
+ * import { delegatedHTTPRouting, httpGatewayRouting } from '@helia/routers'
  * import { unixfs } from '@helia/unixfs'
  * import { CID } from 'multiformats/cid'
  *
  * const helia = await createHeliaHTTP({
  *   blockBrokers: [
- *     trustlessGateway({
- *       gateways: ['https://cloudflare-ipfs.com', 'https://ipfs.io'],
- *     }),
+ *     trustlessGateway()
  *   ],
  *   routers: [
- *     delegatedHTTPRouting('https://delegated-ipfs.dev')
+ *     delegatedHTTPRouting('https://delegated-ipfs.dev'),
+ *     httpGatewayRouting({
+ *       gateways: ['https://cloudflare-ipfs.com', 'https://ipfs.io']
+ *     })
  *   ]
  * })
  *

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -67,6 +67,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build"
   },
   "dependencies": {

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -47,6 +47,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/ipns/CHANGELOG.md
+++ b/packages/ipns/CHANGELOG.md
@@ -174,41 +174,6 @@
 
 * alters the options object passed to the `ipns` factory function
 
-#### Before
-
-```typescript
-import { createHelia } from 'helia'
-import { ipns } from '@helia/ipns'
-import { dht, pubsub } from '@helia/ipns/routing'
-import { unixfs } from '@helia/unixfs'
-
-const helia = await createHelia()
-const name = ipns(helia, [
-  dht(helia),
-  pubsub(helia)
-])
-```
-
-#### After
-
-```typescript
-import { createHelia } from 'helia'
-import { ipns } from '@helia/ipns'
-import { dnsOverHttps } from '@helia/ipns/dns-resolvers'
-import { unixfs } from '@helia/unixfs'
-
-const helia = await createHelia()
-const name = ipns(helia, {
-  routers: [
-    dht(helia),
-    pubsub(helia)
-  ],
-  resolvers: [
-    dnsOverHttps('https://private-dns-server.me/dns-query'),
-  ]
-})
-```
-
 ### Features
 
 * support DNS over HTTPS and DNS-JSON over HTTPS ([#55](https://github.com/ipfs/helia-ipns/issues/55)) ([2ac0e8b](https://github.com/ipfs/helia/commit/2ac0e8b26556b73961e67191c564ac2b18d32b31))

--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -183,7 +183,7 @@ const result = await name.resolve(privateKey.publicKey)
 
 ## Example - Using custom DNS over HTTPS resolvers
 
-With default DNSResolver resolvers:
+To use custom resolvers, configure Helia's `dns` option:
 
 ```TypeScript
 import { createHelia } from 'helia'

--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -40,23 +40,23 @@ With IPNSRouting routers:
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
 import { unixfs } from '@helia/unixfs'
+import { generateKeyPair } from '@libp2p/crypto/keys'
 
 const helia = await createHelia()
 const name = ipns(helia)
 
-// create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
-const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
+// create a keypair to publish an IPNS name
+const privateKey = await generateKeyPair('Ed25519')
 
 // store some data to publish
 const fs = unixfs(helia)
-const cid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // publish the name
-await name.publish(peerId, cid)
+await name.publish(privateKey, cid)
 
 // resolve the name
-const result = name.resolve(peerId)
+const result = await name.resolve(privateKey.publicKey)
 
 console.info(result.cid, result.path)
 ```
@@ -70,30 +70,29 @@ value.
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
 import { unixfs } from '@helia/unixfs'
+import { generateKeyPair } from '@libp2p/crypto/keys'
 
 const helia = await createHelia()
 const name = ipns(helia)
 
-// create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
-const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
+// create a keypair to publish an IPNS name
+const privateKey = await generateKeyPair('Ed25519')
 
 // store some data to publish
 const fs = unixfs(helia)
-const cid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // publish the name
-await name.publish(peerId, cid)
+await name.publish(privateKey, cid)
 
-// create another public key to re-publish the original record
-const recursiveKeyInfo = await helia.libp2p.services.keychain.createKey('my-recursive-key')
-const recursivePeerId = await helia.libp2p.services.keychain.exportPeerId(recursiveKeyInfo.name)
+// create another keypair to re-publish the original record
+const recursivePrivateKey = await generateKeyPair('Ed25519')
 
 // publish the recursive name
-await name.publish(recursivePeerId, peerId)
+await name.publish(recursivePrivateKey, privateKey.publicKey)
 
 // resolve the name recursively - it resolves until a CID is found
-const result = name.resolve(recursivePeerId)
+const result = await name.resolve(recursivePrivateKey.publicKey)
 console.info(result.cid.toString() === cid.toString()) // true
 ```
 
@@ -105,27 +104,27 @@ It is possible to publish CIDs with an associated path.
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
 import { unixfs } from '@helia/unixfs'
+import { generateKeyPair } from '@libp2p/crypto/keys'
 
 const helia = await createHelia()
 const name = ipns(helia)
 
-// create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
-const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
+// create a keypair to publish an IPNS name
+const privateKey = await generateKeyPair('Ed25519')
 
 // store some data to publish
 const fs = unixfs(helia)
-const fileCid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const fileCid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // store the file in a directory
-const dirCid = await fs.mkdir()
+const dirCid = await fs.addDirectory()
 const finalDirCid = await fs.cp(fileCid, dirCid, '/foo.txt')
 
 // publish the name
-await name.publish(peerId, `/ipfs/${finalDirCid}/foo.txt)
+await name.publish(privateKey, `/ipfs/${finalDirCid}/foo.txt`)
 
 // resolve the name
-const result = name.resolve(peerId)
+const result = await name.resolve(privateKey.publicKey)
 
 console.info(result.cid, result.path) // QmFoo.. 'foo.txt'
 ```
@@ -152,11 +151,14 @@ import { ipns } from '@helia/ipns'
 import { pubsub } from '@helia/ipns/routing'
 import { unixfs } from '@helia/unixfs'
 import { gossipsub } from '@chainsafe/libp2p-gossipsub'
+import { generateKeyPair } from '@libp2p/crypto/keys'
+import type { Libp2p, PubSub } from '@libp2p/interface'
+import type { DefaultLibp2pServices } from 'helia'
 
 const libp2pOptions = libp2pDefaults()
 libp2pOptions.services.pubsub = gossipsub()
 
-const helia = await createHelia({
+const helia = await createHelia<Libp2p<DefaultLibp2pServices & { pubsub: PubSub }>>({
   libp2p: libp2pOptions
 })
 const name = ipns(helia, {
@@ -165,19 +167,18 @@ const name = ipns(helia, {
  ]
 })
 
-// create a public key to publish as an IPNS name
-const keyInfo = await helia.libp2p.services.keychain.createKey('my-key')
-const peerId = await helia.libp2p.services.keychain.exportPeerId(keyInfo.name)
+// create a keypair to publish an IPNS name
+const privateKey = await generateKeyPair('Ed25519')
 
 // store some data to publish
 const fs = unixfs(helia)
-const cid = await fs.add(Uint8Array.from([0, 1, 2, 3, 4]))
+const cid = await fs.addBytes(Uint8Array.from([0, 1, 2, 3, 4]))
 
 // publish the name
-await name.publish(peerId, cid)
+await name.publish(privateKey, cid)
 
 // resolve the name
-const { cid, path } = name.resolve(peerId)
+const result = await name.resolve(privateKey.publicKey)
 ```
 
 ## Example - Using custom DNS over HTTPS resolvers
@@ -187,22 +188,29 @@ With default DNSResolver resolvers:
 ```TypeScript
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
-import { unixfs } from '@helia/unixfs'
-import { dnsOverHttps } from '@helia/ipns/dns-resolvers'
+import { dns } from '@multiformats/dns'
+import { dnsOverHttps } from '@multiformats/dns/resolvers'
+import { helia } from '@helia/ipns/routing'
 
-const helia = await createHelia()
-const name = ipns(helia, {
- resolvers: [
-   dnsOverHttps('https://private-dns-server.me/dns-query'),
+const node = await createHelia({
+  dns: dns({
+    resolvers: {
+      '.': dnsOverHttps('https://private-dns-server.me/dns-query')
+    }
+  })
+})
+const name = ipns(node, {
+ routers: [
+   helia(node.routing)
  ]
 })
 
-const { cid, path } = name.resolveDns('some-domain-with-dnslink-entry.com')
+const result = name.resolveDNSLink('some-domain-with-dnslink-entry.com')
 ```
 
 ## Example - Resolving a domain with a dnslink entry
 
-Calling `resolveDns` with the `@helia/ipns` instance:
+Calling `resolveDNSLink` with the `@helia/ipns` instance:
 
 ```TypeScript
 // resolve a CID from a TXT record in a DNS zone file, using the default
@@ -214,10 +222,16 @@ Calling `resolveDns` with the `@helia/ipns` instance:
 // ;; ANSWER SECTION:
 // _dnslink.website.ipfs.io.  60     IN      TXT     "dnslink=/ipfs/QmWebsite"
 
-const { cid, path } = name.resolveDns('ipfs.io')
+import { createHelia } from 'helia'
+import { ipns } from '@helia/ipns'
 
-console.info(cid)
-// QmWebsite
+const node = await createHelia()
+const name = ipns(node)
+
+const { answer } = await name.resolveDNSLink('ipfs.io')
+
+console.info(answer)
+// { data: '/ipfs/QmWebsite' }
 ```
 
 ## Example - Using DNS-Over-HTTPS
@@ -229,14 +243,21 @@ response which can increase browser bundle sizes.
 If this is a concern, use the DNS-JSON-Over-HTTPS resolver instead.
 
 ```TypeScript
-// use DNS-Over-HTTPS
-import { dnsOverHttps } from '@helia/ipns/dns-resolvers'
+import { createHelia } from 'helia'
+import { ipns } from '@helia/ipns'
+import { dns } from '@multiformats/dns'
+import { dnsOverHttps } from '@multiformats/dns/resolvers'
 
-const { cid, path } = name.resolveDns('ipfs.io', {
-  resolvers: [
-    dnsOverHttps('https://mozilla.cloudflare-dns.com/dns-query')
-  ]
+const node = await createHelia({
+  dns: dns({
+    resolvers: {
+      '.': dnsOverHttps('https://mozilla.cloudflare-dns.com/dns-query')
+    }
+  })
 })
+const name = ipns(node)
+
+const result = await name.resolveDNSLink('ipfs.io')
 ```
 
 ## Example - Using DNS-JSON-Over-HTTPS
@@ -245,14 +266,21 @@ DNS-JSON-Over-HTTPS resolvers use the RFC 8427 `application/dns-json` and can
 result in a smaller browser bundle due to the response being plain JSON.
 
 ```TypeScript
-// use DNS-JSON-Over-HTTPS
-import { dnsJsonOverHttps } from '@helia/ipns/dns-resolvers'
+import { createHelia } from 'helia'
+import { ipns } from '@helia/ipns'
+import { dns } from '@multiformats/dns'
+import { dnsJsonOverHttps } from '@multiformats/dns/resolvers'
 
-const { cid, path } = name.resolveDns('ipfs.io', {
-  resolvers: [
-    dnsJsonOverHttps('https://mozilla.cloudflare-dns.com/dns-query')
-  ]
+const node = await createHelia({
+  dns: dns({
+    resolvers: {
+      '.': dnsJsonOverHttps('https://mozilla.cloudflare-dns.com/dns-query')
+    }
+  })
 })
+const name = ipns(node)
+
+const result = await name.resolveDNSLink('ipfs.io')
 ```
 
 # Install

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -152,6 +152,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "docs": "aegir docs",
     "test": "aegir test",

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -154,7 +154,7 @@
  *
  * @example Using custom DNS over HTTPS resolvers
  *
- * With default {@link DNSResolver} resolvers:
+ * To use custom resolvers, configure Helia's `dns` option:
  *
  * ```TypeScript
  * import { createHelia } from 'helia'

--- a/packages/ipns/src/routing/index.ts
+++ b/packages/ipns/src/routing/index.ts
@@ -22,6 +22,10 @@ export interface IPNSRouting {
   get(routingKey: Uint8Array, options?: GetOptions): Promise<Uint8Array>
 }
 
+export type { DatastoreProgressEvents }
+export type { HeliaRoutingProgressEvents }
+export type { PubSubProgressEvents }
+
 export type IPNSRoutingEvents =
   DatastoreProgressEvents |
   HeliaRoutingProgressEvents |
@@ -29,3 +33,4 @@ export type IPNSRoutingEvents =
 
 export { helia } from './helia.js'
 export { pubsub } from './pubsub.js'
+export type { PubsubRoutingComponents } from './pubsub.js'

--- a/packages/ipns/typedoc.json
+++ b/packages/ipns/typedoc.json
@@ -1,7 +1,6 @@
 {
   "entryPoints": [
     "./src/index.ts",
-    "./src/dns-resolvers/index.ts",
     "./src/routing/index.ts"
   ]
 }

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -41,8 +41,10 @@ import { createHelia } from 'helia'
 import { json } from '@helia/json'
 import { CID } from 'multiformats/cid'
 
+const helia = await createHelia()
 const j = json(helia)
-const cid = await j.put({
+
+const cid = await j.add({
   hello: 'world'
 })
 const obj = await j.get(cid)

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -128,6 +128,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -12,8 +12,10 @@
  * import { json } from '@helia/json'
  * import { CID } from 'multiformats/cid'
  *
+ * const helia = await createHelia()
  * const j = json(helia)
- * const cid = await j.put({
+ *
+ * const cid = await j.add({
  *   hello: 'world'
  * })
  * const obj = await j.get(cid)
@@ -57,9 +59,12 @@ export interface JSON {
    * @example
    *
    * ```typescript
+   * import { createHelia } from 'helia'
    * import { json } from '@helia/json'
    *
+   * const helia = await createHelia()
    * const j = json(helia)
+   *
    * const cid = await str.add({ hello: 'world' })
    *
    * console.info(cid)
@@ -75,10 +80,13 @@ export interface JSON {
    * @example
    *
    * ```typescript
+   * import { createHelia } from 'helia'
    * import { json } from '@helia/json'
    * import { CID } from 'multiformats/cid'
    *
+   * const helia = await createHelia()
    * const j = json(helia)
+   *
    * const cid = CID.parse('bagaaierasords4njcts6vs7qvdjfcvgnume4hqohf65zsfguprqphs3icwea')
    * const obj = await j.get(cid)
    *

--- a/packages/mfs/README.md
+++ b/packages/mfs/README.md
@@ -40,9 +40,7 @@ See the [API docs](https://ipfs.github.io/helia/modules/_helia_mfs.html) for all
 import { createHelia } from 'helia'
 import { mfs } from '@helia/mfs'
 
-const helia = createHelia({
-  // ... helia config
-})
+const helia = await createHelia()
 const fs = mfs(helia)
 
 // create an empty directory

--- a/packages/mfs/package.json
+++ b/packages/mfs/package.json
@@ -128,6 +128,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/mfs/src/index.ts
+++ b/packages/mfs/src/index.ts
@@ -11,9 +11,7 @@
  * import { createHelia } from 'helia'
  * import { mfs } from '@helia/mfs'
  *
- * const helia = createHelia({
- *   // ... helia config
- * })
+ * const helia = await createHelia()
  * const fs = mfs(helia)
  *
  * // create an empty directory

--- a/packages/routers/package.json
+++ b/packages/routers/package.json
@@ -43,6 +43,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/routers/src/index.ts
+++ b/packages/routers/src/index.ts
@@ -5,4 +5,5 @@
  */
 export { delegatedHTTPRouting } from './delegated-http-routing.js'
 export { httpGatewayRouting } from './http-gateway-routing.js'
+export type { HTTPGatwayRouterInit } from './http-gateway-routing.js'
 export { libp2pRouting } from './libp2p-routing.js'

--- a/packages/strings/README.md
+++ b/packages/strings/README.md
@@ -41,8 +41,9 @@ import { createHelia } from 'helia'
 import { strings } from '@helia/strings'
 import { CID } from 'multiformats/cid'
 
+const helia = await createHelia()
 const str = strings(helia)
-const cid = await str.put('hello world')
+const cid = await str.add('hello world')
 const string = await str.get(cid)
 
 console.info(string)

--- a/packages/strings/package.json
+++ b/packages/strings/package.json
@@ -129,6 +129,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "docs": "aegir docs",
     "test": "aegir test",

--- a/packages/strings/src/index.ts
+++ b/packages/strings/src/index.ts
@@ -12,8 +12,9 @@
  * import { strings } from '@helia/strings'
  * import { CID } from 'multiformats/cid'
  *
+ * const helia = await createHelia()
  * const str = strings(helia)
- * const cid = await str.put('hello world')
+ * const cid = await str.add('hello world')
  * const string = await str.get(cid)
  *
  * console.info(string)
@@ -58,8 +59,10 @@ export interface Strings {
    * @example
    *
    * ```typescript
+   * import { createHelia } from 'helia'
    * import { strings } from '@helia/strings'
    *
+   * const helia = wait createHelia()
    * const str = strings(helia)
    * const cid = await str.add('hello world')
    *
@@ -76,9 +79,11 @@ export interface Strings {
    * @example
    *
    * ```typescript
+   * import { createHelia } from 'helia'
    * import { strings } from '@helia/strings'
    * import { CID } from 'multiformats/cid'
    *
+   * const helia = await createHelia()
    * const str = strings(helia)
    * const cid = CID.parse('bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e')
    * const string = await str.get(cid)

--- a/packages/unixfs/README.md
+++ b/packages/unixfs/README.md
@@ -40,9 +40,7 @@ See the [API docs](https://ipfs.github.io/helia/modules/_helia_unixfs.html) for 
 import { createHelia } from 'helia'
 import { unixfs } from '@helia/unixfs'
 
-const helia = createHelia({
-  // ... helia config
-})
+const helia = await createHelia()
 const fs = unixfs(helia)
 
 // create an empty dir and a file, then add the file to the dir
@@ -64,7 +62,12 @@ for await (const entry of fs.addAll([{
 Node.js-compatibly environments only:
 
 ```typescript
+import { createHelia } from 'helia'
+import { unixfs } from '@helia/unixfs'
 import { globSource } from '@helia/unixfs'
+
+const helia = await createHelia()
+const fs = unixfs(helia)
 
 for await (const entry of fs.addAll(globSource('path/to/containing/dir', 'glob-pattern'))) {
   console.info(entry)

--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -148,6 +148,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/unixfs/src/index.ts
+++ b/packages/unixfs/src/index.ts
@@ -11,9 +11,7 @@
  * import { createHelia } from 'helia'
  * import { unixfs } from '@helia/unixfs'
  *
- * const helia = createHelia({
- *   // ... helia config
- * })
+ * const helia = await createHelia()
  * const fs = unixfs(helia)
  *
  * // create an empty dir and a file, then add the file to the dir
@@ -35,7 +33,12 @@
  * Node.js-compatibly environments only:
  *
  * ```typescript
+ * import { createHelia } from 'helia'
+ * import { unixfs } from '@helia/unixfs'
  * import { globSource } from '@helia/unixfs'
+ *
+ * const helia = await createHelia()
+ * const fs = unixfs(helia)
  *
  * for await (const entry of fs.addAll(globSource('path/to/containing/dir', 'glob-pattern'))) {
  *   console.info(entry)

--- a/packages/unixfs/src/index.ts
+++ b/packages/unixfs/src/index.ts
@@ -557,4 +557,5 @@ export function unixfs (helia: { blockstore: Pick<Blockstore, 'get' | 'put' | 'h
 }
 
 export { globSource } from './utils/glob-source.js'
+export type { GlobSourceResult, GlobSourceOptions } from './utils/glob-source.js'
 export { urlSource } from './utils/url-source.js'

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -30,7 +30,7 @@ repo and examine the changes made.
 
 -->
 
-Exports a `Helia` class that implements the HeliaInterface API.
+Exports a `Helia` class that implements the Helia API.
 
 In general you should use the `helia` or `@helia/http` modules instead which
 pre-configure Helia for certain use-cases (p2p or pure-HTTP).

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -39,10 +39,11 @@ pre-configure Helia for certain use-cases (p2p or pure-HTTP).
 
 ```typescript
 import { Helia } from '@helia/utils'
+import type { HeliaInit } from '@helia/utils'
 
 const node = new Helia({
   // ...options
-})
+} as HeliaInit)
 ```
 
 # Install

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,6 +43,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check",
+    "doc-check": "aegir doc-check",
     "build": "aegir build",
     "test": "aegir test",
     "test:chrome": "aegir test -t browser --cov",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,10 +10,11 @@
  *
  * ```typescript
  * import { Helia } from '@helia/utils'
+ * import type { HeliaInit } from '@helia/utils'
  *
  * const node = new Helia({
  *   // ...options
- * })
+ * } as HeliaInit)
  * ```
  */
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @packageDocumentation
  *
- * Exports a `Helia` class that implements the {@link HeliaInterface} API.
+ * Exports a `Helia` class that implements the Helia API.
  *
  * In general you should use the `helia` or `@helia/http` modules instead which
  * pre-configure Helia for certain use-cases (p2p or pure-HTTP).
@@ -30,6 +30,7 @@ import { assertDatastoreVersionIsCurrent } from './utils/datastore-version.js'
 import { getCodec } from './utils/get-codec.js'
 import { getHasher } from './utils/get-hasher.js'
 import { NetworkedStorage } from './utils/networked-storage.js'
+import type { BlockStorageInit } from './storage.js'
 import type { Await, CodecLoader, GCOptions, HasherLoader, Helia as HeliaInterface, Routing } from '@helia/interface'
 import type { BlockBroker } from '@helia/interface/blocks'
 import type { Pins } from '@helia/interface/pins'
@@ -41,8 +42,12 @@ import type { BlockCodec } from 'multiformats'
 import type { CID } from 'multiformats/cid'
 import type { MultihashHasher } from 'multiformats/hashes/interface'
 
-export { AbstractSession, type AbstractCreateSessionOptions } from './abstract-session.js'
+export { AbstractSession } from './abstract-session.js'
+export type { AbstractCreateSessionOptions, BlockstoreSessionEvents, AbstractSessionComponents } from './abstract-session.js'
 export { BloomFilter } from './bloom-filter.js'
+export type { BloomFilterOptions } from './bloom-filter.js'
+
+export type { BlockStorage, BlockStorageInit }
 
 /**
  * Options used to create a Helia node.


### PR DESCRIPTION
Uses tsc to attempt to compile any `typescript` code blocks in markdown files to ensure our examples don't get out of date.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
