### PR TITLE
feat: add WebRTC-Direct listener

### DIFF
--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -78,7 +78,7 @@
     "@libp2p/tcp": "^10.0.18",
     "@libp2p/tls": "^2.0.15",
     "@libp2p/upnp-nat": "^3.1.1",
-    "@libp2p/webrtc": "^5.0.26",
+    "@libp2p/webrtc": "^5.1.0",
     "@libp2p/websockets": "^9.1.5",
     "@multiformats/dns": "^1.0.6",
     "blockstore-core": "^5.0.2",

--- a/packages/helia/src/utils/libp2p-defaults.ts
+++ b/packages/helia/src/utils/libp2p-defaults.ts
@@ -53,10 +53,11 @@ export function libp2pDefaults (options: Libp2pDefaultsOptions = {}): Libp2pOpti
       listen: [
         '/ip4/0.0.0.0/tcp/0',
         '/ip4/0.0.0.0/tcp/0/ws',
+        '/ip4/0.0.0.0/udp/0/webrtc-direct',
         '/ip6/::/tcp/0',
         '/ip6/::/tcp/0/ws',
-        '/p2p-circuit',
-        '/webrtc'
+        '/ip6/::/udp/0/webrtc-direct',
+        '/p2p-circuit'
       ]
     },
     transports: [


### PR DESCRIPTION
Replaces the WebRTC listener with a WebRTC-Direct one under Node.js so the Helia instance can accept incoming dials without also needing a relay reservation.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
