### PR TITLE
chore: add issue templates with need/triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report a bug in Helia.
+labels:
+  - kind/bug
+  - need/triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Make sure you are running the [latest version of Helia][releases] before reporting an issue.
+        - If you have an enhancement or feature request for Helia, please select [a different option][issues].
+        - Please report possible security issues by email to security@ipfs.io
+
+        [issues]: https://github.com/ipfs/helia/issues/new/choose
+        [releases]: https://github.com/ipfs/helia/releases
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please verify that you've followed these steps
+      options:
+        - label: This is a bug report, not a question. Ask questions on [discuss.ipfs.tech](https://discuss.ipfs.tech/c/help/13).
+          required: true
+        - label: I have searched on the [issue tracker](https://github.com/ipfs/helia/issues?q=is%3Aissue) for my bug.
+          required: true
+        - label: I am running the latest [Helia version](https://github.com/ipfs/helia/releases) or have an issue updating.
+          required: true
+  - type: dropdown
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: Environment
+      description: Where are you running Helia?
+      options:
+        - Node.js
+        - Browser (Chrome/Chromium)
+        - Browser (Firefox)
+        - Browser (Safari)
+        - Browser (Other)
+        - Electron
+        - React Native
+        - Other
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      render: Text
+      description: |
+        Please include the Helia version(s) you are using. You can find this in your package.json or by running `npm ls helia`.
+  - type: textarea
+    id: runtime
+    attributes:
+      label: Runtime version
+      render: Text
+      description: |
+        Please include your Node.js version (`node --version`) or browser version.
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        This is where you get to tell us what went wrong. When doing so, please make sure to include *all* relevant information.
+
+        Please try to include:
+        * What you were doing when you experienced the bug.
+        * Any error messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
+        * When possible, steps to reliably produce the bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+ - name: Getting Help on IPFS
+   url: https://ipfs.tech/help
+   about: All information about how and where to get help on IPFS.
+ - name: Helia Wiki
+   url: https://github.com/ipfs/helia/wiki
+   about: Documentation, FAQ, and Manifesto for Helia.
+ - name: Helia Examples
+   url: https://github.com/ipfs-examples/helia-examples
+   about: Code examples for using Helia.
+ - name: IPFS Official Discussion Forum
+   url: https://discuss.ipfs.tech
+   about: Please post general questions, support requests, and discussions here.

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,0 +1,29 @@
+name: Documentation Issue
+description: Report missing, erroneous docs, broken links or propose new Helia docs.
+labels:
+  - topic/docs
+  - need/triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Problems with documentation on https://docs.ipfs.tech should be reported to https://github.com/ipfs/ipfs-docs
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please verify the following.
+      options:
+        - label: I am reporting a documentation issue in this repo, not https://docs.ipfs.tech.
+          required: true
+        - label: I have searched on the [issue tracker](https://github.com/ipfs/helia/issues?q=is%3Aissue) for my issue.
+          required: true
+  - type: input
+    attributes:
+      label: Location
+      description: |
+        If possible, please provide a link to the documentation issue.
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        Please describe your issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,35 @@
+name: Feature / Enhancement
+description: Suggest a new feature or improvement to an existing Helia feature.
+labels:
+  - kind/enhancement
+  - need/triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest a new feature or enhancement to Helia. If you'd like to suggest an improvement to the IPFS protocol, please discuss it on [the forum](https://discuss.ipfs.tech).
+
+        Issues in this repo must be specific, actionable, and well motivated. They should be starting points for _building_ new features, not brainstorming ideas.
+
+        If you have an idea you'd like to discuss, please open a new thread on [the forum](https://discuss.ipfs.tech).
+
+        **Example:**
+
+        > Add streaming support to `@helia/unixfs` (specific) by implementing async iterators for large files (actionable). This would let me efficiently handle files larger than available memory (motivated).
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Please verify the following.
+      options:
+        - label: My issue is specific & actionable.
+          required: true
+        - label: I am not suggesting a protocol enhancement.
+          required: true
+        - label: I have searched on the [issue tracker](https://github.com/ipfs/helia/issues?q=is%3Aissue) for my issue.
+          required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: |
+        Please describe your idea. When requesting a feature, please be sure to include your motivation and a concrete description of how the feature should work.


### PR DESCRIPTION
This PR adds GitHub issue templates that automatically assign the need/triage label to all new issues, ensuring they appear in triage workflows.

templates:
- bug-report.yml (kind/bug, need/triage)
- feature.yml (kind/enhancement, need/triage)
- doc.yml (topic/docs, need/triage)
- config.yml (disables blank issues, adds contact links)


@achingbrain this is inspired by what we have in Kubo, but feel free to adjust/simplify, the only part I really care about is `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml` + making sure `need/triage` is autofilled for every new issue. There is a simpler version of this in https://github.com/ipfs/helia-verified-fetch/pull/317, we could do that here as well if you feel this PR is overkill.