### PR TITLE
docs: update @helia/car export method example

### DIFF
--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -120,31 +120,28 @@ export interface Car {
    *
    * ```typescript
    * import fs from 'node:fs'
-   * import { Readable } from 'stream'
+   * import { Readable } from 'node:stream'
    * import { car } from '@helia/car'
    * import { CarWriter } from '@ipld/car'
    * import { createHelia } from 'helia'
    * import { CID } from 'multiformats/cid'
+   * import { pEvent } from 'p-event'
    *
    * const helia = await createHelia()
    * const cid = CID.parse('QmFoo...')
    *
    * const c = car(helia)
    * const { writer, out } = CarWriter.create(cid)
-   * c.export(cid, writer).catch(console.error)
    * const output = fs.createWriteStream('example.car')
-   * await new Promise((resolve, reject) => {
-   *   const stream = Readable.from(out).pipe(output)
-   *   stream.on('finish', () => {
-   *     resolve()
-   *   })
-   *   stream.on('error', (err) => {
-   *     reject(err)
-   *   })
-   * })
+   * const stream = Readable.from(out).pipe(output)
+   *
+   * await Promise.all([
+   *   c.export(cid, writer),
+   *   pEvent(stream, 'close')
+   * ])
+   * ```
    *
    * @deprecated Use `stream` instead. In a future release `stream` will be renamed `export`.
-   * ```
    */
   export(root: CID | CID[], writer: Pick<CarWriter, 'put' | 'close'>, options?: ExportCarOptions): Promise<void>
 

--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -121,22 +121,27 @@ export interface Car {
    * ```typescript
    * import fs from 'node:fs'
    * import { Readable } from 'stream'
+   * import { car } from '@helia/car'
+   * import { CarWriter } from '@ipld/car'
    * import { createHelia } from 'helia'
-   * import { car } from '@helia/car
    * import { CID } from 'multiformats/cid'
-   * import pEvent from 'p-event'
    *
    * const helia = await createHelia()
    * const cid = CID.parse('QmFoo...')
    *
    * const c = car(helia)
-   *
-   * const byteStream = await c.export(cid)
+   * const { writer, out } = CarWriter.create(cid)
+   * c.export(cid, writer)
    * const output = fs.createWriteStream('example.car')
-   * const eventPromise = pEvent(output, 'end')
-   * Readable.from(byteStream).pipe(output)
-   *
-   * await eventPromise
+   * await new Promise((resolve, reject) => {
+   *   const stream = Readable.from(out).pipe(output)
+   *   stream.on('finish', () => {
+   *     resolve()
+   *   })
+   *   stream.on('error', (err) => {
+   *     reject(err)
+   *   })
+   * })
    * ```
    */
   export(root: CID | CID[], writer: Pick<CarWriter, 'put' | 'close'>, options?: ExportCarOptions): Promise<void>

--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -131,7 +131,7 @@ export interface Car {
    *
    * const c = car(helia)
    * const { writer, out } = CarWriter.create(cid)
-   * c.export(cid, writer)
+   * c.export(cid, writer).catch(console.error)
    * const output = fs.createWriteStream('example.car')
    * await new Promise((resolve, reject) => {
    *   const stream = Readable.from(out).pipe(output)
@@ -142,6 +142,8 @@ export interface Car {
    *     reject(err)
    *   })
    * })
+   *
+   * @deprecated Use `stream` instead. In a future release `stream` will be renamed `export`.
    * ```
    */
   export(root: CID | CID[], writer: Pick<CarWriter, 'put' | 'close'>, options?: ExportCarOptions): Promise<void>


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

docs: update @helia/car export method example

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Fixes an issue with the example with invalid code.

* removed `await` from `c.export` because that results in an error in node.js v22.9.0:

```
Warning: Detected unsettled top-level await at file:///Users/sgtpooki/code/work/protocol.ai/ipfs/helia/packages/car/test.js:29
await c.export(cid, writer)
^
```

* removed pEvent listening on wrong (`end`) event, which doesn't exist in LTS: https://nodejs.org/docs/latest-v22.x/api/stream.html

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Tested with code locally:

```js
import fs from 'node:fs'
import path from 'node:path'
import { cwd } from 'node:process'
import { Readable } from 'stream'
import { car } from '@helia/car'
import { createHeliaHTTP } from '@helia/http'
import { createVerifiedFetch } from '@helia/verified-fetch'
import { CarWriter } from '@ipld/car'
import { FsBlockstore } from 'blockstore-fs'
import { FsDatastore } from 'datastore-fs'
import { CID } from 'multiformats/cid'

const currentPath = path.join(cwd(), 'packages', 'car')
const helia = await createHeliaHTTP({
  blockstore: new FsBlockstore(path.join(currentPath, 'blockstore')),
  datastore: new FsDatastore(path.join(currentPath, 'datastore'))
})

const verifiedFetch = await createVerifiedFetch(helia)

await verifiedFetch('https://ipfs.io/ipfs/QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D/_Metadata.json?format=raw')

const cid = CID.parse('QmWXShtJXt6Mw3FH7hVCQvR56xPcaEtSj4YFSGjp2QxA4v')

const c = car(helia)

const { writer, out } = CarWriter.create(cid)

c.export(cid, writer)

const output = fs.createWriteStream('example.car')

await new Promise((resolve, reject) => {
  const stream = Readable.from(out).pipe(output)
  stream.on('finish', () => {
    resolve()
  })
  stream.on('error', (err) => {
    reject(err)
  })
})

// check that example.car exists
const exists = fs.existsSync('example.car')
if (!exists) {
  throw new Error('example.car does not exist')
}
```

### Some questions:

1. Do we need c.export to be a promise?
2. Should we update the example to listen to `out.on('finish'` instead?

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
