### PR TITLE
fix: align implicit default ttl with specs

### DIFF
--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -284,10 +284,10 @@ const log = logger('helia:ipns')
 const MINUTE = 60 * 1000
 const HOUR = 60 * MINUTE
 
-const DEFAULT_LIFETIME_MS = 24 * HOUR
+const DEFAULT_LIFETIME_MS = 48 * HOUR
 const DEFAULT_REPUBLISH_INTERVAL_MS = 23 * HOUR
 
-const DEFAULT_TTL_NS = BigInt(HOUR) * 1_000_000n
+const DEFAULT_TTL_NS = BigInt(MINUTE) * 5_000_000n // 5 minutes
 
 export type PublishProgressEvents =
   ProgressEvent<'ipns:publish:start'> |
@@ -311,7 +311,7 @@ export type ResolveDNSLinkProgressEvents =
 
 export interface PublishOptions extends AbortOptions, ProgressOptions<PublishProgressEvents | IPNSRoutingEvents> {
   /**
-   * Time duration of the record in ms (default: 24hrs)
+   * Time duration of the signature validity in ms (default: 48hrs)
    */
   lifetime?: number
 
@@ -327,7 +327,7 @@ export interface PublishOptions extends AbortOptions, ProgressOptions<PublishPro
   v1Compatible?: boolean
 
   /**
-   * The TTL of the record in ms (default: 1 hour)
+   * The TTL of the record in ms (default: 5 minutes)
    */
   ttl?: number
 }

--- a/packages/ipns/test/publish.spec.ts
+++ b/packages/ipns/test/publish.spec.ts
@@ -45,7 +45,7 @@ describe('publish', () => {
     const ipnsEntry = await name.publish(key, cid)
 
     expect(ipnsEntry).to.have.property('sequence', 1n)
-    expect(ipnsEntry).to.have.property('ttl', 3_600_000_000_000n) // 1 hour
+    expect(ipnsEntry).to.have.property('ttl', 300_000_000_000n) // 5 minutes
   })
 
   it('should publish an IPNS record with a custom lifetime params', async function () {


### PR DESCRIPTION
## Title

chore(ipns): align implicit default ttl with specs

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

- lowering TTL to 5m due to https://github.com/ipfs/specs/pull/492 
- raised lifetime  to 48h to match [recommendation from specs](https://specs.ipfs.tech/ipns/ipns-record/#validity-bytes) (48h, to at least match Amino DHT expiration window)

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
