### PR TITLE
test: disable bitswap broadcast reduction for kubo interop test

### DIFF
--- a/packages/interop/src/fixtures/create-kubo.ts
+++ b/packages/interop/src/fixtures/create-kubo.ts
@@ -25,6 +25,11 @@ export async function createKuboNode (): Promise<KuboNode> {
             'Access-Control-Allow-Origin': ['*'],
             'Access-Control-Allow-Methods': ['GET', 'POST', 'PUT', 'OPTIONS']
           }
+        },
+        Internal: {
+          Bitswap: {
+            BroadcastReductionEnabled: false
+          }
         }
       }
     },


### PR DESCRIPTION
## Title

Disable bitswap broadcast reduction for kubo interop testing

## Description

Helia interop testing does not work when kubo broadcast reduction is enabled. This change configures kubo to disable broadcast reduction.

## Notes & open questions

- Need help testing.
- Should the interop test be changed so that it works with broadcast reduction enabled?

## Change checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
