### PR TITLE
fix: update log formatting to print errors correctly

### DIFF
--- a/packages/bitswap/src/bitswap.ts
+++ b/packages/bitswap/src/bitswap.ts
@@ -86,7 +86,7 @@ export class Bitswap implements BitswapInterface {
         // if the controller was aborted we found the block already so ignore
         // the error
         if (!controller.signal.aborted) {
-          this.log.error('error during finding and connect for cid %c', cid, err)
+          this.log.error('error during finding and connect for cid %c - %e', cid, err)
         }
       })
 

--- a/packages/bitswap/src/network.ts
+++ b/packages/bitswap/src/network.ts
@@ -234,14 +234,14 @@ export class Network extends TypedEventEmitter<NetworkEvents> {
           setMaxListeners(Infinity, signal)
           signal.addEventListener('abort', abortListener)
         } catch (err: any) {
-          this.log.error('error reading incoming bitswap message from %p on stream', connection.remotePeer, stream.id, err)
+          this.log.error('error reading incoming bitswap message from %p on stream - %e', connection.remotePeer, stream.id, err)
           stream.abort(err)
           break
         }
       }
     })
       .catch(err => {
-        this.log.error('error handling incoming stream from %p', connection.remotePeer, err)
+        this.log.error('error handling incoming stream from %p - %e', connection.remotePeer, err)
         stream.abort(err)
       })
   }
@@ -339,7 +339,7 @@ export class Network extends TypedEventEmitter<NetworkEvents> {
         await stream.close(options)
       } catch (err: any) {
         options?.onProgress?.(new CustomProgressEvent<{ peer: PeerId, error: Error }>('bitswap:network:send-wantlist:error', { peer: peerId, error: err }))
-        this.log.error('error sending message to %p', peerId, err)
+        this.log.error('error sending message to %p - %e', peerId, err)
         stream.abort(err)
       }
 

--- a/packages/bitswap/src/peer-want-lists/index.ts
+++ b/packages/bitswap/src/peer-want-lists/index.ts
@@ -54,7 +54,7 @@ export class PeerWantLists {
     this.network.addEventListener('bitswap:message', (evt) => {
       this.receiveMessage(evt.detail.peer, evt.detail.message)
         .catch(err => {
-          this.log.error('error receiving bitswap message from %p', evt.detail.peer, err)
+          this.log.error('error receiving bitswap message from %p - %e', evt.detail.peer, err)
         })
     })
     this.network.addEventListener('peer:disconnected', evt => {

--- a/packages/bitswap/src/want-list.ts
+++ b/packages/bitswap/src/want-list.ts
@@ -126,13 +126,13 @@ export class WantList extends TypedEventEmitter<WantListEvents> implements Start
     this.network.addEventListener('bitswap:message', (evt) => {
       this.receiveMessage(evt.detail.peer, evt.detail.message)
         .catch(err => {
-          this.log.error('error receiving bitswap message from %p', evt.detail.peer, err)
+          this.log.error('error receiving bitswap message from %p - %e', evt.detail.peer, err)
         })
     })
     this.network.addEventListener('peer:connected', evt => {
       this.peerConnected(evt.detail)
         .catch(err => {
-          this.log.error('error processing newly connected bitswap peer %p', evt.detail, err)
+          this.log.error('error processing newly connected bitswap peer %p - %e', evt.detail, err)
         })
     })
     this.network.addEventListener('peer:disconnected', evt => {
@@ -205,7 +205,7 @@ export class WantList extends TypedEventEmitter<WantListEvents> implements Start
     this.sendMessagesTimeout = setTimeout(() => {
       void this.sendMessages()
         .catch(err => {
-          this.log('error sending messages to peers', err)
+          this.log('error sending messages to peers - %e', err)
         })
     }, this.sendMessagesDelay)
   }
@@ -251,11 +251,11 @@ export class WantList extends TypedEventEmitter<WantListEvents> implements Start
             sentWants.add(key)
           }
         } catch (err: any) {
-          this.log.error('error sending full wantlist to new peer', err)
+          this.log.error('error sending full wantlist to new peer - %e', err)
         }
       })
     ).catch(err => {
-      this.log.error('error sending messages', err)
+      this.log.error('error sending messages - %e', err)
     })
 
     // queued all message sends, remove cancelled wants from wantlist and sent
@@ -478,7 +478,7 @@ export class WantList extends TypedEventEmitter<WantListEvents> implements Start
 
       this.peers.set(peerId, sentWants)
     } catch (err) {
-      this.log.error('error sending full wantlist to new peer %p', peerId, err)
+      this.log.error('error sending full wantlist to new peer %p - %e', peerId, err)
     }
   }
 

--- a/packages/block-brokers/src/trustless-gateway/broker.ts
+++ b/packages/block-brokers/src/trustless-gateway/broker.ts
@@ -67,14 +67,14 @@ export class TrustlessGatewayBlockBroker implements BlockBroker<TrustlessGateway
         try {
           await options.validateFn?.(block)
         } catch (err) {
-          this.log.error('failed to validate block for %c from %s', cid, gateway.url, err)
+          this.log.error('failed to validate block for %c from %s - %e', cid, gateway.url, err)
           // try another gateway
           continue
         }
 
         return block
       } catch (err: unknown) {
-        this.log.error('failed to get block for %c from %s', cid, gateway.url, err)
+        this.log.error('failed to get block for %c from %s - %e', cid, gateway.url, err)
 
         if (err instanceof Error) {
           aggregateErrors.push(err)

--- a/packages/dnslink/src/dnslink.ts
+++ b/packages/dnslink/src/dnslink.ts
@@ -171,7 +171,7 @@ export class DNSLink <Namespaces extends Record<string, DNSLinkParser<DNSLinkRes
 
         output.push(parser(result, answer))
       } catch (err: any) {
-        this.log.error('could not parse DNS link record for domain %s, %s', domain, answer.data, err)
+        this.log.error('could not parse DNS link record for domain %s, %s - %e', domain, answer.data, err)
       }
     }
 

--- a/packages/ipns/src/ipns/republisher.ts
+++ b/packages/ipns/src/ipns/republisher.ts
@@ -107,14 +107,14 @@ export class IPNSRepublisher {
         try {
           privKey = await this.keychain.exportKey(metadata.keyName)
         } catch (err: any) {
-          this.log.error(`missing key ${metadata.keyName}, skipping republishing record`, err)
+          this.log.error('missing key %s, skipping republishing record - %e', metadata.keyName, err)
           continue
         }
         try {
           const updatedRecord = await createIPNSRecord(privKey, ipnsRecord.value, sequenceNumber, metadata.lifetime, { ...options, ttlNs })
           recordsToRepublish.push({ routingKey, record: updatedRecord })
         } catch (err: any) {
-          this.log.error(`error creating updated IPNS record for ${routingKey.toString()}`, err)
+          this.log.error('error creating updated IPNS record for %s - %e', routingKey, err)
           continue
         }
       }

--- a/packages/ipns/src/routing/pubsub.ts
+++ b/packages/ipns/src/routing/pubsub.ts
@@ -77,7 +77,7 @@ class PubSubRouting implements IPNSRouting {
       }
 
       this.#processPubSubMessage(message).catch(err => {
-        log.error('Error processing message', err)
+        log.error('Error processing message - %e', err)
       })
     })
   }

--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -133,7 +133,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
           deferred.resolve(await this.retrieve(cid, options))
         })
         .catch(err => {
-          this.log.error('could not find new providers for %c', cid, err)
+          this.log.error('could not find new providers for %c - %e', cid, err)
           deferred.reject(err)
         })
     })
@@ -151,7 +151,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
             return
           }
 
-          this.log.error('error retrieving session block for %c', cid, err)
+          this.log.error('error retrieving session block for %c - %e', cid, err)
         })
     }
 
@@ -173,7 +173,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
           return
         }
 
-        this.log.error('error retrieving session block for %c', cid, err)
+        this.log.error('error retrieving session block for %c - %e', cid, err)
       })
 
     const signalAbortedListener = (): void => {
@@ -319,7 +319,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
         }
       })
       .catch(err => {
-        this.log.error('error searching routing for potential session peers for %c', cid, err.errors ?? err)
+        this.log.error('error searching routing for potential session peers for %c - %e', cid, err)
         deferred.reject(err)
       })
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -306,7 +306,7 @@ export class Helia<T extends Libp2p> implements HeliaInterface<T> {
 
             options.onProgress?.(new CustomProgressEvent<CID>('helia:gc:deleted', cid))
           } catch (err: any) {
-            helia.log.error('Error during gc', err)
+            helia.log.error('error during gc - %e', err)
             options.onProgress?.(new CustomProgressEvent<Error>('helia:gc:error', err))
           }
         }

--- a/packages/utils/src/routing.ts
+++ b/packages/utils/src/routing.ts
@@ -104,7 +104,7 @@ export class Routing implements RoutingInterface, Startable {
 
             return provider
           } catch (err) {
-            this.log.error('could not load multiaddrs for peer %p', peer.id, err)
+            this.log.error('could not load multiaddrs for peer %p - %e', peer.id, err)
             return null
           }
         }, {
@@ -112,7 +112,7 @@ export class Routing implements RoutingInterface, Startable {
           signal: options.signal
         })
           .catch(err => {
-            this.log.error('could not load multiaddrs for peer %p', peer.id, err)
+            this.log.error('could not load multiaddrs for peer %p - %e', peer.id, err)
           })
       }
 

--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -476,7 +476,7 @@ async function raceBlockRetrievers (cid: CID, blockBrokers: BlockBroker[], hashe
 
             return block
           } catch (err) {
-            options.log.error('could not retrieve verified block for %c', cid, err)
+            options.log.error('could not retrieve verified block for %c - %e', cid, err)
             throw err
           }
         })


### PR DESCRIPTION
Ensure that errors are passed with the `%e` formatter so they are logged correctly.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
