### PR TITLE
feat: add `includeTraversalBlocks` options

### DIFF
--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -48,12 +48,13 @@
   },
   "dependencies": {
     "@helia/interface": "^6.0.0",
+    "@helia/utils": "^2.0.1",
     "@ipld/car": "^5.4.2",
     "@ipld/dag-pb": "^4.1.5",
     "@libp2p/interface": "^3.0.2",
     "@libp2p/utils": "^7.0.5",
     "interface-blockstore": "^6.0.1",
-    "ipfs-unixfs": "^12.0.0",
+    "ipfs-unixfs-exporter": "^14.0.1",
     "it-drain": "^3.0.10",
     "it-map": "^3.1.4",
     "it-to-buffer": "^4.0.10",
@@ -70,6 +71,7 @@
     "blockstore-core": "^6.1.1",
     "datastore-core": "^11.0.2",
     "ipfs-unixfs-importer": "^16.0.1",
+    "it-all": "^3.0.9",
     "it-foreach": "^2.1.4",
     "it-length": "^3.0.9",
     "sinon": "^21.0.0"

--- a/packages/car/src/errors.ts
+++ b/packages/car/src/errors.ts
@@ -6,3 +6,13 @@ export class NotUnixFSError extends Error {
   message = 'Not a UnixFS node'
   name = 'NotUnixFSError'
 }
+
+export class NotDescendantError extends Error {
+  static name = 'NotDescendantError'
+  name = 'NotDescendantError'
+}
+
+export class InvalidTraversalError extends Error {
+  static name = 'InvalidTraversalError'
+  name = 'InvalidTraversalError'
+}

--- a/packages/car/src/export-strategies/block-exporter.ts
+++ b/packages/car/src/export-strategies/block-exporter.ts
@@ -1,13 +1,22 @@
+import toBuffer from 'it-to-buffer'
+import { createUnsafe } from 'multiformats/block'
 import type { ExportStrategy } from '../index.js'
-import type { BlockView } from 'multiformats/block/interface'
+import type { CodecLoader } from '@helia/interface'
+import type { AbortOptions } from '@libp2p/interface'
+import type { Blockstore } from 'interface-blockstore'
+import type { BlockView } from 'multiformats'
 import type { CID } from 'multiformats/cid'
 
 /**
  * Yields the first block from the first CID and stops
  */
 export class BlockExporter implements ExportStrategy {
-  async * export (cid: CID, block: BlockView<any, any, any, 0 | 1>): AsyncGenerator<CID, void, undefined> {
-    // don't yield the block, index.ts will add it to the car file and then
-    // we're done
+  async * export (cid: CID, blockstore: Blockstore, getCodec: CodecLoader, options?: AbortOptions): AsyncGenerator<BlockView<unknown, number, number, 0 | 1>, void, undefined> {
+    const bytes = await toBuffer(blockstore.get(cid, options))
+    yield createUnsafe({
+      cid,
+      bytes,
+      codec: await getCodec(cid.code)
+    })
   }
 }

--- a/packages/car/src/export-strategies/subgraph-exporter.ts
+++ b/packages/car/src/export-strategies/subgraph-exporter.ts
@@ -1,5 +1,9 @@
+import { breadthFirstWalker } from '@helia/utils'
 import type { ExportStrategy } from '../index.js'
-import type { BlockView } from 'multiformats/block/interface'
+import type { CodecLoader } from '@helia/interface'
+import type { AbortOptions } from '@libp2p/interface'
+import type { Blockstore } from 'interface-blockstore'
+import type { BlockView } from 'multiformats'
 import type { CID } from 'multiformats/cid'
 
 /**
@@ -10,9 +14,14 @@ import type { CID } from 'multiformats/cid'
  * the helia config.
  */
 export class SubgraphExporter implements ExportStrategy {
-  async * export (_cid: CID, block: BlockView<any, any, any, 0 | 1>): AsyncGenerator<CID, void, undefined> {
-    for (const [, linkedCid] of block.links()) {
-      yield linkedCid
+  async * export (cid: CID, blockstore: Blockstore, getCodec: CodecLoader, options?: AbortOptions): AsyncGenerator<BlockView<unknown, number, number, 0 | 1>, void, undefined> {
+    const walker = breadthFirstWalker({
+      blockstore,
+      getCodec
+    })
+
+    for await (const node of walker.walk(cid, options)) {
+      yield node.block
     }
   }
 }

--- a/packages/car/src/export-strategies/unixfs-exporter.ts
+++ b/packages/car/src/export-strategies/unixfs-exporter.ts
@@ -1,22 +1,33 @@
-import { DAG_PB_CODEC_CODE, RAW_PB_CODEC_CODE } from '../constants.js'
-import { NotUnixFSError } from '../errors.js'
+import { depthFirstWalker } from '@helia/utils'
+import { DAG_PB_CODEC_CODE, RAW_PB_CODEC_CODE } from '../constants.ts'
+import { NotUnixFSError } from '../errors.ts'
 import type { ExportStrategy } from '../index.js'
-import type { BlockView } from 'multiformats/block/interface'
+import type { CodecLoader } from '@helia/interface'
+import type { AbortOptions } from '@libp2p/interface'
+import type { Blockstore } from 'interface-blockstore'
+import type { BlockView } from 'multiformats'
 import type { CID } from 'multiformats/cid'
 
 /**
- * This exporter is used when you want to generate a car file that contains a
- * single UnixFS file or directory
+ * Traverses the DAG depth-first starting at the target CID and yields all
+ * encountered blocks.
+ *
+ * Blocks linked to from the target block are traversed using codecs defined in
+ * the helia config.
  */
 export class UnixFSExporter implements ExportStrategy {
-  async * export (cid: CID, block: BlockView<any, any, any, 0 | 1>): AsyncGenerator<CID, void, undefined> {
+  async * export (cid: CID, blockstore: Blockstore, getCodec: CodecLoader, options?: AbortOptions): AsyncGenerator<BlockView<unknown, number, number, 0 | 1>, void, undefined> {
     if (cid.code !== DAG_PB_CODEC_CODE && cid.code !== RAW_PB_CODEC_CODE) {
       throw new NotUnixFSError('Target CID was not UnixFS - use the SubGraphExporter to export arbitrary graphs')
     }
 
-    // yield all the blocks that make up the file or directory
-    for (const [, linkedCid] of block.links()) {
-      yield linkedCid
+    const walker = depthFirstWalker({
+      blockstore,
+      getCodec
+    })
+
+    for await (const node of walker.walk(cid, options)) {
+      yield node.block
     }
   }
 }

--- a/packages/car/src/traversal-strategies/cid-path.ts
+++ b/packages/car/src/traversal-strategies/cid-path.ts
@@ -1,29 +1,59 @@
+import toBuffer from 'it-to-buffer'
+import { createUnsafe } from 'multiformats/block'
+import { InvalidTraversalError, NotDescendantError } from '../errors.js'
 import type { TraversalStrategy } from '../index.js'
-import type { BlockView } from 'multiformats/block/interface'
+import type { CodecLoader } from '@helia/interface'
+import type { AbortOptions } from '@libp2p/interface'
+import type { Blockstore } from 'interface-blockstore'
+import type { BlockView } from 'multiformats'
 import type { CID } from 'multiformats/cid'
 
 /**
  * Simple strategy that traverses a known path to a target CID.
  *
  * All this strategy does is yield the next CID in the known path.
+ *
+ * The path should end with the CID to be exported
  */
 export class CIDPath implements TraversalStrategy {
-  private readonly pathToTarget: CID[]
-  private readonly target: CID
+  private readonly path: CID[]
 
-  constructor (pathToTarget: CID[]) {
-    this.pathToTarget = pathToTarget
-    this.target = pathToTarget[pathToTarget.length - 1]
+  constructor (path: CID[]) {
+    this.path = path
   }
 
-  isTarget (cid: CID): boolean {
-    return this.target.equals(cid)
-  }
+  async * traverse (root: CID, blockstore: Blockstore, getCodec: CodecLoader, options?: AbortOptions): AsyncGenerator<BlockView<unknown, number, number, 0 | 1>, void, undefined> {
+    if (!this.path.some(c => c.equals(root))) {
+      throw new InvalidTraversalError(`CIDPath traversal must include ${root}`)
+    }
 
-  async * traverse <T extends BlockView<any, any, any, 0 | 1>>(cid: CID, _block?: T): AsyncGenerator<CID, void, undefined> {
-    const givenCidIndex = this.pathToTarget.indexOf(cid)
-    const nextCid = this.pathToTarget[givenCidIndex + 1]
+    let parentBlock: BlockView<unknown, number, number, 0 | 1> | undefined
 
-    yield nextCid
+    for (const cid of this.path) {
+      if (parentBlock != null) {
+        let isChild = false
+
+        for (const [, child] of parentBlock.links()) {
+          if (child.equals(cid)) {
+            isChild = true
+            break
+          }
+        }
+
+        if (!isChild) {
+          throw new NotDescendantError(`${cid} is not a child of ${parentBlock.cid}`)
+        }
+      }
+
+      const bytes = await toBuffer(blockstore.get(cid, options))
+      const block = createUnsafe({
+        cid,
+        bytes,
+        codec: await getCodec(cid.code)
+      })
+
+      parentBlock = block
+      yield block
+    }
   }
 }

--- a/packages/car/src/traversal-strategies/graph-search.ts
+++ b/packages/car/src/traversal-strategies/graph-search.ts
@@ -1,25 +1,83 @@
+import { breadthFirstWalker, depthFirstWalker } from '@helia/utils'
+import { InvalidParametersError } from '@libp2p/interface'
+import toBuffer from 'it-to-buffer'
+import { createUnsafe } from 'multiformats/block'
+import { InvalidTraversalError } from '../errors.ts'
 import type { TraversalStrategy } from '../index.js'
-import type { BlockView } from 'multiformats/block/interface'
+import type { CodecLoader } from '@helia/interface'
+import type { GraphWalker } from '@helia/utils'
+import type { AbortOptions } from '@libp2p/interface'
+import type { Blockstore } from 'interface-blockstore'
+import type { BlockView } from 'multiformats'
 import type { CID } from 'multiformats/cid'
 
+export interface GraphSearchOptions {
+  strategy?: 'depth-first' | 'breadth-first'
+}
+
+function isCID (obj?: any): obj is CID {
+  return obj != null && obj?.asCID === obj
+}
+
 /**
- * A traversal strategy that performs a breadth-first search (so as to not load blocks unnecessarily) looking for a
- * target CID. Traversal stops when we reach the target CID or run out of nodes.
+ * A traversal strategy that performs a depth-first search looking for a target
+ * CID.
  */
 export class GraphSearch implements TraversalStrategy {
-  private readonly target: CID
+  private haystack?: CID
+  private readonly needle: CID
+  private readonly options?: GraphSearchOptions
 
-  constructor (target: CID) {
-    this.target = target
-  }
-
-  isTarget (cid: CID): boolean {
-    return this.target.equals(cid)
-  }
-
-  async * traverse <T extends BlockView<any, any, any, 0 | 1>>(cid: CID, block: T): AsyncGenerator<CID, void, undefined> {
-    for (const [, linkedCid] of block.links()) {
-      yield linkedCid
+  constructor (needle: CID, options?: GraphSearchOptions)
+  constructor (haystack: CID, needle: CID, options?: GraphSearchOptions)
+  constructor (...args: any[]) {
+    if (isCID(args[0])) {
+      if (isCID(args[1])) {
+        this.haystack = args[0]
+        this.needle = args[1]
+        this.options = args[2]
+      } else {
+        this.needle = args[0]
+        this.options = args[1]
+      }
+    } else {
+      throw new InvalidParametersError('needle must be specified')
     }
+  }
+
+  async * traverse (root: CID, blockstore: Blockstore, getCodec: CodecLoader, options?: AbortOptions): AsyncGenerator<BlockView<unknown, number, number, 0 | 1>, void, undefined> {
+    const start = this.haystack ?? root
+    let walker: GraphWalker
+
+    if (this.options?.strategy === 'breadth-first') {
+      walker = breadthFirstWalker({
+        blockstore,
+        getCodec
+      })
+    } else {
+      walker = depthFirstWalker({
+        blockstore,
+        getCodec
+      })
+    }
+
+    for await (const node of walker.walk(start, options)) {
+      if (node.block.cid.equals(this.needle)) {
+        for (const cid of node.path) {
+          const bytes = await toBuffer(blockstore.get(cid, options))
+          const block = createUnsafe({
+            cid,
+            bytes,
+            codec: await getCodec(cid.code)
+          })
+
+          yield block
+        }
+
+        return
+      }
+    }
+
+    throw new InvalidTraversalError(`${this.needle} was not a child of ${start}`)
   }
 }


### PR DESCRIPTION
Adds an `includeTraversalBlocks` option to be explicit about when we want traversal blocks to be included and when not.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
