### PR TITLE
fix: allow truncated hashes

### DIFF
--- a/packages/bitswap/src/want-list.ts
+++ b/packages/bitswap/src/want-list.ts
@@ -372,7 +372,7 @@ export class WantList extends TypedEventEmitter<WantListEvents> implements Start
       const cidVersion = values[0]
       const multicodec = values[1]
       const hashAlg = values[2]
-      // const hashLen = values[3] // We haven't need to use this so far
+      const hashLen = values[3]
 
       const hasher = hashAlg === sha256.code ? sha256 : await this.hashLoader?.getHasher(hashAlg)
 
@@ -381,7 +381,9 @@ export class WantList extends TypedEventEmitter<WantListEvents> implements Start
         continue
       }
 
-      let hash: any = hasher.digest(block.data)
+      let hash: any = hasher.digest(block.data, {
+        truncate: hashLen
+      })
 
       if (hash.then != null) {
         hash = await hash

--- a/packages/utils/src/utils/networked-storage.ts
+++ b/packages/utils/src/utils/networked-storage.ts
@@ -413,7 +413,10 @@ export const getCidBlockVerifierFunction = (cid: CID, hasher: MultihashHasher): 
   return async (block: Uint8Array): Promise<void> => {
     // verify block
     let hash: MultihashDigest<number>
-    const res = hasher.digest(block)
+    const res = hasher.digest(block, {
+      // support truncated hashes where they are truncated
+      truncate: cid.multihash.digest.byteLength
+    })
 
     if (isPromise(res)) {
       hash = await res


### PR DESCRIPTION
Use the incoming hash length in bitswap and the passed digest length in block brokers to test the validtity of incoming blocks.

Refs: https://github.com/ipfs/service-worker-gateway/issues/894

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
