### PR TITLE
feat: add method tracing to routing

### DIFF
--- a/packages/interface/src/routing.ts
+++ b/packages/interface/src/routing.ts
@@ -1,4 +1,4 @@
-import type { AbortOptions, PeerId, PeerInfo } from '@libp2p/interface'
+import type { AbortOptions, PeerId, PeerInfo, TraceOptions } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
 import type { ProgressOptions } from 'progress-events'
 
@@ -8,7 +8,7 @@ import type { ProgressOptions } from 'progress-events'
  * local cache that may be used in preference over network calls, for example
  * when a record has a TTL.
  */
-export interface RoutingOptions extends AbortOptions, ProgressOptions {
+export interface RoutingOptions extends AbortOptions, ProgressOptions, TraceOptions {
   /**
    * Pass `false` to not use the network
    *

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -58,7 +58,7 @@
     "@ipld/dag-cbor": "^9.2.2",
     "@ipld/dag-json": "^10.2.3",
     "@ipld/dag-pb": "^4.1.3",
-    "@libp2p/interface": "^2.2.1",
+    "@libp2p/interface": "^2.4.0",
     "@libp2p/logger": "^5.1.4",
     "@libp2p/utils": "^6.2.1",
     "@multiformats/dns": "^1.0.6",

--- a/packages/utils/src/routing.ts
+++ b/packages/utils/src/routing.ts
@@ -3,7 +3,7 @@ import { NotFoundError, start, stop } from '@libp2p/interface'
 import { PeerQueue } from '@libp2p/utils/peer-queue'
 import merge from 'it-merge'
 import type { Routing as RoutingInterface, Provider, RoutingOptions } from '@helia/interface'
-import type { AbortOptions, ComponentLogger, Logger, PeerId, PeerInfo, Startable } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, Logger, Metrics, PeerId, PeerInfo, Startable } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
 
 const DEFAULT_PROVIDER_LOOKUP_CONCURRENCY = 5
@@ -15,6 +15,7 @@ export interface RoutingInit {
 
 export interface RoutingComponents {
   logger: ComponentLogger
+  metrics?: Metrics
 }
 
 export class Routing implements RoutingInterface, Startable {
@@ -26,6 +27,28 @@ export class Routing implements RoutingInterface, Startable {
     this.log = components.logger.forComponent('helia:routing')
     this.routers = init.routers ?? []
     this.providerLookupConcurrency = init.providerLookupConcurrency ?? DEFAULT_PROVIDER_LOOKUP_CONCURRENCY
+
+    this.findProviders = components.metrics?.traceFunction('helia.routing.findProviders', this.findProviders.bind(this), {
+      optionsIndex: 1
+    }) ?? this.findProviders
+    this.provide = components.metrics?.traceFunction('helia.routing.provide', this.provide.bind(this), {
+      optionsIndex: 1
+    }) ?? this.provide
+    this.cancelReprovide = components.metrics?.traceFunction('helia.routing.cancelReprovide', this.cancelReprovide.bind(this), {
+      optionsIndex: 1
+    }) ?? this.cancelReprovide
+    this.put = components.metrics?.traceFunction('helia.routing.put', this.put.bind(this), {
+      optionsIndex: 2
+    }) ?? this.put
+    this.get = components.metrics?.traceFunction('helia.routing.get', this.get.bind(this), {
+      optionsIndex: 1
+    }) ?? this.get
+    this.findPeer = components.metrics?.traceFunction('helia.routing.findPeer', this.findPeer.bind(this), {
+      optionsIndex: 1
+    }) ?? this.findPeer
+    this.getClosestPeers = components.metrics?.traceFunction('helia.routing.getClosestPeers', this.getClosestPeers.bind(this), {
+      optionsIndex: 1
+    }) ?? this.getClosestPeers
   }
 
   async start (): Promise<void> {


### PR DESCRIPTION
Adds a `trace` option to all routing methods that can be used with libp2p metrics implementations that support method tracing.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
