### PR TITLE
fix!: define string metadata type

### DIFF
--- a/packages/interface/src/pins.ts
+++ b/packages/interface/src/pins.ts
@@ -8,7 +8,7 @@ export type PinType = 'recursive' | 'direct' | 'indirect'
 export interface Pin {
   cid: CID
   depth: number
-  metadata: Record<string, any>
+  metadata: Record<string, string | number | boolean>
 }
 
 export type AddPinEvents =


### PR DESCRIPTION
The record values are added as `string | number | boolean` so reflect that in the listed type.

BREAKING CHANGE: the metadata record value field has changed from `any` to `string | number | boolean`

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
