### PR TITLE
feat: expose providers option

### DIFF
--- a/packages/car/src/index.ts
+++ b/packages/car/src/index.ts
@@ -78,7 +78,7 @@
 
 import { Car as CarClass } from './car.js'
 import type { CodecLoader } from '@helia/interface'
-import type { PutManyBlocksProgressEvents, GetBlockProgressEvents } from '@helia/interface/blocks'
+import type { PutManyBlocksProgressEvents, GetBlockProgressEvents, ProviderOptions } from '@helia/interface/blocks'
 import type { CarWriter, CarReader } from '@ipld/car'
 import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { Filter } from '@libp2p/utils/filters'
@@ -127,7 +127,7 @@ export interface ExportStrategy {
 export * from './export-strategies/index.js'
 export * from './traversal-strategies/index.js'
 
-export interface ExportCarOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents> {
+export interface ExportCarOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents>, ProviderOptions {
 
   /**
    * If true, the blockstore will not do any network requests.

--- a/packages/dag-cbor/src/index.ts
+++ b/packages/dag-cbor/src/index.ts
@@ -28,7 +28,7 @@
 import * as codec from '@ipld/dag-cbor'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import type { GetBlockProgressEvents, PutBlockProgressEvents } from '@helia/interface/blocks'
+import type { GetBlockProgressEvents, ProviderOptions, PutBlockProgressEvents } from '@helia/interface/blocks'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
 import type { BlockCodec } from 'multiformats/codecs/interface'
@@ -43,7 +43,7 @@ export interface AddOptions extends AbortOptions, ProgressOptions<PutBlockProgre
   hasher: MultihashHasher
 }
 
-export interface GetOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents> {
+export interface GetOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents>, ProviderOptions {
   codec: BlockCodec<any, unknown>
 }
 

--- a/packages/dag-json/src/index.ts
+++ b/packages/dag-json/src/index.ts
@@ -28,7 +28,7 @@
 import * as codec from '@ipld/dag-json'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import type { GetBlockProgressEvents, PutBlockProgressEvents } from '@helia/interface/blocks'
+import type { GetBlockProgressEvents, ProviderOptions, PutBlockProgressEvents } from '@helia/interface/blocks'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
 import type { BlockCodec } from 'multiformats/codecs/interface'
@@ -43,7 +43,7 @@ export interface AddOptions extends AbortOptions, ProgressOptions<PutBlockProgre
   hasher: MultihashHasher
 }
 
-export interface GetOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents> {
+export interface GetOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents>, ProviderOptions {
   codec: BlockCodec<any, unknown>
 }
 

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -79,6 +79,7 @@
     "@libp2p/kad-dht": "^15.0.2",
     "@libp2p/keychain": "^5.0.10",
     "@libp2p/peer-id": "^5.0.8",
+    "@libp2p/utils": "^6.7.1",
     "@libp2p/websockets": "^9.0.13",
     "@multiformats/multiaddr": "^12.4.0",
     "@multiformats/sha3": "^3.0.2",

--- a/packages/interop/src/providers.spec.ts
+++ b/packages/interop/src/providers.spec.ts
@@ -1,0 +1,157 @@
+/* eslint-env mocha */
+
+import { car } from '@helia/car'
+import { dagCbor } from '@helia/dag-cbor'
+import { dagJson } from '@helia/dag-json'
+import { mfs } from '@helia/mfs'
+import { strings } from '@helia/strings'
+import { unixfs } from '@helia/unixfs'
+import { createScalableCuckooFilter } from '@libp2p/utils/filters'
+import { expect } from 'aegir/chai'
+import toBuffer from 'it-to-buffer'
+import { multiaddr } from 'kubo-rpc-client'
+import { CID } from 'multiformats/cid'
+import { createHeliaNode } from './fixtures/create-helia.js'
+import { createKuboNode } from './fixtures/create-kubo.js'
+import type { Helia } from 'helia'
+import type { FileCandidate } from 'ipfs-unixfs-importer'
+import type { KuboInfo, KuboNode } from 'ipfsd-ctl'
+
+describe('providers', () => {
+  let helia: Helia
+  let kubo: KuboNode
+  let cid: CID
+  let kuboInfo: KuboInfo
+  let input: Uint8Array[]
+
+  beforeEach(async () => {
+    // helia and kubo are not connected together before the test
+    helia = await createHeliaNode()
+    kubo = await createKuboNode()
+
+    const chunkSize = 1024 * 1024
+    const size = chunkSize * 10
+    input = []
+
+    const candidate: FileCandidate = {
+      content: (async function * () {
+        for (let i = 0; i < size; i += chunkSize) {
+          const buf = new Uint8Array(chunkSize)
+          input.push(buf)
+
+          yield buf
+        }
+      }())
+    }
+
+    const importResult = await kubo.api.add(candidate.content)
+    cid = CID.parse(importResult.cid.toString())
+    kuboInfo = await kubo.info()
+  })
+
+  afterEach(async () => {
+    if (helia != null) {
+      await helia.stop()
+    }
+
+    if (kubo != null) {
+      await kubo.stop()
+    }
+  })
+
+  it('should fetch raw using a provider', async () => {
+    const buf = await helia.blockstore.get(cid, {
+      providers: [
+        kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+      ]
+    })
+
+    expect(buf).to.have.lengthOf(1930)
+  })
+
+  it('should fetch dag-cbor using a provider', async () => {
+    const obj = { hello: 'world' }
+    const cid = await kubo.api.dag.put(obj, {
+      storeCodec: 'dag-cbor'
+    })
+
+    const d = dagCbor(helia)
+
+    await expect(d.get(cid, {
+      providers: [
+        kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+      ]
+    })).to.eventually.deep.equal(obj)
+  })
+
+  it('should fetch dag-json using a provider', async () => {
+    const obj = { hello: 'world' }
+    const cid = await kubo.api.dag.put(obj, {
+      storeCodec: 'dag-json'
+    })
+
+    const d = dagJson(helia)
+
+    await expect(d.get(cid, {
+      providers: [
+        kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+      ]
+    })).to.eventually.deep.equal(obj)
+  })
+
+  it('should fetch string using a provider', async () => {
+    const obj = 'hello world'
+    const cid = await kubo.api.dag.put(obj, {
+      storeCodec: 'dag-json'
+    })
+
+    const s = strings(helia)
+
+    await expect(s.get(cid, {
+      providers: [
+        kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+      ]
+    })).to.eventually.equal(JSON.stringify(obj))
+  })
+
+  it('should fetch via unixfs using a provider', async () => {
+    const fs = unixfs(helia)
+
+    const bytes = await toBuffer(fs.cat(cid, {
+      providers: [
+        kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+      ]
+    }))
+
+    expect(bytes).to.equalBytes(toBuffer(input))
+  })
+
+  it('should fetch via mfs using a provider', async () => {
+    const fs = mfs(helia)
+
+    await fs.cp(cid, '/file.txt', {
+      providers: [
+        kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+      ]
+    })
+
+    const bytes = await toBuffer(fs.cat('/file.txt'))
+
+    expect(bytes).to.equalBytes(toBuffer(input))
+  })
+
+  it('should fetch via car using a provider', async () => {
+    const c = car(helia)
+
+    expect(await toBuffer(
+      c.stream(cid, {
+        providers: [
+          kuboInfo.multiaddrs.map(ma => multiaddr(ma))
+        ],
+        blockFilter: createScalableCuckooFilter(10)
+      }))
+    ).to.equalBytes(await toBuffer(
+      kubo.api.dag.export(cid)
+    ))
+  })
+})

--- a/packages/strings/src/index.ts
+++ b/packages/strings/src/index.ts
@@ -27,7 +27,7 @@ import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import type { GetBlockProgressEvents, PutBlockProgressEvents } from '@helia/interface/blocks'
+import type { GetBlockProgressEvents, ProviderOptions, PutBlockProgressEvents } from '@helia/interface/blocks'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Blockstore } from 'interface-blockstore'
 import type { BlockCodec } from 'multiformats/codecs/interface'
@@ -43,7 +43,7 @@ export interface AddOptions extends AbortOptions, ProgressOptions<PutBlockProgre
   codec: BlockCodec<any, unknown>
 }
 
-export interface GetOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents> {
+export interface GetOptions extends AbortOptions, ProgressOptions<GetBlockProgressEvents>, ProviderOptions {
   codec: BlockCodec<any, unknown>
 }
 

--- a/packages/unixfs/src/index.ts
+++ b/packages/unixfs/src/index.ts
@@ -76,7 +76,7 @@
  */
 
 import { UnixFS as UnixFSClass } from './unixfs.js'
-import type { GetBlockProgressEvents, PutBlockProgressEvents } from '@helia/interface/blocks'
+import type { GetBlockProgressEvents, ProviderOptions, PutBlockProgressEvents } from '@helia/interface/blocks'
 import type { AbortOptions } from '@libp2p/interface'
 import type { Filter } from '@libp2p/utils/filters'
 import type { Blockstore } from 'interface-blockstore'
@@ -112,7 +112,7 @@ export type GetEvents = GetBlockProgressEvents
 /**
  * Options to pass to the cat command
  */
-export interface CatOptions extends AbortOptions, ProgressOptions<GetEvents> {
+export interface CatOptions extends AbortOptions, ProgressOptions<GetEvents>, ProviderOptions {
   /**
    * Start reading the file at this offset
    */
@@ -138,7 +138,7 @@ export interface CatOptions extends AbortOptions, ProgressOptions<GetEvents> {
 /**
  * Options to pass to the chmod command
  */
-export interface ChmodOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents> {
+export interface ChmodOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents>, ProviderOptions {
   /**
    * If the target of the operation is a directory and this is true,
    * apply the new mode to all directory contents
@@ -166,7 +166,7 @@ export interface ChmodOptions extends AbortOptions, ProgressOptions<GetEvents | 
 /**
  * Options to pass to the cp command
  */
-export interface CpOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents> {
+export interface CpOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents>, ProviderOptions {
   /**
    * If true, allow overwriting existing directory entries (default: false)
    */
@@ -215,7 +215,7 @@ export interface LsOptions extends AbortOptions, ProgressOptions<GetEvents> {
 /**
  * Options to pass to the mkdir command
  */
-export interface MkdirOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents> {
+export interface MkdirOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents>, ProviderOptions {
   /**
    * The CID version to create the new directory with - defaults to the same
    * version as the containing directory
@@ -253,7 +253,7 @@ export interface MkdirOptions extends AbortOptions, ProgressOptions<GetEvents | 
 /**
  * Options to pass to the rm command
  */
-export interface RmOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents> {
+export interface RmOptions extends AbortOptions, ProgressOptions<GetEvents | PutBlockProgressEvents>, ProviderOptions {
   /**
    * DAGs with a root block larger than this value will be sharded. Blocks
    * smaller than this value will be regular UnixFS directories.
@@ -270,7 +270,7 @@ export interface RmOptions extends AbortOptions, ProgressOptions<GetEvents | Put
 /**
  * Options to pass to the stat command
  */
-export interface StatOptions extends AbortOptions, ProgressOptions<GetEvents> {
+export interface StatOptions extends AbortOptions, ProgressOptions<GetEvents>, ProviderOptions {
   /**
    * An optional path to allow getting stats of paths inside directories
    */


### PR DESCRIPTION
Allows pre-seeding transfer sessions with known providers if they are available.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
