### PR TITLE
fix: propagate ipns failures

### DIFF
--- a/packages/ipns/src/routing/helia.ts
+++ b/packages/ipns/src/routing/helia.ts
@@ -22,6 +22,7 @@ export class HeliaRouting implements IPNSRouting {
       await this.routing.put(routingKey, marshaledRecord, options)
     } catch (err: any) {
       options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:helia:error', err))
+      throw err
     }
   }
 
@@ -30,9 +31,8 @@ export class HeliaRouting implements IPNSRouting {
       return await this.routing.get(routingKey, options)
     } catch (err: any) {
       options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:helia:error', err))
+      throw err
     }
-
-    throw new Error('Not found')
   }
 }
 


### PR DESCRIPTION
If the helia routing fails to put or get a record, propagate that failure to the caller, same as the local store/pubusb routings.

Refs: https://github.com/ipfs/helia/issues/780#issuecomment-2863328014

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
