### PR TITLE
fix: remove webtransport from default transports

### DIFF
--- a/benchmarks/transports/package.json
+++ b/benchmarks/transports/package.json
@@ -25,7 +25,6 @@
     "@libp2p/tcp": "^10.0.0",
     "@libp2p/webrtc": "^5.0.0",
     "@libp2p/websockets": "^9.0.0",
-    "@libp2p/webtransport": "^5.0.0",
     "@multiformats/multiaddr": "^12.2.1",
     "aegir": "^45.0.1",
     "blockstore-fs": "^2.0.1",

--- a/benchmarks/transports/src/runner/helia/transports.browser.ts
+++ b/benchmarks/transports/src/runner/helia/transports.browser.ts
@@ -2,7 +2,6 @@ import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
 import { webRTC } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
 import * as wsFilters from '@libp2p/websockets/filters'
-import { webTransport } from '@libp2p/webtransport'
 import type { Transport } from '@libp2p/interface'
 
 interface TransportFactory { (...args: any[]): Transport }
@@ -13,7 +12,6 @@ export function getTransports (): TransportFactory[] {
       filter: wsFilters.all
     }),
     webRTC(),
-    circuitRelayTransport(),
-    webTransport()
+    circuitRelayTransport()
   ]
 }

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -80,7 +80,6 @@
     "@libp2p/upnp-nat": "^2.0.0",
     "@libp2p/webrtc": "^5.0.0",
     "@libp2p/websockets": "^9.0.0",
-    "@libp2p/webtransport": "^5.0.0",
     "@multiformats/dns": "^1.0.1",
     "blockstore-core": "^5.0.0",
     "datastore-core": "^10.0.0",

--- a/packages/helia/src/utils/libp2p-defaults.browser.ts
+++ b/packages/helia/src/utils/libp2p-defaults.browser.ts
@@ -13,7 +13,6 @@ import { mplex } from '@libp2p/mplex'
 import { ping, type PingService } from '@libp2p/ping'
 import { webRTC, webRTCDirect } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
-import { webTransport } from '@libp2p/webtransport'
 import { ipnsSelector } from 'ipns/selector'
 import { ipnsValidator } from 'ipns/validator'
 import * as libp2pInfo from 'libp2p/version'
@@ -48,7 +47,6 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
       circuitRelayTransport(),
       webRTC(),
       webRTCDirect(),
-      webTransport(),
       webSockets()
     ],
     connectionEncrypters: [


### PR DESCRIPTION
## Description

WebTransport is still working reliably across different browsers. Moreover, the go-libp2p implementation needs to be updated to meet newer revisions of the spec. 

As we discussed during Helia WG, the most sensible thing for now is to remove WebTransport from the default transports.

Related to https://github.com/libp2p/js-libp2p/issues/2572


## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
