### PR TITLE
fix: relax CID input type for resolving IPNS names

### DIFF
--- a/packages/interop/src/ipns-pubsub.spec.ts
+++ b/packages/interop/src/ipns-pubsub.spec.ts
@@ -20,7 +20,7 @@ import { createHeliaNode } from './fixtures/create-helia.ts'
 import { createKuboNode } from './fixtures/create-kubo.ts'
 import { keyTypes } from './fixtures/key-types.ts'
 import { waitFor } from './fixtures/wait-for.ts'
-import type { IPNS, ResolveResult } from '@helia/ipns'
+import type { IPNS, IPNSResolveResult } from '@helia/ipns'
 import type { PubSub } from '@helia/ipns/routing'
 import type { HeliaWithLibp2p } from '@helia/libp2p'
 import type { Keychain } from '@libp2p/keychain'
@@ -165,7 +165,7 @@ keyTypes.filter(keyType => keyType !== 'RSA').forEach(keyType => {
         key: keyName
       })
 
-      let resolveResult: ResolveResult | undefined
+      let resolveResult: IPNSResolveResult | undefined
 
       // we should get an update eventually
       await waitFor(async () => {

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -211,7 +211,7 @@ export interface IPNSRecordMetadata {
   lifetime: number
 }
 
-export interface ResolveOptions extends AbortOptions, ProgressOptions<ResolveProgressEvents | IPNSRoutingProgressEvents> {
+export interface IPNSResolveOptions extends AbortOptions, ProgressOptions<ResolveProgressEvents | IPNSRoutingProgressEvents> {
   /**
    * Do not query the network for the IPNS record
    *
@@ -227,14 +227,14 @@ export interface ResolveOptions extends AbortOptions, ProgressOptions<ResolvePro
   nocache?: boolean
 }
 
-export interface ResolveResult {
+export interface IPNSResolveResult {
   /**
    * The resolved record
    */
   record: IPNSRecord
 }
 
-export interface PublishResult {
+export interface IPNSPublishResult {
   /**
    * The published record
    */
@@ -253,13 +253,12 @@ export interface PublishResult {
 
 export interface IPNSResolver {
   /**
-   * Accepts a libp2p public key, a CID with the libp2p-key codec and either the
-   * identity hash (for Ed25519 and secp256k1 public keys) or a SHA256 hash (for
-   * RSA public keys), or the multihash of a libp2p-key encoded CID, or a
-   * Ed25519, secp256k1 or RSA PeerId and recursively resolves the IPNS record
-   * corresponding to that key until a value is found.
+   * Accepts a CID with the libp2p-key codec and either the identity hash (for
+   * Ed25519 and secp256k1 public keys) or a SHA256 hash (for RSA public keys),
+   * or the multihash of a libp2p-key encoded CID and recursively resolves the
+   * IPNS record corresponding to that key until a value is found.
    */
-  resolve(key: CID<unknown, 0x72> | MultihashDigest, options?: ResolveOptions): AsyncGenerator<ResolveResult>
+  resolve(key: CID | MultihashDigest, options?: IPNSResolveOptions): AsyncGenerator<IPNSResolveResult>
 }
 
 export interface IPNS {
@@ -298,7 +297,7 @@ export interface IPNS {
    * console.info(result) // { answer: ... }
    * ```
    */
-  publish(keyName: string, value: CID | PublicKey | MultihashDigest | string, options?: PublishOptions): Promise<PublishResult>
+  publish(keyName: string, value: CID | PublicKey | MultihashDigest | string, options?: PublishOptions): Promise<IPNSPublishResult>
 
   /**
    * Accepts a multihash of a public key, a libp2p-key CID containing the
@@ -307,7 +306,7 @@ export interface IPNS {
    * (e.g. the value can be parsed as a string that does not start with
    * `/ipns/`).
    */
-  resolve(name: CID<unknown, 0x72> | PublicKey | MultihashDigest | string, options?: ResolveOptions): AsyncGenerator<ResolveResult>
+  resolve(name: CID | PublicKey | MultihashDigest | string, options?: IPNSResolveOptions): AsyncGenerator<IPNSResolveResult>
 
   /**
    * Stop republishing of an IPNS record

--- a/packages/ipns/src/ipns.ts
+++ b/packages/ipns/src/ipns.ts
@@ -8,7 +8,7 @@ import { localStoreRouting } from './routing/local-store.ts'
 import { ipnsSelector } from './selector.ts'
 import { normalizeKey, normalizeValue, unmarshalIPNSRecord } from './utils.ts'
 import { ipnsValidator } from './validator.ts'
-import type { IPNSComponents, IPNS as IPNSInterface, IPNSOptions, PublishResult, PublishOptions, ResolveOptions, ResolveResult } from './index.ts'
+import type { IPNSComponents, IPNS as IPNSInterface, IPNSOptions, IPNSPublishResult, PublishOptions, IPNSResolveOptions, IPNSResolveResult } from './index.ts'
 import type { LocalStore } from './local-store.ts'
 import type { IPNSRouting } from './routing/index.ts'
 import type { PublicKey } from '@helia/interface'
@@ -100,11 +100,11 @@ export class IPNS implements IPNSInterface, Startable {
     this.republisher.stop()
   }
 
-  async publish (keyName: string, value: PublicKey | CID | MultihashDigest | string, options: PublishOptions = {}): Promise<PublishResult> {
+  async publish (keyName: string, value: PublicKey | CID | MultihashDigest | string, options: PublishOptions = {}): Promise<IPNSPublishResult> {
     return this.publisher.publish(keyName, normalizeValue(value), options)
   }
 
-  async * resolve (key: PublicKey | CID<unknown, 0x72> | MultihashDigest | string, options: ResolveOptions = {}): AsyncGenerator<ResolveResult> {
+  async * resolve (key: PublicKey | CID | MultihashDigest | string, options: IPNSResolveOptions = {}): AsyncGenerator<IPNSResolveResult> {
     const { digest } = normalizeKey(key)
 
     yield * this.resolver.resolve(digest, options)

--- a/packages/ipns/src/ipns/publisher.ts
+++ b/packages/ipns/src/ipns/publisher.ts
@@ -3,7 +3,7 @@ import { CustomProgressEvent } from 'progress-events'
 import { DEFAULT_LIFETIME_MS, DEFAULT_TTL_NS } from '../constants.ts'
 import { createIPNSRecord } from '../records.ts'
 import { marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from '../utils.ts'
-import type { PublishResult, PublishOptions } from '../index.ts'
+import type { IPNSPublishResult, PublishOptions } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
 import type { Keychain, PrivateKey } from '@helia/interface'
@@ -32,7 +32,7 @@ export class IPNSPublisher {
     this.routers = init.routers
   }
 
-  async publish (keyName: string, value: string, options: PublishOptions = {}): Promise<PublishResult> {
+  async publish (keyName: string, value: string, options: PublishOptions = {}): Promise<IPNSPublishResult> {
     try {
       const key = await this.#loadOrCreateKey(keyName, options)
       const digest = key.publicKey.toMultihash()

--- a/packages/ipns/src/ipns/resolver.ts
+++ b/packages/ipns/src/ipns/resolver.ts
@@ -3,7 +3,7 @@ import { RecordNotFoundError, RecordsFailedValidationError } from '../errors.ts'
 import { ipnsSelector } from '../selector.ts'
 import { multihashToIPNSRoutingKey, unmarshalIPNSRecord, normalizeKey, IPNS_STRING_PREFIX } from '../utils.ts'
 import { ipnsValidator } from '../validator.ts'
-import type { IPNSRecord, ResolveOptions, ResolveResult } from '../index.ts'
+import type { IPNSRecord, IPNSResolveOptions, IPNSResolveResult } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
 import type { Routing, Keychain } from '@helia/interface'
@@ -36,7 +36,7 @@ export class IPNSResolver {
     this.keychain = components.keychain
   }
 
-  async * resolve (key: MultihashDigest, options: ResolveOptions = {}): AsyncGenerator<ResolveResult> {
+  async * resolve (key: MultihashDigest, options: IPNSResolveOptions = {}): AsyncGenerator<IPNSResolveResult> {
     let { digest } = normalizeKey(key)
 
     while (true) {
@@ -56,7 +56,7 @@ export class IPNSResolver {
     }
   }
 
-  async #findIpnsRecord (routingKey: Uint8Array, options: ResolveOptions = {}): Promise<IPNSRecord> {
+  async #findIpnsRecord (routingKey: Uint8Array, options: IPNSResolveOptions = {}): Promise<IPNSRecord> {
     const records: IPNSRecord[] = []
     const cached = await this.localStore.has(routingKey, options)
 

--- a/packages/ipns/src/utils.ts
+++ b/packages/ipns/src/utils.ts
@@ -335,7 +335,7 @@ function isMultihashDigest (obj: any): obj is MultihashDigest {
   return typeof obj.code === 'number' && obj.digest instanceof Uint8Array && typeof obj.size === 'number' && obj.bytes instanceof Uint8Array
 }
 
-export function normalizeKey (key?: PublicKey | CID<unknown, 0x72> | MultihashDigest | string): { digest: MultihashDigest, path: string } {
+export function normalizeKey (key?: PublicKey | CID | MultihashDigest | string): { digest: MultihashDigest, path: string } {
   if (key != null) {
     if (isPublicKey(key)) {
       return {


### PR DESCRIPTION
Remove the `0x72` codec requirement as it may not be derivable from string CIDs

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
