### PR TITLE
fix: listen for signal abort during session creation

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -73,6 +73,7 @@
     "multiformats": "^13.4.1",
     "p-defer": "^4.0.1",
     "progress-events": "^1.0.1",
+    "race-signal": "^2.0.0",
     "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
@@ -84,7 +85,6 @@
     "delay": "^6.0.0",
     "it-all": "^3.0.9",
     "it-map": "^3.1.4",
-    "race-signal": "^2.0.0",
     "sinon": "^21.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -457,6 +457,7 @@ async function raceBlockRetrievers (cid: CID, blockBrokers: BlockBroker[], hashe
               signal,
               validateFn: async (block: Uint8Array): Promise<void> => {
                 await validateFn(block)
+                options.signal?.throwIfAborted()
                 blocksWereValidated = true
               }
             })
@@ -465,6 +466,7 @@ async function raceBlockRetrievers (cid: CID, blockBrokers: BlockBroker[], hashe
               // the blockBroker either did not throw an error when attempting to validate the block
               // or did not call the validateFn at all. We should validate the block ourselves
               await validateFn(block)
+              options.signal?.throwIfAborted()
             }
 
             return block


### PR DESCRIPTION
Handles signals aborting in a few places where it was missed

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
