### PR TITLE
feat: add provider shuffle option to HTTPGatewayRouter

### DIFF
--- a/packages/routers/src/http-gateway-routing.ts
+++ b/packages/routers/src/http-gateway-routing.ts
@@ -17,7 +17,12 @@ export const DEFAULT_TRUSTLESS_GATEWAYS = [
 
 export interface HTTPGatewayRouterInit {
   gateways?: Array<URL | string>
-  skipProviderShuffle?: boolean
+  /**
+   * Whether to shuffle the list of gateways
+   *
+   * @default true
+   */
+  shuffle?: boolean
 }
 
 // this value is from https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -36,17 +41,17 @@ function toPeerInfo (url: string | URL): PeerInfo {
 
 class HTTPGatewayRouter implements Partial<Routing> {
   private readonly gateways: PeerInfo[]
-  private readonly skipProviderShuffle: boolean
+  private readonly shuffle: boolean
 
   constructor (init: HTTPGatewayRouterInit = {}) {
     this.gateways = (init.gateways ?? DEFAULT_TRUSTLESS_GATEWAYS).map(url => toPeerInfo(url))
-    this.skipProviderShuffle = init.skipProviderShuffle ?? false
+    this.shuffle = init.shuffle ?? true
   }
 
   async * findProviders (cid: CID<unknown, number, number, Version>, options?: RoutingOptions | undefined): AsyncIterable<Provider> {
-    yield * (this.skipProviderShuffle
-      ? this.gateways
-      : this.gateways.toSorted(() => Math.random() > 0.5 ? 1 : -1)
+    yield * (this.shuffle
+      ? this.gateways.toSorted(() => Math.random() > 0.5 ? 1 : -1)
+      : this.gateways
     ).map(info => ({
       ...info,
       protocols: ['transport-ipfs-gateway-http']

--- a/packages/routers/test/http-gateway-routing.spec.ts
+++ b/packages/routers/test/http-gateway-routing.spec.ts
@@ -35,13 +35,13 @@ describe('http-gateway-routing', () => {
     expect(shuffledOrder).to.not.deep.equal(originalOrder)
   })
 
-  it('should preserve provider order when skipProviderShuffle is true', async () => {
+  it('should preserve provider order when shuffle is false', async () => {
     // long enough to make a false positive very unlikely, 1/(10!)
     const gateways = Array.from({ length: 10 }, (_, i) => `https://example${i + 1}.com`)
 
     const routing = httpGatewayRouting({
       gateways,
-      skipProviderShuffle: true
+      shuffle: false
     })
 
     const cid = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')

--- a/packages/routers/test/http-gateway-routing.spec.ts
+++ b/packages/routers/test/http-gateway-routing.spec.ts
@@ -20,4 +20,36 @@ describe('http-gateway-routing', () => {
     expect(providers).to.have.nested.property('[0].protocols').that.includes('transport-ipfs-gateway-http')
     expect(providers[0].multiaddrs.map(ma => ma.toString())).to.include('/dns4/example.com/tcp/443/https')
   })
+
+  it('should shuffle providers by default', async () => {
+    // long enough to make a false positive very unlikely, 1/(10!)
+    const gateways = Array.from({ length: 10 }, (_, i) => `https://example${i + 1}.com`)
+    const routing = httpGatewayRouting({ gateways })
+
+    const cid = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')
+
+    const providers = await all(routing.findProviders?.(cid) ?? [])
+
+    const originalOrder = gateways.map(gw => `/dns4/${gw.replace('https://', '')}/tcp/443/https`)
+    const shuffledOrder = providers.map(p => p.multiaddrs.map(ma => ma.toString())[0])
+    expect(shuffledOrder).to.not.deep.equal(originalOrder)
+  })
+
+  it('should preserve provider order when skipProviderShuffle is true', async () => {
+    // long enough to make a false positive very unlikely, 1/(10!)
+    const gateways = Array.from({ length: 10 }, (_, i) => `https://example${i + 1}.com`)
+
+    const routing = httpGatewayRouting({
+      gateways,
+      skipProviderShuffle: true
+    })
+
+    const cid = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')
+
+    const providers = await all(routing.findProviders?.(cid) ?? [])
+
+    const expected = gateways.map(gw => `/dns4/${gw.replace('https://', '')}/tcp/443/https`)
+    const actual = providers.map(p => p.multiaddrs.map(ma => ma.toString())[0])
+    expect(actual).to.deep.equal(expected)
+  })
 })


### PR DESCRIPTION
## feat: allow opting out of provider shuffle in HTTPGatewayRouter

See #771 for motivation.

## Description

For use cases where gateway lookup order is important, this PR allows passing a new config param to `HTTPGatewayRouter` which opts out of the shuffling which happens on each call to `findProviders`.

## Notes & open questions

- The new param is optional
- Default value preserves the original behavior

I.e., the feature is backward-compatible.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
