### PR TITLE
fix: respect routers config in helia factory

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -121,7 +121,7 @@ export async function createHelia (init: Partial<HeliaInit> = {}): Promise<Helia
       trustlessGateway(),
       bitswap()
     ],
-    routers: [
+    routers: init.routers ?? [
       libp2pRouting(libp2p),
       httpGatewayRouting()
     ],


### PR DESCRIPTION
## What's in this PR
- take the passed routers config in createHelia into acount


This PR allows overriding the routers configuration when customising Helia. Useful when you want to exclusively fetch directly from peers without relying on recursive gateways.

## Relevant context

In `@helia/http` we already do this:
https://github.com/ipfs/helia/blob/332580c4dd1646381bfeedd7741e52bc3a364301/packages/http/src/index.ts#L79-L82
