### PR TITLE
fix: propagate provider option through session and broker to trustles…

### DIFF
--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -10,7 +10,7 @@ import type { CID } from 'multiformats/cid'
 export interface CreateTrustlessGatewaySessionOptions extends CreateSessionOptions<TrustlessGatewayGetBlockProgressEvents> {
   /**
    * By default we will only connect to peers with HTTPS addresses, pass true
-   * to also connect to HTTP addresses.
+   * to also connect to HTTP addresses. 
    *
    * @default false
    */
@@ -57,7 +57,7 @@ export class TrustlessGatewayBlockBroker implements BlockBroker<TrustlessGateway
       this.log('getting block for %c from %s', cid, gateway.url)
 
       try {
-        const block = await gateway.getRawBlock(cid, options)
+        const block = await gateway.getRawBlock(cid, { ...options, provider: options.provider })
         this.log.trace('got block for %c from %s', cid, gateway.url)
 
         try {

--- a/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
+++ b/packages/block-brokers/src/trustless-gateway/trustless-gateway.ts
@@ -30,6 +30,7 @@ export interface GetRawBlockOptions {
    * @default 2_097_152 (2MiB)
    */
   maxSize?: number
+  provider?: string 
 }
 
 /**
@@ -102,13 +103,17 @@ export class TrustlessGateway {
    * Fetch a raw block from `this.url` following the specification defined at
    * https://specs.ipfs.tech/http-gateways/trustless-gateway/
    */
-  async getRawBlock (cid: CID, { signal, maxSize = DEFAULT_MAX_SIZE }: GetRawBlockOptions = {}): Promise<Uint8Array> {
+  async getRawBlock (cid: CID, { signal, maxSize = DEFAULT_MAX_SIZE, provider }: GetRawBlockOptions = {}): Promise<Uint8Array> {
     const gwUrl = new URL(this.url.toString())
     gwUrl.pathname = `/ipfs/${cid.toString()}`
 
-    // necessary as not every gateway supports dag-cbor, but every should support
-    // sending raw block as-is
-    gwUrl.search = '?format=raw'
+    const params  = new URLSearchParams( {format: 'raw'})
+    if (provider != null) {
+      params.set('provider', provider)
+    }
+    gwUrl.search = params.toString()
+    
+    
 
     if (signal?.aborted === true) {
       throw new Error(`Signal to fetch raw block for CID ${cid} from gateway ${this.url} was aborted prior to fetch`)

--- a/packages/interface/src/blocks.ts
+++ b/packages/interface/src/blocks.ts
@@ -119,6 +119,7 @@ export interface BlockRetrievalOptions <ProgressEvents extends ProgressEvent<any
    * @default 2_097_152
    */
   maxSize?: number
+  provider?: string
 }
 
 export interface BlockAnnounceOptions <ProgressEvents extends ProgressEvent<any, any> = ProgressEvent<any, any>> extends AbortOptions, ProgressOptions<ProgressEvents> {


### PR DESCRIPTION
Ensure the `provider` option is correctly propagated from the API, through the session and broker layers, down to the trustless gateway HTTP request.

Fixes #816


