### PR TITLE
feat: allow filtering children

### DIFF
--- a/packages/utils/test/graph-walker.spec.ts
+++ b/packages/utils/test/graph-walker.spec.ts
@@ -120,6 +120,27 @@ describe('graph-walker', () => {
         'root', 'a', 'd', 'e', 'f', 'b', 'g', 'h', 'i', 'c', 'j', 'k', 'l'
       ])
     })
+
+    it('should filter children', async () => {
+      const walker = depthFirstWalker({
+        blockstore,
+        getCodec
+      })
+
+      const result = await all(map(walker.walk(nodes.root.cid, {
+        includeChild (child, parent) {
+          return parent.value.name === 'root' || parent.value.name === 'a'
+        }
+      }), (node) => {
+        const obj = dagCbor.decode<Node>(node.block.bytes)
+
+        return obj.name
+      }))
+
+      expect(result).to.deep.equal([
+        'root', 'a', 'd', 'e', 'f', 'b', 'c'
+      ])
+    })
   })
 
   describe('breadth-first', () => {
@@ -137,6 +158,27 @@ describe('graph-walker', () => {
 
       expect(result).to.deep.equal([
         'root', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'
+      ])
+    })
+
+    it('should filter children', async () => {
+      const walker = breadthFirstWalker({
+        blockstore,
+        getCodec
+      })
+
+      const result = await all(map(walker.walk(nodes.root.cid, {
+        includeChild (child, parent) {
+          return parent.value.name === 'root' || parent.value.name === 'a'
+        }
+      }), (node) => {
+        const obj = dagCbor.decode<Node>(node.block.bytes)
+
+        return obj.name
+      }))
+
+      expect(result).to.deep.equal([
+        'root', 'a', 'b', 'c', 'd', 'e', 'f'
       ])
     })
   })


### PR DESCRIPTION
Adds an `includeChild` traversal option to not include children in the traversal before their block is loaded.


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
