### PR TITLE
fix: use exact matcher for trustless gateway detection

### DIFF
--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -13,7 +13,14 @@ import type { ProgressOptions } from 'progress-events'
 
 export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure: boolean, allowLocal: boolean): Multiaddr[] {
   return multiaddrs.filter(ma => {
-    if (HTTPS.exactMatch(ma) || (allowInsecure && HTTP.exactMatch(ma))) {
+    const isHttps = HTTPS.exactMatch(ma)
+    const isHttp = HTTP.exactMatch(ma)
+
+    if (!isHttps && !isHttp) {
+      return false
+    }
+
+    if (isHttps || (allowInsecure && isHttp)) {
       if (allowLocal) {
         return true
       }

--- a/packages/block-brokers/src/trustless-gateway/utils.ts
+++ b/packages/block-brokers/src/trustless-gateway/utils.ts
@@ -13,7 +13,7 @@ import type { ProgressOptions } from 'progress-events'
 
 export function filterNonHTTPMultiaddrs (multiaddrs: Multiaddr[], allowInsecure: boolean, allowLocal: boolean): Multiaddr[] {
   return multiaddrs.filter(ma => {
-    if (HTTPS.matches(ma) || (allowInsecure && HTTP.matches(ma))) {
+    if (HTTPS.exactMatch(ma) || (allowInsecure && HTTP.exactMatch(ma))) {
       if (allowLocal) {
         return true
       }

--- a/packages/block-brokers/test/trustless-gateway-utils.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-utils.spec.ts
@@ -53,7 +53,7 @@ describe('trustless-gateway-block-broker-utils', () => {
     expect(filtered.length).to.deep.equal(1)
   })
 
-  it('filterNonHTTPMultiaddrs filters WebSocket addresses', async function () {
+  it('filterNonHTTPMultiaddrs filters non-HTTP addresses', async function () {
     const filtered = filterNonHTTPMultiaddrs([
       multiaddr('/ip4/123.123.123.123/tcp/1234/ws'),
       multiaddr('/ip4/123.123.123.123/tcp/1234/wss'),
@@ -64,7 +64,9 @@ describe('trustless-gateway-block-broker-utils', () => {
       multiaddr('/dns/localhost/https/ws'),
       multiaddr('/dns/localhost/tls/ws'),
       multiaddr('/dns/localhost/tcp/1234/wss'),
-      multiaddr('/dns/localhost/wss')
+      multiaddr('/dns/localhost/wss'),
+      multiaddr('/dns/localhost/quic-v1/webtransport/certhash/uEiDmNOgNuICfKiuNAz90dP2by6ti_0dyTB7FtgDXKDVbyQ'),
+      multiaddr('/dns/localhost/udp/1234/quic-v1/webtransport/certhash/uEiDmNOgNuICfKiuNAz90dP2by6ti_0dyTB7FtgDXKDVbyQ')
     ], true, true)
 
     expect(filtered.length).to.deep.equal(0)

--- a/packages/block-brokers/test/trustless-gateway-utils.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-utils.spec.ts
@@ -54,7 +54,7 @@ describe('trustless-gateway-block-broker-utils', () => {
   })
 
   it('filterNonHTTPMultiaddrs filters non-HTTP addresses', async function () {
-    const filtered = filterNonHTTPMultiaddrs([
+    const addrs = [
       multiaddr('/ip4/123.123.123.123/tcp/1234/ws'),
       multiaddr('/ip4/123.123.123.123/tcp/1234/wss'),
       multiaddr('/ip4/123.123.123.123/tcp/1234/tls/ws'),
@@ -67,9 +67,10 @@ describe('trustless-gateway-block-broker-utils', () => {
       multiaddr('/dns/localhost/wss'),
       multiaddr('/dns/localhost/quic-v1/webtransport/certhash/uEiDmNOgNuICfKiuNAz90dP2by6ti_0dyTB7FtgDXKDVbyQ'),
       multiaddr('/dns/localhost/udp/1234/quic-v1/webtransport/certhash/uEiDmNOgNuICfKiuNAz90dP2by6ti_0dyTB7FtgDXKDVbyQ')
-    ], true, true)
+    ]
 
-    expect(filtered.length).to.deep.equal(0)
+    expect(filterNonHTTPMultiaddrs(addrs, true, true)).to.have.lengthOf(0)
+    expect(filterNonHTTPMultiaddrs(addrs, false, true)).to.have.lengthOf(0)
   })
 
   it('limitedResponse throws an error when the content-length header is greater than the limit', async function () {

--- a/packages/block-brokers/test/trustless-gateway-utils.spec.ts
+++ b/packages/block-brokers/test/trustless-gateway-utils.spec.ts
@@ -1,3 +1,4 @@
+import { multiaddr } from '@multiformats/multiaddr'
 import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
 import { expect } from 'aegir/chai'
 import { filterNonHTTPMultiaddrs, limitedResponse } from '../src/trustless-gateway/utils.ts'
@@ -50,6 +51,23 @@ describe('trustless-gateway-block-broker-utils', () => {
     const filtered = filterNonHTTPMultiaddrs([localAddr], false, true)
 
     expect(filtered.length).to.deep.equal(1)
+  })
+
+  it('filterNonHTTPMultiaddrs filters WebSocket addresses', async function () {
+    const filtered = filterNonHTTPMultiaddrs([
+      multiaddr('/ip4/123.123.123.123/tcp/1234/ws'),
+      multiaddr('/ip4/123.123.123.123/tcp/1234/wss'),
+      multiaddr('/ip4/123.123.123.123/tcp/1234/tls/ws'),
+      multiaddr('/ip4/123.123.123.123/tls/ws'),
+      multiaddr('/dns/localhost/tcp/1234/ws'),
+      multiaddr('/dns/localhost/ws'),
+      multiaddr('/dns/localhost/https/ws'),
+      multiaddr('/dns/localhost/tls/ws'),
+      multiaddr('/dns/localhost/tcp/1234/wss'),
+      multiaddr('/dns/localhost/wss')
+    ], true, true)
+
+    expect(filtered.length).to.deep.equal(0)
   })
 
   it('limitedResponse throws an error when the content-length header is greater than the limit', async function () {


### PR DESCRIPTION
When a peer has HTTP multiaddrs, ensure that the matching doesn't eagerly also match WS(S) addresses.

Refs: https://github.com/ipfs/service-worker-gateway/issues/1092
Refs: https://github.com/ipfs/service-worker-gateway/pull/1097

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
