### PR TITLE
chore: update aegir to 48.0.9

### DIFF
--- a/benchmarks/add-dir/package.json
+++ b/benchmarks/add-dir/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@helia/unixfs": "^5.0.2",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^6.1.1",
     "blockstore-fs": "^3.0.2",
     "datastore-core": "^11.0.2",

--- a/benchmarks/add-dir/package.json
+++ b/benchmarks/add-dir/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@helia/unixfs": "^5.0.2",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^6.1.1",
     "blockstore-fs": "^3.0.2",
     "datastore-core": "^11.0.2",

--- a/benchmarks/gc/package.json
+++ b/benchmarks/gc/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@ipld/dag-pb": "^4.0.6",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-fs": "^3.0.2",
     "datastore-level": "^12.0.2",
     "execa": "^9.5.3",

--- a/benchmarks/gc/package.json
+++ b/benchmarks/gc/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@ipld/dag-pb": "^4.0.6",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-fs": "^3.0.2",
     "datastore-level": "^12.0.2",
     "execa": "^9.5.3",

--- a/benchmarks/pinning/package.json
+++ b/benchmarks/pinning/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@ipld/dag-pb": "^4.0.6",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-fs": "^3.0.2",
     "datastore-level": "^12.0.2",
     "execa": "^9.5.3",

--- a/benchmarks/pinning/package.json
+++ b/benchmarks/pinning/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@ipld/dag-pb": "^4.0.6",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-fs": "^3.0.2",
     "datastore-level": "^12.0.2",
     "execa": "^9.5.3",

--- a/benchmarks/transfer/package.json
+++ b/benchmarks/transfer/package.json
@@ -20,7 +20,7 @@
     "@libp2p/identify": "^4.0.5",
     "@libp2p/tcp": "^11.0.5",
     "@multiformats/multiaddr": "^13.0.1",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-fs": "^3.0.2",
     "datastore-level": "^12.0.2",
     "helia": "^5.1.1",

--- a/benchmarks/transfer/package.json
+++ b/benchmarks/transfer/package.json
@@ -20,7 +20,7 @@
     "@libp2p/identify": "^4.0.5",
     "@libp2p/tcp": "^11.0.5",
     "@multiformats/multiaddr": "^13.0.1",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-fs": "^3.0.2",
     "datastore-level": "^12.0.2",
     "helia": "^5.1.1",

--- a/benchmarks/transports/package.json
+++ b/benchmarks/transports/package.json
@@ -27,7 +27,7 @@
     "@libp2p/websockets": "^10.0.6",
     "@libp2p/webtransport": "^6.0.7",
     "@multiformats/multiaddr": "^13.0.1",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-fs": "^3.0.2",
     "blockstore-idb": "^3.0.1",
     "datastore-idb": "^4.0.1",

--- a/benchmarks/transports/package.json
+++ b/benchmarks/transports/package.json
@@ -27,7 +27,7 @@
     "@libp2p/websockets": "^10.0.6",
     "@libp2p/webtransport": "^6.0.7",
     "@multiformats/multiaddr": "^13.0.1",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-fs": "^3.0.2",
     "blockstore-idb": "^3.0.1",
     "datastore-idb": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docs:no-publish": "aegir docs --publish false"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "npm-run-all": "^4.1.5"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docs:no-publish": "aegir docs --publish false"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "npm-run-all": "^4.1.5"
   },
   "type": "module",

--- a/packages/bitswap/package.json
+++ b/packages/bitswap/package.json
@@ -80,7 +80,7 @@
     "@libp2p/crypto": "^5.1.15",
     "@libp2p/peer-id": "^6.0.6",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.11",

--- a/packages/bitswap/package.json
+++ b/packages/bitswap/package.json
@@ -80,7 +80,7 @@
     "@libp2p/crypto": "^5.1.15",
     "@libp2p/peer-id": "^6.0.6",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.11",

--- a/packages/block-brokers/package.json
+++ b/packages/block-brokers/package.json
@@ -69,7 +69,7 @@
     "@libp2p/logger": "^6.2.4",
     "@types/polka": "^0.5.8",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "cors": "^2.8.6",
     "polka": "^0.5.2",
     "race-signal": "^2.0.0",

--- a/packages/block-brokers/package.json
+++ b/packages/block-brokers/package.json
@@ -69,7 +69,7 @@
     "@libp2p/logger": "^6.2.4",
     "@types/polka": "^0.5.8",
     "@types/sinon": "^21.0.1",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "cors": "^2.8.6",
     "polka": "^0.5.2",
     "race-signal": "^2.0.0",

--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -70,7 +70,7 @@
     "@helia/unixfs": "^7.2.1",
     "@ipld/dag-cbor": "^10.0.0",
     "@libp2p/logger": "^6.2.4",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1",
     "datastore-core": "^12.0.1",
     "ipfs-unixfs-importer": "^17.0.0",

--- a/packages/car/package.json
+++ b/packages/car/package.json
@@ -70,7 +70,7 @@
     "@helia/unixfs": "^7.2.1",
     "@ipld/dag-cbor": "^10.0.0",
     "@libp2p/logger": "^6.2.4",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1",
     "datastore-core": "^12.0.1",
     "ipfs-unixfs-importer": "^17.0.0",

--- a/packages/dag-cbor/package.json
+++ b/packages/dag-cbor/package.json
@@ -58,7 +58,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/dag-cbor/package.json
+++ b/packages/dag-cbor/package.json
@@ -58,7 +58,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/dag-json/package.json
+++ b/packages/dag-json/package.json
@@ -57,7 +57,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/dag-json/package.json
+++ b/packages/dag-json/package.json
@@ -57,7 +57,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/dnslink/package.json
+++ b/packages/dnslink/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.4",
     "@types/dns-packet": "^5.6.5",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "delay": "^7.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/dnslink/package.json
+++ b/packages/dnslink/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@libp2p/logger": "^6.2.4",
     "@types/dns-packet": "^5.6.5",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "delay": "^7.0.0",
     "sinon-ts": "^2.0.0"
   },

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^13.0.1",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "it-all": "^3.0.11",
     "it-drain": "^3.0.12"
   },

--- a/packages/helia/package.json
+++ b/packages/helia/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@multiformats/mafmt": "^12.1.6",
     "@multiformats/multiaddr": "^13.0.1",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "it-all": "^3.0.11",
     "it-drain": "^3.0.12"
   },

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -63,7 +63,7 @@
     "libp2p": "^3.2.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "multiformats": "^14.0.0",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -63,7 +63,7 @@
     "libp2p": "^3.2.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "multiformats": "^14.0.0",
     "sinon": "^22.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -84,7 +84,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.8"
+    "aegir": "^48.0.9"
   },
   "sideEffects": false
 }

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -84,7 +84,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.4"
+    "aegir": "^48.0.8"
   },
   "sideEffects": false
 }

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -77,7 +77,7 @@
     "@libp2p/websockets": "^10.1.8",
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/sha3": "^4.0.0",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "helia": "^6.1.4",
     "ipfs-unixfs-importer": "^17.0.0",
     "ipfsd-ctl": "^17.0.0",

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -77,7 +77,7 @@
     "@libp2p/websockets": "^10.1.8",
     "@multiformats/multiaddr": "^13.0.1",
     "@multiformats/sha3": "^4.0.0",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "helia": "^6.1.4",
     "ipfs-unixfs-importer": "^17.0.0",
     "ipfsd-ctl": "^17.0.0",

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -99,7 +99,7 @@
   "devDependencies": {
     "@ipshipyard/crypto": "^1.1.0",
     "@ipshipyard/keychain": "^1.0.2",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "datastore-core": "^12.0.1",
     "it-drain": "^3.0.12",
     "it-last": "^3.0.11",

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -99,7 +99,7 @@
   "devDependencies": {
     "@ipshipyard/crypto": "^1.1.0",
     "@ipshipyard/keychain": "^1.0.2",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "datastore-core": "^12.0.1",
     "it-drain": "^3.0.12",
     "it-last": "^3.0.11",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -56,7 +56,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -56,7 +56,7 @@
     "progress-events": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/mfs/package.json
+++ b/packages/mfs/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@ipld/dag-pb": "^4.1.5",
     "@libp2p/logger": "^6.2.4",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",

--- a/packages/mfs/package.json
+++ b/packages/mfs/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@ipld/dag-pb": "^4.1.5",
     "@libp2p/logger": "^6.2.4",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",

--- a/packages/routers/package.json
+++ b/packages/routers/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.4",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "it-all": "^3.0.11",
     "it-drain": "^3.0.12",
     "sinon-ts": "^2.0.0"

--- a/packages/routers/package.json
+++ b/packages/routers/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.4",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "it-all": "^3.0.11",
     "it-drain": "^3.0.12",
     "sinon-ts": "^2.0.0"

--- a/packages/strings/package.json
+++ b/packages/strings/package.json
@@ -58,7 +58,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/strings/package.json
+++ b/packages/strings/package.json
@@ -58,7 +58,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1"
   },
   "sideEffects": false

--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -91,7 +91,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "blockstore-core": "^7.0.1",
     "delay": "^7.0.0",
     "iso-url": "^1.2.1",

--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -91,7 +91,7 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "blockstore-core": "^7.0.1",
     "delay": "^7.0.0",
     "iso-url": "^1.2.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -82,7 +82,7 @@
     "@libp2p/peer-id": "^6.0.6",
     "@types/sinon": "^21.0.1",
     "abort-error": "^1.0.2",
-    "aegir": "^48.0.4",
+    "aegir": "^48.0.8",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.11",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -82,7 +82,7 @@
     "@libp2p/peer-id": "^6.0.6",
     "@types/sinon": "^21.0.1",
     "abort-error": "^1.0.2",
-    "aegir": "^48.0.8",
+    "aegir": "^48.0.9",
     "datastore-core": "^12.0.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.11",


### PR DESCRIPTION
To pull in version with fix for electron downloads upgrade aegir to 48.0.9.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
