### PR TITLE
feat: add configurable delay to trustless gateway router

### DIFF
--- a/packages/routers/src/http-gateway-routing.ts
+++ b/packages/routers/src/http-gateway-routing.ts
@@ -7,6 +7,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { Provider, Routing, RoutingOptions } from '@helia/interface'
 import type { PeerInfo } from '@libp2p/interface'
 import type { Version } from 'multiformats'
+import { delay } from './utils/delay.ts'
 
 export const DEFAULT_TRUSTLESS_GATEWAYS = [
   // 2023-10-03: IPNS, Origin, and Block/CAR support from https://ipfs.github.io/public-gateway-checker/
@@ -18,12 +19,22 @@ export const DEFAULT_TRUSTLESS_GATEWAYS = [
 
 export interface HTTPGatewayRouterInit {
   gateways?: Array<URL | string>
+
   /**
    * Whether to shuffle the list of gateways
    *
    * @default true
    */
   shuffle?: boolean
+
+  /**
+   * Trustless gateways should be used as a fallback provider, pass a number
+   * here to wait this many ms before yielding a trustless gateway as a provider
+   * of any given CID
+   *
+   * @default 0
+   */
+  delay?: number
 }
 
 // this value is from https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -48,24 +59,26 @@ class HTTPGatewayRouter implements Partial<Routing> {
   public readonly name = 'http-gateway-router'
   private readonly gateways: PeerInfo[]
   private readonly shuffle: boolean
+  private readonly delay: number
 
   constructor (init: HTTPGatewayRouterInit = {}) {
     this.gateways = (init.gateways ?? DEFAULT_TRUSTLESS_GATEWAYS).map(url => toPeerInfo(url))
     this.shuffle = init.shuffle ?? true
+    this.delay = init.delay ?? 0
   }
 
   async * findProviders (cid: CID<unknown, number, number, Version>, options?: RoutingOptions | undefined): AsyncIterable<Provider> {
     yield * (this.shuffle
       ? this.gateways.toSorted(() => Math.random() > 0.5 ? 1 : -1)
       : this.gateways
-    ).map(info => {
-      const provider = {
+    ).map(async info => {
+      await delay(this.delay)
+
+      return {
         ...info,
         protocols: ['transport-ipfs-gateway-http'],
         routing: 'http-gateway-routing'
       }
-
-      return provider
     })
   }
 

--- a/packages/routers/src/utils/delay.ts
+++ b/packages/routers/src/utils/delay.ts
@@ -1,0 +1,8 @@
+import type { AbortOptions } from "@libp2p/interface";
+import { raceSignal } from 'race-signal'
+
+export function delay (ms: number, options?: AbortOptions): Promise<void> {
+  return raceSignal(new Promise<void>(resolve => {
+    setTimeout(() => resolve(), ms)
+  }), options?.signal)
+}

--- a/packages/routers/test/http-gateway-routing.spec.ts
+++ b/packages/routers/test/http-gateway-routing.spec.ts
@@ -52,4 +52,21 @@ describe('http-gateway-routing', () => {
     const actual = providers.map(p => p.multiaddrs.map(ma => ma.toString())[0])
     expect(actual).to.deep.equal(expected)
   })
+
+  it('should delay yielding providers', async () => {
+    const gateway = 'https://example.com'
+    const routing = httpGatewayRouting({
+      gateways: [
+        gateway
+      ],
+      delay: 500
+    })
+
+    const cid = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')
+
+    const start = Date.now()
+    const providers = await all(routing.findProviders?.(cid) ?? [])
+    expect(providers).to.have.lengthOf(1)
+    expect(Date.now() - start > 100)
+  })
 })


### PR DESCRIPTION
Allow slowing down "discovery" of trustless gateway routers to give other routing systems a chance to find providers for a given CID.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
