### PR TITLE
chore: update tests with toBuffer usage

### DIFF
--- a/packages/utils/test/block-broker.spec.ts
+++ b/packages/utils/test/block-broker.spec.ts
@@ -82,10 +82,10 @@ describe('block-broker', () => {
         yield blocks[i].cid
         await delay(10)
       }
-    }()), ({ cid, bytes }) => {
+    }()), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))
 
@@ -118,10 +118,10 @@ describe('block-broker', () => {
         yield blocks[i].cid
         await delay(10)
       }
-    }()), ({ cid, bytes }) => {
+    }()), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))
 

--- a/packages/utils/test/storage.spec.ts
+++ b/packages/utils/test/storage.spec.ts
@@ -77,10 +77,10 @@ describe('storage', () => {
         yield blocks[i].cid
         await delay(10)
       }
-    }()), ({ cid, bytes }) => {
+    }()), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))
 

--- a/packages/utils/test/utils/networked-storage.spec.ts
+++ b/packages/utils/test/utils/networked-storage.spec.ts
@@ -100,10 +100,10 @@ describe('networked-storage', () => {
         yield blocks[i].cid
         await delay(10)
       }
-    }()), ({ cid, bytes }) => {
+    }()), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))
 
@@ -115,10 +115,10 @@ describe('networked-storage', () => {
 
     await expect(drain(map(storage.getMany([cid], {
       offline: true
-    }), ({ cid, bytes }) => {
+    }), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))).to.eventually.be.rejected.with.property('name', 'BlockNotFoundWhileOfflineError')
   })
@@ -174,10 +174,10 @@ describe('networked-storage', () => {
         yield blocks[i].cid
         await delay(10)
       }
-    }()), ({ cid, bytes }) => {
+    }()), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))
 
@@ -210,10 +210,10 @@ describe('networked-storage', () => {
         yield blocks[i].cid
         await delay(10)
       }
-    }()), ({ cid, bytes }) => {
+    }()), async ({ cid, bytes }) => {
       return {
         cid,
-        block: toBuffer(bytes)
+        block: await toBuffer(bytes)
       }
     }))
 


### PR DESCRIPTION
The value returned from getMany will be an async generator so await the toBuffer call.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
