### PR TITLE
chore: use peer id parsing function from libp2p

### DIFF
--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -83,7 +83,7 @@
     "@libp2p/interface": "^2.2.1",
     "@libp2p/kad-dht": "^14.1.3",
     "@libp2p/logger": "^5.1.4",
-    "@libp2p/peer-id": "^5.0.8",
+    "@libp2p/peer-id": "^5.1.0",
     "@multiformats/dns": "^1.0.6",
     "interface-datastore": "^8.3.1",
     "ipns": "^10.0.0",

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -280,7 +280,7 @@
 
 import { NotFoundError, isPublicKey } from '@libp2p/interface'
 import { logger } from '@libp2p/logger'
-import { peerIdFromCID, peerIdFromString } from '@libp2p/peer-id'
+import { peerIdFromString } from '@libp2p/peer-id'
 import { createIPNSRecord, extractPublicKeyFromIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord, type IPNSRecord } from 'ipns'
 import { ipnsSelector } from 'ipns/selector'
 import { ipnsValidator } from 'ipns/validator'
@@ -749,18 +749,6 @@ class DefaultIPNS implements IPNS {
     return unmarshalIPNSRecord(record)
   }
 
-  /**
-   * Convert a string to a PeerId
-   */
-  #getPeerIdFromString (peerIdString: string): PeerId {
-    // It's either base58btc encoded multihash (identity or sha256)
-    if (peerIdString.charAt(0) === '1' || peerIdString.charAt(0) === 'Q') {
-      return peerIdFromString(peerIdString)
-    }
-
-    // or base36 encoded CID
-    return peerIdFromCID(CID.parse(peerIdString))
-  }
 
   async republishRecord (key: MultihashDigest<0x00 | 0x12> | string, record: IPNSRecord, options: RepublishRecordOptions = {}): Promise<void> {
     let mh: MultihashDigest<0x00 | 0x12> | undefined
@@ -771,7 +759,7 @@ class DefaultIPNS implements IPNS {
         if (typeof key === 'string') {
           // Convert string key to MultihashDigest
           try {
-            mh = this.#getPeerIdFromString(key).toMultihash()
+            mh = peerIdFromString(key).toMultihash()
           } catch (err: any) {
             throw new Error(`Invalid string key: ${err.message}`)
           }

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -296,7 +296,7 @@ import { localStore, type LocalStore } from './routing/local-store.js'
 import { isCodec, IDENTITY_CODEC, SHA2_256_CODEC } from './utils.js'
 import type { IPNSRouting, IPNSRoutingEvents } from './routing/index.js'
 import type { Routing } from '@helia/interface'
-import type { AbortOptions, ComponentLogger, Logger, PeerId, PrivateKey, PublicKey } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger, Logger, PrivateKey, PublicKey } from '@libp2p/interface'
 import type { Answer, DNS, ResolveDnsProgressEvents } from '@multiformats/dns'
 import type { Datastore } from 'interface-datastore'
 import type { MultibaseDecoder } from 'multiformats/bases/interface'
@@ -748,7 +748,6 @@ class DefaultIPNS implements IPNS {
 
     return unmarshalIPNSRecord(record)
   }
-
 
   async republishRecord (key: MultihashDigest<0x00 | 0x12> | string, record: IPNSRecord, options: RepublishRecordOptions = {}): Promise<void> {
     let mh: MultihashDigest<0x00 | 0x12> | undefined


### PR DESCRIPTION
## What

Small refactor to use `peerIdFromString` in `@libp2p/peer-id` which now accepts CID encoded PeerIDs.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
