### PR TITLE
docs: fix module name typo in readme

### DIFF
--- a/packages/dag-cbor/README.md
+++ b/packages/dag-cbor/README.md
@@ -30,7 +30,7 @@ repo and examine the changes made.
 
 -->
 
-`@helia/dag-cbor` makes working with DAG-JSON Helia simple & straightforward.
+`@helia/dag-cbor` makes working with DAG-CBOR Helia simple & straightforward.
 
 See the DAGCBOR interface for all available operations.
 

--- a/packages/dag-cbor/src/index.ts
+++ b/packages/dag-cbor/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @packageDocumentation
  *
- * `@helia/dag-cbor` makes working with DAG-JSON {@link https://github.com/ipfs/helia Helia} simple & straightforward.
+ * `@helia/dag-cbor` makes working with DAG-CBOR {@link https://ipld.io/docs/codecs/known/dag-cbor/} simple & straightforward.
  *
  * See the {@link DAGCBOR} interface for all available operations.
  *


### PR DESCRIPTION
## Description

Fixes typo in the dag-cbor module