### PR TITLE
fix!: remove deprecated HeliaLibp2p interace

### DIFF
--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -50,13 +50,6 @@ export interface DAGWalker {
 }
 
 /**
- * Helia with a libp2p node
- *
- * @deprecated Use the `Helia` type instead. This will be removed in the next major version.
- */
-export type HeliaLibp2p = Helia
-
-/**
  * Create and return a Helia node
  */
 export async function createHelia <T extends Libp2p> (init: Partial<HeliaInit<T>>): Promise<Helia<T>>


### PR DESCRIPTION
Removes old interface, the plain `Helia` interface should be used instead.

BREAKING CHANGE: use `Helia` interface instead of `HeliaLibp2p`


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
