### PR TITLE
fix: add tls to default delegated routing filters

### DIFF
--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -65,7 +65,7 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
       dcutr: dcutr(),
       delegatedRouting: () => createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev', {
         filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-        filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss']
+        filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss', 'tls']
       }),
       dht: kadDHT({
         clientMode: true,

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -1,6 +1,7 @@
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
+import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults.js'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
@@ -63,10 +64,7 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
     services: {
       autoNAT: autoNAT(),
       dcutr: dcutr(),
-      delegatedRouting: () => createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev', {
-        filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-        filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss', 'tls']
-      }),
+      delegatedRouting: () => createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev', delegatedHTTPRoutingDefaults()),
       dht: kadDHT({
         clientMode: true,
         validators: {

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -1,7 +1,7 @@
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
-import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults'
+import { delegatedHTTPRoutingDefaults } from '@helia/routers'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -1,7 +1,7 @@
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
-import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults.js'
+import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -74,7 +74,7 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
       dcutr: dcutr(),
       delegatedRouting: () => createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev', {
         filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-        filterAddrs: ['https', 'tcp', 'webrtc', 'webrtc-direct', 'wss']
+        filterAddrs: ['https', 'tcp', 'webrtc', 'webrtc-direct', 'wss', 'tls']
       }),
       dht: kadDHT({
         validators: {

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -1,6 +1,7 @@
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
+import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults.js'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from '@libp2p/circuit-relay-v2'
@@ -72,10 +73,7 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
     services: {
       autoNAT: autoNAT(),
       dcutr: dcutr(),
-      delegatedRouting: () => createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev', {
-        filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-        filterAddrs: ['https', 'tcp', 'webrtc', 'webrtc-direct', 'wss', 'tls']
-      }),
+      delegatedRouting: () => createDelegatedRoutingV1HttpApiClient('https://delegated-ipfs.dev', delegatedHTTPRoutingDefaults()),
       dht: kadDHT({
         validators: {
           ipns: ipnsValidator

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -1,7 +1,7 @@
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
-import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults'
+import { delegatedHTTPRoutingDefaults } from '@helia/routers'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from '@libp2p/circuit-relay-v2'

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -1,7 +1,7 @@
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { createDelegatedRoutingV1HttpApiClient } from '@helia/delegated-routing-v1-http-api-client'
-import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults.js'
+import { delegatedHTTPRoutingDefaults } from '@helia/routers/src/utils/delegated-http-routing-defaults'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { circuitRelayTransport, circuitRelayServer, type CircuitRelayService } from '@libp2p/circuit-relay-v2'

--- a/packages/routers/src/index.ts
+++ b/packages/routers/src/index.ts
@@ -4,6 +4,7 @@
  * Abstraction layer over different content and peer routing mechanisms.
  */
 export { delegatedHTTPRouting } from './delegated-http-routing.js'
+export { delegatedHTTPRoutingDefaults } from './utils/delegated-http-routing-defaults'
 export { httpGatewayRouting } from './http-gateway-routing.js'
 export type { HTTPGatwayRouterInit } from './http-gateway-routing.js'
 export { libp2pRouting } from './libp2p-routing.js'

--- a/packages/routers/src/index.ts
+++ b/packages/routers/src/index.ts
@@ -4,7 +4,7 @@
  * Abstraction layer over different content and peer routing mechanisms.
  */
 export { delegatedHTTPRouting } from './delegated-http-routing.js'
-export { delegatedHTTPRoutingDefaults } from './utils/delegated-http-routing-defaults'
+export { delegatedHTTPRoutingDefaults } from './utils/delegated-http-routing-defaults.js'
 export { httpGatewayRouting } from './http-gateway-routing.js'
 export type { HTTPGatwayRouterInit } from './http-gateway-routing.js'
 export { libp2pRouting } from './libp2p-routing.js'

--- a/packages/routers/src/utils/delegated-http-routing-defaults.browser.ts
+++ b/packages/routers/src/utils/delegated-http-routing-defaults.browser.ts
@@ -3,6 +3,6 @@ import type { DelegatedRoutingV1HttpApiClientInit } from '@helia/delegated-routi
 export function delegatedHTTPRoutingDefaults (): DelegatedRoutingV1HttpApiClientInit {
   return {
     filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-    filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss']
+    filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss', 'tls']
   }
 }

--- a/packages/routers/src/utils/delegated-http-routing-defaults.ts
+++ b/packages/routers/src/utils/delegated-http-routing-defaults.ts
@@ -3,6 +3,6 @@ import type { DelegatedRoutingV1HttpApiClientInit } from '@helia/delegated-routi
 export function delegatedHTTPRoutingDefaults (): DelegatedRoutingV1HttpApiClientInit {
   return {
     filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-    filterAddrs: ['https', 'tcp', 'webrtc', 'webrtc-direct', 'wss']
+    filterAddrs: ['https', 'tcp', 'webrtc', 'webrtc-direct', 'wss', 'tls']
   }
 }


### PR DESCRIPTION
## Description

- **fix: add tls to all default filters**
- **chore: avoid duplication of filters**

## Notes & open questions

Should we just move these defaults to the [Delegated Routing client](https://github.com/ipfs/helia-delegated-routing-v1-http-api/blob/main/packages/client/src/client.ts#L26)? 

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
