### PR TITLE
fix: support truncated hashes based on multihash length

### DIFF
--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -411,6 +411,13 @@ export const getCidBlockVerifierFunction = (cid: CID, hasher: MultihashHasher): 
       hash = res
     }
 
+    if (hash.digest.length > cid.multihash.size) {
+      hash = {
+        ...hash,
+        digest: hash.digest.subarray(0, cid.multihash.size)
+      }
+    }
+
     if (!uint8ArrayEquals(hash.digest, cid.multihash.digest)) {
       // if a hash mismatch occurs for a TrustlessGatewayBlockBroker, we should try another gateway
       throw new InvalidMultihashError('Hash of downloaded block did not match multihash from passed CID')


### PR DESCRIPTION
## Description
- Added logic to handle truncated multihashes during verification in networked storage
- Enhanced hash verification to work with partial hash values
- Added test to cover truncated hash scenario

## Background 

Originally reported in https://ipshipyard.slack.com/archives/C0238P3SU4X/p1753096031053949 

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
