### PR TITLE
fix: cancel re-provide when deleting block

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -264,7 +264,7 @@ export class Helia<T extends Libp2p> implements HeliaInterface<T> {
 
     const networkedStorage = new NetworkedStorage(components, init)
     this.pins = new PinsImpl(init.datastore, networkedStorage, this.getCodec)
-    this.blockstore = new BlockStorage(networkedStorage, this.pins, {
+    this.blockstore = new BlockStorage(networkedStorage, this.pins, this.routing, {
       holdGcLock: init.holdGcLock ?? true
     })
     this.datastore = init.datastore

--- a/packages/utils/src/storage.ts
+++ b/packages/utils/src/storage.ts
@@ -1,6 +1,7 @@
 import { start, stop } from '@libp2p/interface'
 import createMortice from 'mortice'
 import { BlockPinnedError } from './errors.ts'
+import type { Routing } from '@helia/interface'
 import type { Blocks, Pair, DeleteManyBlocksProgressEvents, DeleteBlockProgressEvents, GetBlockProgressEvents, GetManyBlocksProgressEvents, PutManyBlocksProgressEvents, PutBlockProgressEvents, GetAllBlocksProgressEvents, GetOfflineOptions, SessionBlockstore } from '@helia/interface/blocks'
 import type { Pins } from '@helia/interface/pins'
 import type { AbortOptions, Startable } from '@libp2p/interface'
@@ -27,14 +28,16 @@ export class BlockStorage implements Blocks, Startable {
   public lock: Mortice
   private readonly child: Blocks
   private readonly pins: Pins
+  private readonly routing: Routing
   private started: boolean
 
   /**
    * Create a new BlockStorage
    */
-  constructor (blockstore: Blocks, pins: Pins, options: BlockStorageInit = {}) {
+  constructor (blockstore: Blocks, pins: Pins, routing: Routing, options: BlockStorageInit = {}) {
     this.child = blockstore
     this.pins = pins
+    this.routing = routing
     this.lock = createMortice({
       singleProcess: options.holdGcLock
     })
@@ -127,6 +130,9 @@ export class BlockStorage implements Blocks, Startable {
         throw new BlockPinnedError('Block was pinned - please unpin and try again')
       }
 
+      // stop re-providing this CID if necessary
+      await this.routing.cancelReprovide(cid, options)
+
       await this.child.delete(cid, options)
     } finally {
       releaseLock()
@@ -148,6 +154,9 @@ export class BlockStorage implements Blocks, Startable {
           if (await storage.pins.isPinned(cid)) {
             throw new BlockPinnedError('Block was pinned - please unpin and try again')
           }
+
+          // stop re-providing this CID if necessary
+          await storage.routing.cancelReprovide(cid, options)
 
           yield cid
         }

--- a/packages/utils/test/storage.spec.ts
+++ b/packages/utils/test/storage.spec.ts
@@ -7,13 +7,15 @@ import drain from 'it-drain'
 import map from 'it-map'
 import toBuffer from 'it-to-buffer'
 import * as raw from 'multiformats/codecs/raw'
+import { stubInterface } from 'sinon-ts'
 import { PinsImpl } from '../src/pins.ts'
 import { BlockStorage } from '../src/storage.ts'
 import { getCodec } from '../src/utils/get-codec.ts'
 import { createBlock } from './fixtures/create-block.ts'
-import type { Blocks, SessionBlockstore } from '@helia/interface'
+import type { Blocks, Routing, SessionBlockstore } from '@helia/interface'
 import type { Pins } from '@helia/interface/pins'
 import type { CID } from 'multiformats/cid'
+import type { StubbedInstance } from 'sinon-ts'
 
 class MemoryBlocks extends MemoryBlockstore implements Blocks {
   createSession (): SessionBlockstore {
@@ -25,6 +27,7 @@ describe('storage', () => {
   let storage: BlockStorage
   let blockstore: Blocks
   let pins: Pins
+  let routing: StubbedInstance<Routing>
   let blocks: Array<{ cid: CID, block: Uint8Array }>
 
   beforeEach(async () => {
@@ -38,7 +41,8 @@ describe('storage', () => {
 
     blockstore = new MemoryBlocks()
     pins = new PinsImpl(datastore, blockstore, getCodec())
-    storage = new BlockStorage(blockstore, pins, {
+    routing = stubInterface()
+    storage = new BlockStorage(blockstore, pins, routing, {
       holdGcLock: true
     })
   })
@@ -138,5 +142,42 @@ describe('storage', () => {
       signal: controller.signal
     }))).to.eventually.be.rejected
       .with.property('name', 'AbortError')
+  })
+
+  it('removes a block from the blockstore', async () => {
+    const { cid, block } = blocks[0]
+
+    await expect(storage.has(cid)).to.eventually.be.false()
+
+    await storage.put(cid, block)
+
+    await expect(storage.has(cid)).to.eventually.be.true()
+
+    expect(routing.cancelReprovide).to.have.property('called', false)
+    await storage.delete(cid)
+
+    await expect(storage.has(cid)).to.eventually.be.false()
+  })
+
+  it('stops re-providing a CID after removing a block from the blockstore', async () => {
+    const { cid, block } = blocks[0]
+    await storage.put(cid, block)
+
+    expect(routing.cancelReprovide).to.have.property('called', false)
+    await storage.delete(cid)
+
+    expect(routing.cancelReprovide).to.have.property('called', true, 'did not cancel re-providing of CID on block deletion')
+    expect(routing.cancelReprovide.getCall(0)?.args[0]).to.equal(cid)
+  })
+
+  it('stops re-providing a CID after removing many blocks from the blockstore', async () => {
+    const { cid, block } = blocks[0]
+    await storage.put(cid, block)
+
+    expect(routing.cancelReprovide).to.have.property('called', false)
+    await drain(storage.deleteMany([cid]))
+
+    expect(routing.cancelReprovide).to.have.property('called', true, 'did not cancel re-providing of CID on block deletion')
+    expect(routing.cancelReprovide.getCall(0)?.args[0]).to.equal(cid)
   })
 })


### PR DESCRIPTION
When deleting a block, ensure we stop reproviding the CID, otherwise we would publish provider records for blocks we don't have.

Fixes #982

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
