### PR TITLE
fix: enforce maximum identity hash size

### DIFF
--- a/benchmarks/add-dir/package.json
+++ b/benchmarks/add-dir/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@helia/unixfs": "^5.0.2",
     "aegir": "^47.0.7",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "blockstore-fs": "^3.0.2",
     "datastore-core": "^11.0.2",
     "datastore-level": "^12.0.2",

--- a/packages/bitswap/package.json
+++ b/packages/bitswap/package.json
@@ -81,7 +81,7 @@
     "@libp2p/peer-id": "^6.0.3",
     "@types/sinon": "^17.0.4",
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "delay": "^6.0.0",
     "it-all": "^3.0.9",
     "p-event": "^7.0.0",

--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -67,7 +67,7 @@
     "@ipld/dag-cbor": "^9.2.5",
     "@libp2p/logger": "^6.0.5",
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "datastore-core": "^11.0.2",
     "ipfs-unixfs-importer": "^16.0.1",
     "it-foreach": "^2.1.4",

--- a/packages/dag-cbor/package.json
+++ b/packages/dag-cbor/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2"
+    "blockstore-core": "^6.1.1"
   },
   "sideEffects": false
 }

--- a/packages/dag-json/package.json
+++ b/packages/dag-json/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2"
+    "blockstore-core": "^6.1.1"
   },
   "sideEffects": false
 }

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -75,7 +75,7 @@
     "@libp2p/webrtc": "^6.0.6",
     "@libp2p/websockets": "^10.0.6",
     "@multiformats/dns": "^1.0.9",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "datastore-core": "^11.0.2",
     "interface-datastore": "^9.0.2",
     "ipns": "^10.1.2",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -56,7 +56,7 @@
     "@libp2p/interface": "^3.0.2",
     "@libp2p/keychain": "^6.0.5",
     "@multiformats/dns": "^1.0.9",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "datastore-core": "^11.0.2",
     "interface-datastore": "^9.0.2",
     "libp2p": "^3.0.6"

--- a/packages/interop/src/helia-hashes.spec.ts
+++ b/packages/interop/src/helia-hashes.spec.ts
@@ -5,6 +5,7 @@ import { expect } from 'aegir/chai'
 import toBuffer from 'it-to-buffer'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
+import { identity } from 'multiformats/hashes/identity'
 import { createHeliaNode } from './fixtures/create-helia.js'
 import { createKuboNode } from './fixtures/create-kubo.js'
 import type { Helia } from 'helia'
@@ -53,5 +54,13 @@ describe('helia - hashes', () => {
     const output = await toBuffer(helia.blockstore.get(CID.parse(cid.toString())))
 
     expect(output).to.equalBytes(input)
+  })
+
+  it('should enforce a maximum size for identity hashes', async () => {
+    const cid = CID.createV1(raw.code, identity.digest(new Uint8Array(129)))
+
+    await expect(toBuffer(helia.blockstore.get(cid)))
+      .to.eventually.be.rejected
+      .with.property('name', 'IdentityHashDigestTooLongError')
   })
 })

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2"
+    "blockstore-core": "^6.1.1"
   },
   "sideEffects": false
 }

--- a/packages/mfs/package.json
+++ b/packages/mfs/package.json
@@ -60,7 +60,7 @@
     "@ipld/dag-pb": "^4.1.5",
     "@libp2p/logger": "^6.0.5",
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "datastore-core": "^11.0.2",
     "delay": "^6.0.0",
     "it-all": "^3.0.9",

--- a/packages/strings/package.json
+++ b/packages/strings/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2"
+    "blockstore-core": "^6.1.1"
   },
   "sideEffects": false
 }

--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "aegir": "^47.0.22",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "delay": "^6.0.0",
     "iso-url": "^1.2.1",
     "it-drain": "^3.0.10",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -58,7 +58,7 @@
     "@multiformats/dns": "^1.0.9",
     "@multiformats/multiaddr": "^13.0.1",
     "any-signal": "^4.1.1",
-    "blockstore-core": "^6.0.2",
+    "blockstore-core": "^6.1.1",
     "cborg": "^4.2.15",
     "interface-blockstore": "^6.0.1",
     "interface-datastore": "^9.0.2",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -168,6 +168,13 @@ export interface HeliaInit<T extends Libp2p = Libp2p> {
    * usage.
    */
   metrics?: Metrics
+
+  /**
+   * Limit the maximum supported size of identity hash digests to this value
+   *
+   * @default 128
+   */
+  maxIdentityHashDigestLength?: number
 }
 
 interface Components {
@@ -243,7 +250,7 @@ export class Helia<T extends Libp2p> implements HeliaInterface<T> {
       providerLookupConcurrency: init.providerLookupConcurrency
     })
 
-    const networkedStorage = new NetworkedStorage(components)
+    const networkedStorage = new NetworkedStorage(components, init)
     this.pins = new PinsImpl(init.datastore, networkedStorage, this.getCodec)
     this.blockstore = new BlockStorage(networkedStorage, this.pins, {
       holdGcLock: init.holdGcLock ?? true

--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -26,6 +26,12 @@ export interface StorageComponents {
   getHasher: HasherLoader
 }
 
+export interface StorageInit {
+  maxIdentityHashDigestLength?: number
+}
+
+const DEFAULT_MAX_IDENTITY_HASH_DIGEST_LENGTH = 128
+
 class Storage implements Blockstore {
   protected readonly child: Blockstore
   protected readonly getHasher: HasherLoader
@@ -36,11 +42,13 @@ class Storage implements Blockstore {
   /**
    * Create a new BlockStorage
    */
-  constructor (components: StorageComponents) {
+  constructor (components: StorageComponents, init: StorageInit = {}) {
     this.log = components.logger.forComponent('helia:networked-storage')
     this.logger = components.logger
     this.components = components
-    this.child = new IdentityBlockstore(components.blockstore)
+    this.child = new IdentityBlockstore(components.blockstore, {
+      maxDigestLength: init.maxIdentityHashDigestLength ?? DEFAULT_MAX_IDENTITY_HASH_DIGEST_LENGTH
+    })
     this.getHasher = components.getHasher
   }
 
@@ -191,8 +199,8 @@ export class NetworkedStorage extends Storage implements Blocks, Startable {
   /**
    * Create a new BlockStorage
    */
-  constructor (components: NetworkedStorageComponents) {
-    super(components)
+  constructor (components: NetworkedStorageComponents, init: StorageInit = {}) {
+    super(components, init)
 
     this.started = false
   }


### PR DESCRIPTION
Limit identity hash digest size to 128 bytes.

Fixes #846

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
