### PR TITLE
fix: remove block request promise when initial provider search fails

### DIFF
--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -73,10 +73,21 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
         this.initialPeerSearchComplete = this.findProviders(cid, this.minProviders, options)
       }
 
-      await raceSignal(this.initialPeerSearchComplete, options.signal)
+      try {
+        await raceSignal(this.initialPeerSearchComplete, options.signal)
 
-      if (first) {
-        this.log('found initial session peers for %c', cid)
+        if (first) {
+          this.log('found initial session peers for %c', cid)
+        }
+      } catch (err) {
+        if (first) {
+          this.log('failed to find initial session peers for %c - %e', cid, err)
+        }
+
+        this.requests.delete(cidStr)
+        deferred.reject(err)
+
+        throw err
       }
     }
 


### PR DESCRIPTION
Remove the deferred promise when the initial provider search fails otherwise other requesters will join the same promise which then never resolves.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
