### PR TITLE
fix: use bytestream methods to add byte streams

### DIFF
--- a/packages/interop/src/car.spec.ts
+++ b/packages/interop/src/car.spec.ts
@@ -12,7 +12,7 @@ import { createKuboNode } from './fixtures/create-kubo.js'
 import { memoryCarWriter } from './fixtures/memory-car.js'
 import type { Car } from '@helia/car'
 import type { HeliaLibp2p } from 'helia'
-import type { FileCandidate } from 'ipfs-unixfs-importer'
+import type { ByteStream, FileCandidate } from 'ipfs-unixfs-importer'
 import type { KuboNode } from 'ipfsd-ctl'
 
 describe('@helia/car', () => {
@@ -46,18 +46,16 @@ describe('@helia/car', () => {
     const size = chunkSize * 10
     const input: Uint8Array[] = []
 
-    const candidate: FileCandidate = {
-      content: (async function * () {
-        for (let i = 0; i < size; i += chunkSize) {
-          const buf = new Uint8Array(chunkSize)
-          input.push(buf)
+    const bytes: ByteStream = (async function * () {
+      for (let i = 0; i < size; i += chunkSize) {
+        const buf = new Uint8Array(chunkSize)
+        input.push(buf)
 
-          yield buf
-        }
-      }())
-    }
+        yield buf
+      }
+    }())
 
-    const cid = await u.addFile(candidate)
+    const cid = await u.addByteStream(bytes)
     const writer = memoryCarWriter(cid)
     await c.export(cid, writer)
 

--- a/packages/interop/src/unixfs-bitswap.spec.ts
+++ b/packages/interop/src/unixfs-bitswap.spec.ts
@@ -7,7 +7,7 @@ import { CID } from 'multiformats/cid'
 import { createHeliaNode } from './fixtures/create-helia.js'
 import { createKuboNode } from './fixtures/create-kubo.js'
 import type { HeliaLibp2p } from 'helia'
-import type { FileCandidate } from 'ipfs-unixfs-importer'
+import type { ByteStream, FileCandidate } from 'ipfs-unixfs-importer'
 import type { KuboNode } from 'ipfsd-ctl'
 
 describe('@helia/unixfs - bitswap', () => {
@@ -39,22 +39,20 @@ describe('@helia/unixfs - bitswap', () => {
     const size = chunkSize * 10
     const input: Uint8Array[] = []
 
-    const candidate: FileCandidate = {
-      content: (async function * () {
-        for (let i = 0; i < size; i += chunkSize) {
-          const buf = new Uint8Array(chunkSize)
-          input.push(buf)
+    const bytes: ByteStream = (async function * () {
+      for (let i = 0; i < size; i += chunkSize) {
+        const buf = new Uint8Array(chunkSize)
+        input.push(buf)
 
-          yield buf
-        }
-      }())
-    }
+        yield buf
+      }
+    }())
 
-    const cid = await unixFs.addFile(candidate)
+    const cid = await unixFs.addByteStream(bytes)
 
-    const bytes = await toBuffer(kubo.api.cat(CID.parse(cid.toString())))
+    const output = await toBuffer(kubo.api.cat(CID.parse(cid.toString())))
 
-    expect(bytes).to.equalBytes(toBuffer(input))
+    expect(output).to.equalBytes(toBuffer(input))
   })
 
   it('should add a large file to kubo and fetch it from helia', async () => {

--- a/packages/mfs/src/index.ts
+++ b/packages/mfs/src/index.ts
@@ -277,23 +277,31 @@ class DefaultMFS implements MFS {
   }
 
   async writeBytes (bytes: Uint8Array, path: string, options?: Partial<WriteOptions>): Promise<void> {
-    const cid = await this.unixfs.addFile({
-      content: bytes,
-      mode: options?.mode,
-      mtime: options?.mtime
-    }, options)
+    const cid = await this.unixfs.addBytes(bytes, options)
 
     await this.cp(cid, path, options)
+
+    if (options?.mode != null) {
+      await this.chmod(path, options.mode, options)
+    }
+
+    if (options?.mtime != null) {
+      await this.touch(path, options)
+    }
   }
 
   async writeByteStream (bytes: ByteStream, path: string, options?: Partial<WriteOptions>): Promise<void> {
-    const cid = await this.unixfs.addFile({
-      content: bytes,
-      mode: options?.mode,
-      mtime: options?.mtime
-    }, options)
+    const cid = await this.unixfs.addByteStream(bytes, options)
 
     await this.cp(cid, path, options)
+
+    if (options?.mode != null) {
+      await this.chmod(path, options.mode, options)
+    }
+
+    if (options?.mtime != null) {
+      await this.touch(path, options)
+    }
   }
 
   async * cat (path: string, options: Partial<CatOptions> = {}): AsyncIterable<Uint8Array> {


### PR DESCRIPTION
Switch away from `addFile` as it will require paths after #754

These changes are backwards compatible, unlike #754

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
