### PR TITLE
feat: export default helia config

### DIFF
--- a/packages/helia/src/utils/helia-defaults.ts
+++ b/packages/helia/src/utils/helia-defaults.ts
@@ -1,0 +1,85 @@
+/**
+ * @packageDocumentation
+ *
+ * Exports a `createHelia` function that returns an object that implements the {@link Helia} API.
+ *
+ * Pass it to other modules like {@link https://www.npmjs.com/package/@helia/unixfs | @helia/unixfs} to make files available on the distributed web.
+ *
+ * @example
+ *
+ * ```typescript
+ * import { createHelia } from 'helia'
+ * import { unixfs } from '@helia/unixfs'
+ * import { CID } from 'multiformats/cid'
+ *
+ * const helia = await createHelia()
+ *
+ * const fs = unixfs(helia)
+ * fs.cat(CID.parse('bafyFoo'))
+ * ```
+ */
+
+import { bitswap, trustlessGateway } from '@helia/block-brokers'
+import { httpGatewayRouting, libp2pRouting } from '@helia/routers'
+import { MemoryBlockstore } from 'blockstore-core'
+import { MemoryDatastore } from 'datastore-core'
+import { createLibp2p } from '../utils/libp2p.js'
+import type { HeliaInit } from '../index.js'
+import type { DefaultLibp2pServices } from '../utils/libp2p-defaults.js'
+import type { Libp2p } from '@libp2p/interface'
+
+/**
+ * Create and return the default options used to create a Helia node
+ */
+export async function heliaDefaults <T extends Libp2p> (init: Partial<HeliaInit<T>> = {}): Promise<HeliaInit<T> & Required<Pick<HeliaInit, 'libp2p' | 'blockstore'>>> {
+  const datastore = init.datastore ?? new MemoryDatastore()
+  const blockstore = init.blockstore ?? new MemoryBlockstore()
+
+  let libp2p: any
+
+  if (isLibp2p(init.libp2p)) {
+    libp2p = init.libp2p as any
+  } else {
+    libp2p = await createLibp2p<DefaultLibp2pServices>({
+      ...init,
+      libp2p: {
+        dns: init.dns,
+        ...init.libp2p,
+
+        // ignore the libp2p start parameter as it should be on the main init
+        // object instead
+        start: undefined
+      },
+      datastore
+    })
+  }
+
+  return {
+    ...init,
+    libp2p,
+    datastore,
+    blockstore,
+    blockBrokers: init.blockBrokers ?? [
+      trustlessGateway(),
+      bitswap()
+    ],
+    routers: init.routers ?? [
+      libp2pRouting(libp2p),
+      httpGatewayRouting()
+    ],
+    metrics: libp2p.metrics,
+    start: init.start ?? true
+  }
+}
+
+function isLibp2p (obj: any): obj is Libp2p {
+  if (obj == null) {
+    return false
+  }
+
+  // a non-exhaustive list of methods found on the libp2p object
+  const funcs = ['dial', 'dialProtocol', 'hangUp', 'handle', 'unhandle', 'getMultiaddrs', 'getProtocols']
+
+  // if these are all functions it's probably a libp2p object
+  return funcs.every(m => typeof obj[m] === 'function')
+}

--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -29,11 +29,10 @@ export async function createLibp2p <T extends Record<string, unknown>> (options:
     libp2pOptions.privateKey = await loadOrCreateSelfKey(options.datastore, options.keychain)
   }
 
-  const defaults = libp2pDefaults(libp2pOptions)
+  const defaults: any = libp2pDefaults(libp2pOptions)
   defaults.datastore = defaults.datastore ?? options.datastore
 
-  // @ts-expect-error derived ServiceMap is not compatible with ServiceFactoryMap
-  const node = await create({
+  const node = await create<T>({
     ...defaults,
     ...libp2pOptions,
     start: false

--- a/packages/helia/src/utils/libp2p.ts
+++ b/packages/helia/src/utils/libp2p.ts
@@ -1,7 +1,6 @@
 import { loadOrCreateSelfKey } from '@libp2p/config'
 import { createLibp2p as create } from 'libp2p'
 import { libp2pDefaults } from './libp2p-defaults.js'
-import type { DefaultLibp2pServices } from './libp2p-defaults.js'
 import type { ComponentLogger, Libp2p, PrivateKey } from '@libp2p/interface'
 import type { KeychainInit } from '@libp2p/keychain'
 import type { DNS } from '@multiformats/dns'
@@ -22,7 +21,7 @@ export interface Libp2pDefaultsOptions {
   dns?: DNS
 }
 
-export async function createLibp2p <T extends Record<string, unknown> = DefaultLibp2pServices> (options: CreateLibp2pOptions<T>): Promise<Libp2p<T>> {
+export async function createLibp2p <T extends Record<string, unknown>> (options: CreateLibp2pOptions<T>): Promise<Libp2p<T>> {
   const libp2pOptions = options.libp2p ?? {}
 
   // if no peer id was passed, try to load it from the keychain

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -63,6 +63,28 @@ export interface HeliaHTTPInit extends HeliaInit {
 }
 
 /**
+ * Create and return the default options used to create a Helia node that only
+ * uses HTTP services
+ */
+export async function heliaDefaults (init: Partial<HeliaHTTPInit> = {}): Promise<HeliaHTTPInit> {
+  const datastore = init.datastore ?? new MemoryDatastore()
+  const blockstore = init.blockstore ?? new MemoryBlockstore()
+
+  return {
+    ...init,
+    datastore,
+    blockstore,
+    blockBrokers: init.blockBrokers ?? [
+      trustlessGateway()
+    ],
+    routers: init.routers ?? [
+      delegatedHTTPRouting('https://delegated-ipfs.dev'),
+      httpGatewayRouting()
+    ]
+  }
+}
+
+/**
  * Create and return a Helia node
  */
 export async function createHeliaHTTP (init: Partial<HeliaHTTPInit> = {}): Promise<Helia> {


### PR DESCRIPTION
To make it easier to customise the default Helia settings, export a `heliaDefaults` function similar to the existing `libp2pDefaults` function.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
