### PR TITLE
feat: add block received event

### DIFF
--- a/packages/bitswap/src/bitswap.ts
+++ b/packages/bitswap/src/bitswap.ts
@@ -12,7 +12,7 @@ import type { Logger } from '@libp2p/logger'
 import type { AbortOptions } from '@multiformats/multiaddr'
 import type { Blockstore } from 'interface-blockstore'
 import type { CID } from 'multiformats/cid'
-import type { ProgressOptions } from 'progress-events'
+import { CustomProgressEvent, type ProgressOptions } from 'progress-events'
 
 export interface WantOptions extends AbortOptions, ProgressOptions<BitswapWantProgressEvents>, ProviderOptions {
   /**
@@ -95,6 +95,8 @@ export class Bitswap implements BitswapInterface {
         ...options,
         signal
       })
+
+      options.onProgress?.(new CustomProgressEvent<{ cid: CID, sender: PeerId }>('bitswap:want-block:received', { cid, sender: result.sender }))
 
       return result.block
     } finally {

--- a/packages/bitswap/src/index.ts
+++ b/packages/bitswap/src/index.ts
@@ -26,6 +26,7 @@ export type BitswapNotifyProgressEvents =
 export type BitswapWantBlockProgressEvents =
   ProgressEvent<'bitswap:want-block:unwant', CID> |
   ProgressEvent<'bitswap:want-block:block', CID> |
+  ProgressEvent<'bitswap:want-block:received', { cid: CID, sender: PeerId }> |
   BitswapNetworkWantProgressEvents
 
 export type { BitswapNetworkNotifyProgressEvents }


### PR DESCRIPTION
Adds a bitswap event that tells us who sent us a block.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
