### PR TITLE
chore: simplify return type of libp2p defaults

### DIFF
--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -31,7 +31,7 @@ export interface DefaultLibp2pServices extends Record<string, unknown> {
   ping: PingService
 }
 
-export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> & Required<Pick<Libp2pOptions<DefaultLibp2pServices>, 'services'>> {
+export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> {
   const agentVersion = `${name}/${version} ${libp2pInfo.name}/${libp2pInfo.version} UserAgent=${globalThis.navigator.userAgent}`
 
   return {

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -36,7 +36,7 @@ export interface DefaultLibp2pServices extends Record<string, unknown> {
   upnp: unknown
 }
 
-export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> & Required<Pick<Libp2pOptions<DefaultLibp2pServices>, 'services'>> {
+export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOptions<DefaultLibp2pServices> {
   const agentVersion = `${name}/${version} ${libp2pInfo.name}/${libp2pInfo.version} UserAgent=${process.version}`
 
   return {


### PR DESCRIPTION
## What's in this PR

Investigate if we can simplify the default config type for easier customisation.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
