### PR TITLE
fix: allow configuring cid peer filter size

### DIFF
--- a/packages/interface/src/blocks.ts
+++ b/packages/interface/src/blocks.ts
@@ -146,6 +146,15 @@ export interface CreateSessionOptions <ProgressEvents extends ProgressEvent<any,
    * @default 5
    */
   maxProviders?: number
+
+  /**
+   * A scalable cuckoo filter is used to ensure we do not query the same peer
+   * multiple times for the same CID. This setting controls how the initial
+   * maximum number of peers that are expected to be in the filter.
+   *
+   * @default 100
+   */
+  cidPeerFilterSize?: number
 }
 
 export interface BlockBroker<RetrieveProgressEvents extends ProgressEvent<any, any> = ProgressEvent<any, any>, AnnounceProgressEvents extends ProgressEvent<any, any> = ProgressEvent<any, any>> {
@@ -180,3 +189,4 @@ export interface SessionBlockBroker<RetrieveProgressEvents extends ProgressEvent
 
 export const DEFAULT_SESSION_MIN_PROVIDERS = 1
 export const DEFAULT_SESSION_MAX_PROVIDERS = 5
+export const DEFAULT_CID_PEER_FILTER_SIZE = 100

--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SESSION_MIN_PROVIDERS, DEFAULT_SESSION_MAX_PROVIDERS, InsufficientProvidersError } from '@helia/interface'
+import { DEFAULT_SESSION_MIN_PROVIDERS, DEFAULT_SESSION_MAX_PROVIDERS, DEFAULT_CID_PEER_FILTER_SIZE, InsufficientProvidersError } from '@helia/interface'
 import { AbortError, TypedEventEmitter, setMaxListeners } from '@libp2p/interface'
 import { createScalableCuckooFilter, Queue } from '@libp2p/utils'
 import { base64 } from 'multiformats/bases/base64'
@@ -42,6 +42,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
   public readonly providers: Provider[]
   private readonly evictionFilter: Filter
   private readonly initialProviders: Array<PeerId | Multiaddr | Multiaddr[]>
+  private readonly cidPeerFilterSize: number
 
   constructor (components: AbstractSessionComponents, init: AbstractCreateSessionOptions) {
     super()
@@ -53,6 +54,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
     this.requests = new Map()
     this.minProviders = init.minProviders ?? DEFAULT_SESSION_MIN_PROVIDERS
     this.maxProviders = init.maxProviders ?? DEFAULT_SESSION_MAX_PROVIDERS
+    this.cidPeerFilterSize = init.cidPeerFilterSize ?? DEFAULT_CID_PEER_FILTER_SIZE
     this.providers = []
     this.evictionFilter = createScalableCuckooFilter(this.maxProviders)
     this.initialProviders = [...(init.providers ?? [])]
@@ -73,7 +75,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
     const request = {
       promise: deferred.promise,
       observers: 1,
-      queryFilter: createScalableCuckooFilter(1024)
+      queryFilter: createScalableCuckooFilter(this.cidPeerFilterSize)
     }
     this.requests.set(cidStr, request)
 


### PR DESCRIPTION
Sets the default to `100` but allows configuring the size.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
