### PR TITLE
fix: trustless-gateway sessions handle aborts properly 

### DIFF
--- a/packages/block-brokers/.aegir.js
+++ b/packages/block-brokers/.aegir.js
@@ -88,6 +88,17 @@ const options = {
         // fails validation
         res.end(Uint8Array.from([0, 1, 2, 1]))
       })
+      badGateway.all('/ipfs/bafkreig7p6kzwgg4hp3n7wpnnn3kkjmpzxds5rmwhphyueilbzabvyexvq', (req, res) => {
+        // wait for Number.MAX_SAFE_INTEGER seconds to simulate a slow response. Do not query this cid unless you plan to abort the request.
+        setTimeout(() => {
+          res.writeHead(200, {
+            'content-type': 'application/octet-stream',
+            'content-length': 4
+          })
+          res.end(Uint8Array.from([0, 1, 2, 1]))
+        }, Number.MAX_SAFE_INTEGER)
+      })
+
       badGateway.all('/ipfs/*', (req, res) => {
         // fails
         res.writeHead(500)

--- a/packages/block-brokers/.aegir.js
+++ b/packages/block-brokers/.aegir.js
@@ -59,7 +59,7 @@ const options = {
           res.end(Uint8Array.from([0, 1, 2, 0]))
         } else {
           // no reason to use this in tests without the delay configured.
-          res.writeHead(500, {
+          res.writeHead(400, {
             'content-type': 'text/plain',
             'content-length': 13
           })

--- a/packages/block-brokers/.aegir.js
+++ b/packages/block-brokers/.aegir.js
@@ -46,6 +46,27 @@ const options = {
         // "hello"
         res.end(Uint8Array.from([104, 101, 108, 108, 111]))
       })
+
+      goodGateway.all('/ipfs/bafkreig7p6kzwgg4hp3n7wpnnn3kkjmpzxds5rmwhphyueilbzabvyexvq', async (req, res) => {
+        // if 'delay' header is set, delay the response
+        const delay = req.headers['delay']
+        if (delay) {
+          await new Promise((resolve) => setTimeout(resolve, delay))
+          res.writeHead(200, {
+            'content-type': 'application/octet-stream',
+            'content-length': 4
+          })
+          res.end(Uint8Array.from([0, 1, 2, 0]))
+        } else {
+          // no reason to use this in tests without the delay configured.
+          res.writeHead(500, {
+            'content-type': 'text/plain',
+            'content-length': 13
+          })
+          res.end('No delay set')
+        }
+      })
+
       goodGateway.all('/ipfs/*', (req, res) => {
         // succeeds with empty block for any other CID
         res.writeHead(200)
@@ -92,13 +113,16 @@ const options = {
         // wait for 70 seconds to simulate a slow response. Do not query this cid unless you plan to abort the request.
         // typical test timeout is 60 seconds, so if you reach 60 seconds, there is a bug in handling your abort signal.
         // if you don't reach whatever timeout you set (e.g. `AbortSignal.timeout(1000)`), there is likely a bug in your test.
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           res.writeHead(200, {
             'content-type': 'application/octet-stream',
             'content-length': 4
           })
           res.end(Uint8Array.from([0, 1, 2, 1]))
         }, 70000)
+        req.on('close', () => {
+          clearTimeout(timeoutId)
+        })
       })
 
       badGateway.all('/ipfs/*', (req, res) => {

--- a/packages/block-brokers/.aegir.js
+++ b/packages/block-brokers/.aegir.js
@@ -89,14 +89,16 @@ const options = {
         res.end(Uint8Array.from([0, 1, 2, 1]))
       })
       badGateway.all('/ipfs/bafkreig7p6kzwgg4hp3n7wpnnn3kkjmpzxds5rmwhphyueilbzabvyexvq', (req, res) => {
-        // wait for Number.MAX_SAFE_INTEGER seconds to simulate a slow response. Do not query this cid unless you plan to abort the request.
+        // wait for 70 seconds to simulate a slow response. Do not query this cid unless you plan to abort the request.
+        // typical test timeout is 60 seconds, so if you reach 60 seconds, there is a bug in handling your abort signal.
+        // if you don't reach whatever timeout you set (e.g. `AbortSignal.timeout(1000)`), there is likely a bug in your test.
         setTimeout(() => {
           res.writeHead(200, {
             'content-type': 'application/octet-stream',
             'content-length': 4
           })
           res.end(Uint8Array.from([0, 1, 2, 1]))
-        }, Number.MAX_SAFE_INTEGER)
+        }, 70000)
       })
 
       badGateway.all('/ipfs/*', (req, res) => {

--- a/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
@@ -18,16 +18,6 @@ interface StubbedTrustlessGatewaySessionComponents {
   routing: StubbedInstance<Routing>
 }
 
-/**
- * Normalize the abort signal reason string to be the same across Node.js and browsers.
- */
-const getSignal = (msg: string, delay: number): AbortSignal => {
-  const ctrl = new AbortController()
-  const signal = ctrl.signal
-  setTimeout(() => { ctrl.abort(msg) }, delay)
-  return signal
-}
-
 describe('trustless-gateway sessions', () => {
   let components: StubbedTrustlessGatewaySessionComponents
 
@@ -138,7 +128,8 @@ describe('trustless-gateway sessions', () => {
       }
     }())
 
-    await expect(session.retrieve(cid, { signal: getSignal('abort request', 500) })).to.eventually.be.rejectedWith('abort request')
+    await expect(session.retrieve(cid, { signal: AbortSignal.timeout(500) })).to.eventually.be.rejected()
+      .with.property('name', 'AbortError')
     expect(queryProviderSpy.callCount).to.equal(1)
   })
 
@@ -174,7 +165,7 @@ describe('trustless-gateway sessions', () => {
       }
     }())
 
-    await expect(session.retrieve(cid, { signal: getSignal('abort request', 500) })).to.eventually.deep.equal(block)
+    await expect(session.retrieve(cid, { signal: AbortSignal.timeout(500) })).to.eventually.deep.equal(block)
     expect(queryProviderSpy.callCount).to.equal(2)
   })
 })

--- a/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
@@ -128,7 +128,7 @@ describe('trustless-gateway sessions', () => {
       }
     }())
 
-    await expect(session.retrieve(cid, { signal: AbortSignal.timeout(1000) })).to.eventually.be.rejectedWith('Session aborted')
+    await expect(session.retrieve(cid, { signal: AbortSignal.timeout(500) })).to.eventually.be.rejectedWith('Session aborted')
     expect(queryProviderSpy.callCount).to.equal(1)
   })
 })

--- a/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
@@ -18,6 +18,16 @@ interface StubbedTrustlessGatewaySessionComponents {
   routing: StubbedInstance<Routing>
 }
 
+/**
+ * Normalize the abort signal reason string to be the same across Node.js and browsers.
+ */
+const getSignal = (msg: string, delay: number): AbortSignal => {
+  const ctrl = new AbortController()
+  const signal = ctrl.signal
+  setTimeout(() => { ctrl.abort(msg) }, delay)
+  return signal
+}
+
 describe('trustless-gateway sessions', () => {
   let components: StubbedTrustlessGatewaySessionComponents
 
@@ -128,7 +138,7 @@ describe('trustless-gateway sessions', () => {
       }
     }())
 
-    await expect(session.retrieve(cid, { signal: AbortSignal.timeout(500) })).to.eventually.be.rejectedWith('The operation was aborted due to timeout')
+    await expect(session.retrieve(cid, { signal: getSignal('abort request', 500) })).to.eventually.be.rejectedWith('abort request')
     expect(queryProviderSpy.callCount).to.equal(1)
   })
 
@@ -164,7 +174,7 @@ describe('trustless-gateway sessions', () => {
       }
     }())
 
-    await expect(session.retrieve(cid, { signal: AbortSignal.timeout(500) })).to.eventually.deep.equal(block)
+    await expect(session.retrieve(cid, { signal: getSignal('abort request', 500) })).to.eventually.deep.equal(block)
     expect(queryProviderSpy.callCount).to.equal(2)
   })
 })

--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -96,8 +96,18 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
       deferred.resolve(evt.detail.result)
     })
     queue.addEventListener('idle', () => {
-      if (foundBlock || options.signal?.aborted === true) {
-        // we either found the block or the user gave up
+      if (foundBlock) {
+        this.log.trace('session idle, found block')
+        // we found the block, nothing else to do here.
+        return
+      }
+
+      if (options.signal?.aborted === true) {
+        // the session is idle, we haven't found the block, and the signal was aborted, so we can reject the promise.
+        // Note that there is a slight race condition here where we find the block and the signal is aborted within ~10s of ms of each other.
+        // In that case, the request will be rejected with the signal reason.
+        this.log.trace('session idle and signal is aborted')
+        deferred.reject(new Error(options.signal?.reason ?? 'Session aborted'))
         return
       }
 

--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SESSION_MIN_PROVIDERS, DEFAULT_SESSION_MAX_PROVIDERS, InsufficientProvidersError } from '@helia/interface'
-import { TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
+import { AbortError, TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { createScalableCuckooFilter } from '@libp2p/utils/filters'
 import { Queue } from '@libp2p/utils/queue'
 import { base64 } from 'multiformats/bases/base64'
@@ -107,7 +107,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
         // Note that there is a slight race condition here where we find the block and the signal is aborted within ~10s of ms of each other.
         // In that case, the request will be rejected with the signal reason.
         this.log.trace('session idle and signal is aborted')
-        deferred.reject(new Error(options.signal?.reason ?? 'Session aborted'))
+        deferred.reject(new AbortError(options.signal?.reason ?? 'Session aborted'))
         return
       }
 

--- a/packages/utils/test/abstract-session.spec.ts
+++ b/packages/utils/test/abstract-session.spec.ts
@@ -317,5 +317,7 @@ describe('abstract-session', () => {
     await expect(session.retrieve(cid, {
       signal: AbortSignal.timeout(abortDelay)
     })).to.eventually.deep.equal(block)
+
+    expect(session.queryProvider.callCount).to.equal(2)
   })
 })


### PR DESCRIPTION
We originally did not abort when the session was idle because a block may have been found.

This PR changes that so that we have a race condition on signal.abort and foundBlock, but I believe this small window is a better situation than having the session never end (as in #775)