### PR TITLE
feat: add depth and breadth-first graph walkers to utils package

### DIFF
--- a/packages/utils/src/graph-walker.ts
+++ b/packages/utils/src/graph-walker.ts
@@ -1,10 +1,10 @@
-import type { CodecLoader } from "@helia/interface"
-import { Queue } from "@libp2p/utils"
-import type { Blockstore } from "interface-blockstore"
-import type { AbortOptions } from "interface-store"
-import toBuffer from "it-to-buffer"
-import type { BlockView, CID, Version } from "multiformats"
-import { createUnsafe } from "multiformats/block"
+import { Queue } from '@libp2p/utils'
+import toBuffer from 'it-to-buffer'
+import { createUnsafe } from 'multiformats/block'
+import type { CodecLoader } from '@helia/interface'
+import type { Blockstore } from 'interface-blockstore'
+import type { AbortOptions } from 'interface-store'
+import type { BlockView, CID, Version } from 'multiformats'
 
 export interface GraphWalkerComponents {
   blockstore: Blockstore
@@ -46,7 +46,7 @@ class DepthFirstGraphWalker {
     this.components = components
   }
 
-  async * walk <T = any> (cid: CID, options: AbortOptions) {
+  async * walk <T = any> (cid: CID, options: AbortOptions): AsyncGenerator<GraphNode<T>> {
     const queue = new Queue<GraphNode<T>, JobOptions>({
       concurrency: 1,
       sort: (a, b) => {
@@ -115,7 +115,7 @@ class BreadthFirstGraphWalker {
     this.components = components
   }
 
-  async * walk <T = any> (cid: CID, options: AbortOptions) {
+  async * walk <T = any> (cid: CID, options: AbortOptions): AsyncGenerator<GraphNode<T>> {
     const queue = new Queue<GraphNode<T>, JobOptions>({
       concurrency: 1,
       sort: (a, b) => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -36,7 +36,7 @@ export type { AbstractCreateSessionOptions, BlockstoreSessionEvents, AbstractSes
 
 export type { BlockStorage, BlockStorageInit }
 
-export { breadthFirstWalker, depthFirstWalker} from './graph-walker.ts'
+export { breadthFirstWalker, depthFirstWalker } from './graph-walker.ts'
 export type { GraphWalkerComponents, GraphWalkerInit, GraphNode, GraphWalker } from './graph-walker.ts'
 
 /**

--- a/packages/utils/test/graph-walker.spec.ts
+++ b/packages/utils/test/graph-walker.spec.ts
@@ -1,13 +1,13 @@
-import { MemoryBlockstore } from "blockstore-core"
 import * as dagCbor from '@ipld/dag-cbor'
-import type { Blockstore } from "interface-blockstore"
-import { CID } from 'multiformats/cid'
-import { sha256 } from "multiformats/hashes/sha2"
-import { breadthFirstWalker, depthFirstWalker } from "../src/graph-walker.ts"
-import type { CodecLoader } from "@helia/interface"
-import map from "it-map"
+import { expect } from 'aegir/chai'
+import { MemoryBlockstore } from 'blockstore-core'
 import all from 'it-all'
-import { expect } from "aegir/chai"
+import map from 'it-map'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { breadthFirstWalker, depthFirstWalker } from '../src/graph-walker.ts'
+import type { CodecLoader } from '@helia/interface'
+import type { Blockstore } from 'interface-blockstore'
 
 interface Node {
   name: string
@@ -104,7 +104,7 @@ describe('graph-walker', () => {
   })
 
   describe('depth-first', () => {
-    it.only('should walk depth-first', async () => {
+    it('should walk depth-first', async () => {
       const walker = depthFirstWalker({
         blockstore,
         getCodec
@@ -123,7 +123,7 @@ describe('graph-walker', () => {
   })
 
   describe('breadth-first', () => {
-    it.only('should walk breadth-first', async () => {
+    it('should walk breadth-first', async () => {
       const walker = breadthFirstWalker({
         blockstore,
         getCodec


### PR DESCRIPTION
Implement dag walking in a way that will not overflow the stack when walking over arbitrarily large DAGs.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
