### PR TITLE
fix: add provider events to bitswap and trustless gateways

### DIFF
--- a/packages/bitswap/src/bitswap.ts
+++ b/packages/bitswap/src/bitswap.ts
@@ -96,7 +96,7 @@ export class Bitswap implements BitswapInterface {
         signal
       })
 
-      options.onProgress?.(new CustomProgressEvent<{ cid: CID, sender: PeerId }>('bitswap:want-block:received', { cid, sender: result.sender }))
+      options.onProgress?.(new CustomProgressEvent<{ cid: CID, sender: PeerId }>('bitswap:block', { cid, sender: result.sender }))
 
       return result.block
     } finally {

--- a/packages/bitswap/src/index.ts
+++ b/packages/bitswap/src/index.ts
@@ -24,15 +24,16 @@ export type BitswapNotifyProgressEvents =
   BitswapNetworkNotifyProgressEvents
 
 export type BitswapWantBlockProgressEvents =
-  ProgressEvent<'bitswap:want-block:unwant', CID> |
-  ProgressEvent<'bitswap:want-block:block', CID> |
-  ProgressEvent<'bitswap:want-block:received', { cid: CID, sender: PeerId }> |
+  ProgressEvent<'bitswap:unwant', CID> |
+  ProgressEvent<'bitswap:want', CID> |
+  ProgressEvent<'bitswap:block', { cid: CID, sender: PeerId }> |
   BitswapNetworkWantProgressEvents
 
 export type { BitswapNetworkNotifyProgressEvents }
 export type { BitswapNetworkWantProgressEvents }
 export type { BitswapNetworkProgressEvents }
 export type { WantType }
+export type { BitswapProvider } from './network.ts'
 
 export interface WantListEntry {
   cid: CID

--- a/packages/bitswap/test/network.spec.ts
+++ b/packages/bitswap/test/network.spec.ts
@@ -158,7 +158,8 @@ describe('network', () => {
       id: peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -181,7 +182,8 @@ describe('network', () => {
       id: peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001/p2p-circuit')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -216,7 +218,8 @@ describe('network', () => {
       id: peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001/p2p-circuit')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -239,7 +242,8 @@ describe('network', () => {
       id: peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -298,7 +302,8 @@ describe('network', () => {
       id: peerId,
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001/p2p-circuit')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {

--- a/packages/bitswap/test/session.spec.ts
+++ b/packages/bitswap/test/session.spec.ts
@@ -52,7 +52,8 @@ describe('session', () => {
           id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
           multiaddrs: [
             multiaddr(`/ip4/4${i}.4${i}.4${i}.4${i}/tcp/${1234 + i}`)
-          ]
+          ],
+          routing: 'test-routing'
         }
       })
     )
@@ -125,7 +126,8 @@ describe('session', () => {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         multiaddr('/ip4/41.41.41.41/tcp/1234')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.network.findProviders.withArgs(cid).returns((async function * () {
@@ -150,12 +152,14 @@ describe('session', () => {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         multiaddr('/ip4/41.41.41.41/tcp/1234')
-      ]
+      ],
+      routing: 'test-routing'
     }, {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         multiaddr('/ip4/41.41.41.41/tcp/1235')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.network.findProviders.withArgs(cid).returns((async function * () {

--- a/packages/block-brokers/src/index.ts
+++ b/packages/block-brokers/src/index.ts
@@ -50,4 +50,5 @@
 export { bitswap } from './bitswap.js'
 export type { BitswapBlockBrokerInit, BitswapBlockBrokerComponents } from './bitswap.js'
 export { trustlessGateway } from './trustless-gateway/index.js'
-export type { TrustlessGatewayBlockBrokerInit, TrustlessGatewayBlockBrokerComponents, TrustlessGatewayGetBlockProgressEvents } from './trustless-gateway/index.js'
+export type { TrustlessGatewayBlockBrokerInit, TrustlessGatewayBlockBrokerComponents, TrustlessGatewayGetBlockProgressEvents, TrustlessGatewayProvider } from './trustless-gateway/index.js'
+export type { BitswapProvider } from '@helia/bitswap'

--- a/packages/block-brokers/src/trustless-gateway/index.ts
+++ b/packages/block-brokers/src/trustless-gateway/index.ts
@@ -2,6 +2,7 @@ import { TrustlessGatewayBlockBroker } from './broker.js'
 import type { TransformRequestInit } from './trustless-gateway.js'
 import type { Routing, BlockBroker } from '@helia/interface'
 import type { ComponentLogger } from '@libp2p/interface'
+import type { CID } from 'multiformats'
 import type { ProgressEvent } from 'progress-events'
 
 export const DEFAULT_ALLOW_INSECURE = false
@@ -13,8 +14,31 @@ export const DEFAULT_ALLOW_LOCAL = false
  */
 export const DEFAULT_MAX_SIZE = 2_097_152
 
+export interface TrustlessGatewayProvider {
+  /**
+   * The type of provider
+   */
+  type: 'trustless-gateway'
+
+  /**
+   * The CID that the provider can provide the block for
+   */
+  cid: CID
+
+  /**
+   * The provider's URL
+   */
+  url: string
+
+  /**
+   * Which routing implementation found the provider
+   */
+  routing: string
+}
+
 export type TrustlessGatewayGetBlockProgressEvents =
-  ProgressEvent<'trustless-gateway:get-block:fetch', URL>
+  ProgressEvent<'trustless-gateway:get-block:fetch', URL> |
+  ProgressEvent<'trustless-gateway:found-provider', TrustlessGatewayProvider>
 
 export interface TrustlessGatewayBlockBrokerInit {
   /**

--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -1,13 +1,16 @@
 import { getNetConfig, isPrivate } from '@libp2p/utils'
 import { DNS, HTTP, HTTPS } from '@multiformats/multiaddr-matcher'
 import { multiaddrToUri } from '@multiformats/multiaddr-to-uri'
+import { CustomProgressEvent } from 'progress-events'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { TrustlessGateway } from './trustless-gateway.js'
+import type { TrustlessGatewayGetBlockProgressEvents, TrustlessGatewayProvider } from './index.ts'
 import type { TransformRequestInit } from './trustless-gateway.js'
 import type { Routing } from '@helia/interface'
 import type { ComponentLogger, Logger, AbortOptions } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { CID } from 'multiformats/cid'
+import type { ProgressOptions } from 'progress-events'
 
 export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure: boolean, allowLocal: boolean): Multiaddr[] {
   return multiaddrs.filter(ma => {
@@ -36,7 +39,7 @@ export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure:
   })
 }
 
-export interface FindHttpGatewayProvidersOptions extends AbortOptions {
+export interface FindHttpGatewayProvidersOptions extends AbortOptions, ProgressOptions<TrustlessGatewayGetBlockProgressEvents> {
   transformRequestInit?: TransformRequestInit
 }
 
@@ -54,6 +57,15 @@ export async function * findHttpGatewayProviders (cid: CID, routing: Routing, lo
     // /ip4/x.x.x.x/tcp/31337/https
     // etc
     const uri = multiaddrToUri(httpAddresses[0])
+
+    const prov: TrustlessGatewayProvider = {
+      type: 'trustless-gateway',
+      cid,
+      url: uri.toString(),
+      routing: provider.routing
+    }
+
+    options?.onProgress?.(new CustomProgressEvent('trustless-gateway:found-provider', prov))
 
     yield new TrustlessGateway(uri, { logger, transformRequestInit: options.transformRequestInit })
   }

--- a/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-sessions.spec.ts
@@ -18,7 +18,7 @@ import type { StubbedInstance } from 'sinon-ts'
 
 interface StubbedTrustlessGatewaySessionComponents {
   logger: ComponentLogger
-  routing: StubbedInstance<Routing>
+  routing: StubbedInstance<Required<Routing>>
 }
 
 describe('trustless-gateway sessions', () => {
@@ -27,7 +27,7 @@ describe('trustless-gateway sessions', () => {
   beforeEach(async () => {
     components = {
       logger: defaultLogger(),
-      routing: stubInterface<Routing>()
+      routing: stubInterface()
     }
   })
 
@@ -45,7 +45,8 @@ describe('trustless-gateway sessions', () => {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
-        ]
+        ],
+        routing: 'test-routing'
       }
     }())
 
@@ -66,19 +67,22 @@ describe('trustless-gateway sessions', () => {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           multiaddr('/ip4/127.0.0.1/tcp/1234')
-        ]
+        ],
+        routing: 'test-routing'
       }
       yield {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           multiaddr('/ip4/127.0.0.1/udp/1234/quic-v1')
-        ]
+        ],
+        routing: 'test-routing'
       }
       yield {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
-        ]
+        ],
+        routing: 'test-routing'
       }
     }())
 
@@ -100,7 +104,8 @@ describe('trustless-gateway sessions', () => {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
-      ]
+      ],
+      routing: 'test-routing'
     }
 
     components.routing.findProviders.returns(async function * () {
@@ -133,7 +138,8 @@ describe('trustless-gateway sessions', () => {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           uriToMultiaddr(process.env.BAD_TRUSTLESS_GATEWAY ?? '')
-        ]
+        ],
+        routing: 'test-routing'
       }
     }())
 
@@ -153,13 +159,15 @@ describe('trustless-gateway sessions', () => {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         uriToMultiaddr(process.env.BAD_TRUSTLESS_GATEWAY ?? '')
-      ]
+      ],
+      routing: 'test-routing'
     },
     {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
-      ]
+      ],
+      routing: 'test-routing'
     }]
 
     components.routing.findProviders.returns(async function * () {

--- a/packages/block-brokers/test/trustless-gateway.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway.spec.ts
@@ -12,15 +12,14 @@ import { stubInterface } from 'sinon-ts'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { TrustlessGatewayBlockBroker } from '../src/trustless-gateway/broker.js'
 import { TrustlessGateway } from '../src/trustless-gateway/trustless-gateway.js'
-import type { Routing } from '@helia/interface'
-import type { PeerInfo } from '@libp2p/interface'
+import type { Provider, Routing } from '@helia/interface'
 import type { StubbedInstance } from 'sinon-ts'
 
 describe('trustless-gateway-block-broker', () => {
   let gatewayBlockBroker: TrustlessGatewayBlockBroker
-  let routing: StubbedInstance<Routing>
-  let badGatewayPeer: PeerInfo
-  let goodGatewayPeer: PeerInfo
+  let routing: StubbedInstance<Required<Routing>>
+  let badGatewayPeer: Provider
+  let goodGatewayPeer: Provider
   let cid: CID
   let expectedBlock: Uint8Array
 
@@ -29,19 +28,21 @@ describe('trustless-gateway-block-broker', () => {
     cid = CID.parse('bafkreiefnkxuhnq3536qo2i2w3tazvifek4mbbzb6zlq3ouhprjce5c3aq')
     expectedBlock = Uint8Array.from([0, 1, 2, 0])
 
-    routing = stubInterface<Routing>()
+    routing = stubInterface()
 
     badGatewayPeer = {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         uriToMultiaddr(process.env.BAD_TRUSTLESS_GATEWAY ?? '')
-      ]
+      ],
+      routing: 'test-routing'
     }
     goodGatewayPeer = {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
       multiaddrs: [
         uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
-      ]
+      ],
+      routing: 'test-routing'
     }
 
     gatewayBlockBroker = new TrustlessGatewayBlockBroker({
@@ -116,19 +117,22 @@ describe('trustless-gateway-block-broker', () => {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           multiaddr('/ip4/132.32.25.6/tcp/1234')
-        ]
+        ],
+        routing: 'test-routing'
       }
       // expired peer info
       yield {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
-        multiaddrs: []
+        multiaddrs: [],
+        routing: 'test-routing'
       }
       // http gateway
       yield {
         id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
         multiaddrs: [
           uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
-        ]
+        ],
+        routing: 'test-routing'
       }
     }())
 

--- a/packages/interface/src/routing.ts
+++ b/packages/interface/src/routing.ts
@@ -48,6 +48,11 @@ export interface Provider extends PeerInfo {
    * - transport-bitswap
    */
   protocols?: string[]
+
+  /**
+   * The name of the routing implementation that found the provider
+   */
+  routing: string
 }
 
 export interface Routing {

--- a/packages/interop/src/providers.spec.ts
+++ b/packages/interop/src/providers.spec.ts
@@ -78,7 +78,7 @@ describe('providers', () => {
       ],
       onProgress (evt) {
         // @ts-expect-error cannot derive config-based progress event types
-        if (evt.type === 'bitswap:want-block:received') {
+        if (evt.type === 'bitswap:block') {
           // @ts-expect-error cannot derive config-based progress event types
           sender = evt.detail.sender
         }
@@ -104,7 +104,7 @@ describe('providers', () => {
       ],
       onProgress (evt) {
         // @ts-expect-error cannot derive config-based progress event types
-        if (evt.type === 'bitswap:want-block:received') {
+        if (evt.type === 'bitswap:block') {
           // @ts-expect-error cannot derive config-based progress event types
           sender = evt.detail.sender
         }
@@ -128,7 +128,7 @@ describe('providers', () => {
       ],
       onProgress (evt) {
         // @ts-expect-error cannot derive config-based progress event types
-        if (evt.type === 'bitswap:want-block:received') {
+        if (evt.type === 'bitswap:block') {
           // @ts-expect-error cannot derive config-based progress event types
           sender = evt.detail.sender
         }
@@ -152,7 +152,7 @@ describe('providers', () => {
       ],
       onProgress (evt) {
         // @ts-expect-error cannot derive config-based progress event types
-        if (evt.type === 'bitswap:want-block:received') {
+        if (evt.type === 'bitswap:block') {
           // @ts-expect-error cannot derive config-based progress event types
           sender = evt.detail.sender
         }
@@ -171,7 +171,7 @@ describe('providers', () => {
       ],
       onProgress (evt) {
         // @ts-expect-error cannot derive config-based progress event types
-        if (evt.type === 'bitswap:want-block:received') {
+        if (evt.type === 'bitswap:block') {
           // @ts-expect-error cannot derive config-based progress event types
           sender = evt.detail.sender
         }
@@ -192,7 +192,7 @@ describe('providers', () => {
       ],
       onProgress (evt) {
         // @ts-expect-error cannot derive config-based progress event types
-        if (evt.type === 'bitswap:want-block:received') {
+        if (evt.type === 'bitswap:block') {
           // @ts-expect-error cannot derive config-based progress event types
           sender = evt.detail.sender
         }
@@ -217,7 +217,7 @@ describe('providers', () => {
         blockFilter: createScalableCuckooFilter(10),
         onProgress (evt) {
           // @ts-expect-error cannot derive config-based progress event types
-          if (evt.type === 'bitswap:want-block:received') {
+          if (evt.type === 'bitswap:block') {
             // @ts-expect-error cannot derive config-based progress event types
             sender = evt.detail.sender
           }

--- a/packages/routers/src/delegated-http-routing.ts
+++ b/packages/routers/src/delegated-http-routing.ts
@@ -38,7 +38,8 @@ class DelegatedHTTPRouter implements Routing {
       return {
         id: record.ID,
         multiaddrs: record.Addrs,
-        protocols: record.Protocols
+        protocols: record.Protocols,
+        routing: 'delegated-http-routing'
       }
     })
   }

--- a/packages/routers/src/http-gateway-routing.ts
+++ b/packages/routers/src/http-gateway-routing.ts
@@ -52,10 +52,15 @@ class HTTPGatewayRouter implements Partial<Routing> {
     yield * (this.shuffle
       ? this.gateways.toSorted(() => Math.random() > 0.5 ? 1 : -1)
       : this.gateways
-    ).map(info => ({
-      ...info,
-      protocols: ['transport-ipfs-gateway-http']
-    }))
+    ).map(info => {
+      const provider = {
+        ...info,
+        protocols: ['transport-ipfs-gateway-http'],
+        routing: 'http-gateway-routing'
+      }
+
+      return provider
+    })
   }
 }
 

--- a/packages/routers/src/libp2p-routing.ts
+++ b/packages/routers/src/libp2p-routing.ts
@@ -1,3 +1,4 @@
+import map from 'it-map'
 import type { Provider, Routing, RoutingOptions } from '@helia/interface'
 import type { Libp2p, PeerId, PeerInfo } from '@libp2p/interface'
 import type { CID } from 'multiformats'
@@ -18,7 +19,12 @@ class Libp2pRouter implements Routing {
   }
 
   async * findProviders (cid: CID, options?: RoutingOptions): AsyncIterable<Provider> {
-    yield * this.libp2p.contentRouting.findProviders(cid, options)
+    yield * map(this.libp2p.contentRouting.findProviders(cid, options), (info) => {
+      return {
+        ...info,
+        routing: 'libp2p'
+      }
+    })
   }
 
   async put (key: Uint8Array, value: Uint8Array, options?: RoutingOptions): Promise<void> {

--- a/packages/utils/src/routing.ts
+++ b/packages/utils/src/routing.ts
@@ -102,7 +102,11 @@ export class Routing implements RoutingInterface, Startable {
               return null
             }
 
-            return provider
+            return {
+              ...provider,
+              protocols: peer.protocols,
+              routing: peer.routing
+            }
           } catch (err) {
             this.log.error('could not load multiaddrs for peer %p - %e', peer.id, err)
             return null
@@ -114,6 +118,8 @@ export class Routing implements RoutingInterface, Startable {
           .catch(err => {
             this.log.error('could not load multiaddrs for peer %p - %e', peer.id, err)
           })
+
+        continue
       }
 
       yield peer


### PR DESCRIPTION
Add progress events that describe when bitswap/trustless gateways have found providers for blocks.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
