### PR TITLE
docs: fix API docs link

### DIFF
--- a/packages/block-brokers/README.md
+++ b/packages/block-brokers/README.md
@@ -29,7 +29,7 @@ Loading this module through a script tag will make its exports available as `Hel
 
 # API Docs
 
-- <https://ipfs.github.io/helia/modules/_helia_block_brokers.html>
+- <https://ipfs.github.io/helia/modules/_helia_block-brokers.html>
 
 # License
 

--- a/packages/dag-cbor/README.md
+++ b/packages/dag-cbor/README.md
@@ -69,7 +69,7 @@ Loading this module through a script tag will make its exports available as `Hel
 
 # API Docs
 
-- <https://ipfs.github.io/helia/modules/_helia_dag_cbor.html>
+- <https://ipfs.github.io/helia/modules/_helia_dag-cbor.html>
 
 # License
 

--- a/packages/dag-json/README.md
+++ b/packages/dag-json/README.md
@@ -69,7 +69,7 @@ Loading this module through a script tag will make its exports available as `Hel
 
 # API Docs
 
-- <https://ipfs.github.io/helia/modules/_helia_dag_json.html>
+- <https://ipfs.github.io/helia/modules/_helia_dag-json.html>
 
 # License
 

--- a/packages/unixfs/README.md
+++ b/packages/unixfs/README.md
@@ -30,7 +30,7 @@ repo and examine the changes made.
 
 -->
 
-`@helia/unixfs` is an implementation of a filesystem compatible with Helia.
+`@helia/unixfs` is an implementation of a UnixFS filesystem compatible with Helia.
 
 See the [API docs](https://ipfs.github.io/helia/modules/_helia_unixfs.html) for all available operations.
 


### PR DESCRIPTION
Fixes any `API Docs` links for packages that look like `@scope/name-name2` because they were incorrectly linking to `_scope_name_name2` instead of `_scope_name-name2`. 

I thought it could be an error in `aegir` but it seems like `npm run docs` doesn't reset the `API Docs` section entry at all.