### PR TITLE
fix: trustless gateway returned blocks can be limited

### DIFF
--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -57,7 +57,7 @@ export class TrustlessGatewayBlockBroker implements BlockBroker<TrustlessGateway
       this.log('getting block for %c from %s', cid, gateway.url)
 
       try {
-        const block = await gateway.getRawBlock(cid, options.signal)
+        const block = await gateway.getRawBlock(cid, { signal: options.signal, byteLimit: options.byteLimit ?? 2097152 })
         this.log.trace('got block for %c from %s', cid, gateway.url)
 
         try {

--- a/packages/block-brokers/src/trustless-gateway/session.ts
+++ b/packages/block-brokers/src/trustless-gateway/session.ts
@@ -39,7 +39,7 @@ class TrustlessGatewaySession extends AbstractSession<TrustlessGateway, Trustles
   async queryProvider (cid: CID, provider: TrustlessGateway, options: BlockRetrievalOptions): Promise<Uint8Array> {
     this.log('fetching BLOCK for %c from %s', cid, provider.url)
 
-    const block = await provider.getRawBlock(cid, options.signal)
+    const block = await provider.getRawBlock(cid, { signal: options.signal, byteLimit: options.byteLimit ?? 2097152 })
     this.log.trace('got block for %c from %s', cid, provider.url)
 
     await options.validateFn?.(block)

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -1,4 +1,5 @@
 import { base64 } from 'multiformats/bases/base64'
+import { limitedResponse } from './utils.js'
 import type { ComponentLogger, Logger } from '@libp2p/interface'
 import type { CID } from 'multiformats/cid'
 
@@ -17,6 +18,17 @@ export interface TransformRequestInit {
 export interface TrustlessGatewayComponents {
   logger: ComponentLogger
   transformRequestInit?: TransformRequestInit
+}
+
+export interface GetRawBlockOptions {
+  signal?: AbortSignal
+
+  /**
+   * The maximum number of bytes to allow when fetching a raw block.
+   *
+   * @default 2097152 (2MiB)
+   */
+  byteLimit?: number
 }
 
 /**
@@ -89,7 +101,7 @@ export class TrustlessGateway {
    * Fetch a raw block from `this.url` following the specification defined at
    * https://specs.ipfs.tech/http-gateways/trustless-gateway/
    */
-  async getRawBlock (cid: CID, signal?: AbortSignal): Promise<Uint8Array> {
+  async getRawBlock (cid: CID, { signal, byteLimit = 2097152 }: GetRawBlockOptions = {}): Promise<Uint8Array> {
     const gwUrl = new URL(this.url.toString())
     gwUrl.pathname = `/ipfs/${cid.toString()}`
 
@@ -130,8 +142,11 @@ export class TrustlessGateway {
             this.#errors++
             throw new Error(`unable to fetch raw block for CID ${cid} from gateway ${this.url}`)
           }
+          // limited Response ensures the body is less than 2MiB (or configurable byteLimit)
+          // see https://github.com/ipfs/helia/issues/790
+          const body = await limitedResponse(res, { signal: innerController.signal, byteLimit })
           this.#successes++
-          return new Uint8Array(await res.arrayBuffer())
+          return body
         })
         this.#pendingResponses.set(blockId, pendingResponse)
       }

--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -62,7 +62,7 @@ export async function * findHttpGatewayProviders (cid: CID, routing: Routing, lo
  * If the response contains a content-length header greater than the limit or the actual bytes returned are greater than
  * the limit, an error is thrown.
  */
-export async function limitedResponse (response: Response, { log, byteLimit }: { log?: Logger, byteLimit: number }): Promise<Uint8Array> {
+export async function limitedResponse (response: Response, { log, byteLimit, signal }: { log?: Logger, byteLimit: number, signal?: AbortSignal }): Promise<Uint8Array> {
   const contentLength = response.headers.get('content-length')
   if (contentLength != null) {
     const contentLengthNumber = parseInt(contentLength, 10)
@@ -88,6 +88,10 @@ export async function limitedResponse (response: Response, { log, byteLimit }: {
 
   try {
     while (true) {
+      if (signal?.aborted === true) {
+        throw new Error('Response body read was aborted')
+      }
+
       const { done, value } = await reader.read()
       if (done) {
         break

--- a/packages/block-brokers/test/trustless-gateway-utils.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-utils.spec.ts
@@ -1,6 +1,6 @@
 import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
 import { expect } from 'aegir/chai'
-import { filterNonHTTPMultiaddrs } from '../src/trustless-gateway/utils.js'
+import { filterNonHTTPMultiaddrs, limitedResponse } from '../src/trustless-gateway/utils.js'
 
 describe('trustless-gateway-block-broker-utils', () => {
   it('filterNonHTTPMultiaddrs respects allowInsecure multiaddrs correctly', async function () {
@@ -50,5 +50,25 @@ describe('trustless-gateway-block-broker-utils', () => {
     const filtered = filterNonHTTPMultiaddrs([localAddr], false, true)
 
     expect(filtered.length).to.deep.equal(1)
+  })
+
+  it('limitedResponse throws an error when the content-length header is greater than the limit', async function () {
+    const response = new Response('x'.repeat(1000000), {
+      headers: {
+        'content-length': '1000000'
+      }
+    })
+
+    await expect(limitedResponse(response, { byteLimit: 100 })).to.be.rejectedWith('Content-Length header (1000000) is greater than the limit (100)')
+  })
+
+  it('limitedResponse throws an error when the response body is greater than the limit', async function () {
+    const response = new Response('x'.repeat(1000000), {
+      headers: {
+        'content-length': '100'
+      }
+    })
+
+    await expect(limitedResponse(response, { byteLimit: 100 })).to.be.rejectedWith('Response body is greater than the limit (100), received 1000000 bytes')
   })
 })

--- a/packages/interface/src/blocks.ts
+++ b/packages/interface/src/blocks.ts
@@ -110,6 +110,13 @@ export interface BlockRetrievalOptions <ProgressEvents extends ProgressEvent<any
    * and WILL consider the gateway that returned the invalid blocks completely unreliable.
    */
   validateFn?(block: Uint8Array): Promise<void>
+
+  /**
+   * The maximum number of bytes to read from the block.
+   *
+   * @default 20
+   */
+  byteLimit?: number
 }
 
 export interface BlockAnnounceOptions <ProgressEvents extends ProgressEvent<any, any> = ProgressEvent<any, any>> extends AbortOptions, ProgressOptions<ProgressEvents> {


### PR DESCRIPTION
- **fix: create utility function for limiting response bytes**
- **fix: trustless gateway returned blocks can be limited**

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: trustless gateway returned blocks can be limited

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Adds a new utility function `limitedResponse` that ensures the response body is less than a given byte limit.

This is done by:

1. Validating that the `content-length` header is less than the limit, if not, an error is thrown.
2. Consuming the response body until the limit is reached. If the response body is greater than the limit, an error is thrown.

Fixes https://github.com/ipfs/helia/issues/790

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
