### PR TITLE
fix: return multihash value instead of peer id

### DIFF
--- a/packages/dnslink/package.json
+++ b/packages/dnslink/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@libp2p/interface": "^3.2.3",
-    "@libp2p/peer-id": "^6.0.10",
     "@multiformats/dns": "^1.0.13",
     "multiformats": "^14.0.0",
     "progress-events": "^1.1.0",
@@ -58,6 +57,7 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.8",
+    "@libp2p/peer-id": "^6.0.10",
     "@types/dns-packet": "^5.6.5",
     "aegir": "^48.0.11",
     "delay": "^7.0.0",

--- a/packages/dnslink/src/index.ts
+++ b/packages/dnslink/src/index.ts
@@ -100,9 +100,9 @@
  */
 
 import { DNSLink as DNSLinkClass } from './dnslink.ts'
-import type { AbortOptions, ComponentLogger, PeerId } from '@libp2p/interface'
+import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { Answer, DNS, ResolveDnsProgressEvents as ResolveProgressEvents } from '@multiformats/dns'
-import type { CID } from 'multiformats/cid'
+import type { CID, MultihashDigest } from 'multiformats/cid'
 import type { ProgressOptions } from 'progress-events'
 
 export type { ResolveProgressEvents }
@@ -167,7 +167,7 @@ export interface DNSLinkIPNSResult {
   /**
    * The resolved value
    */
-  peerId: PeerId
+  value: MultihashDigest
 
   /**
    * If the resolved value is an IPFS path, it will be present here

--- a/packages/dnslink/src/namespaces/ipns.ts
+++ b/packages/dnslink/src/namespaces/ipns.ts
@@ -1,4 +1,4 @@
-import { peerIdFromString } from '@libp2p/peer-id'
+import { CID } from 'multiformats/cid'
 import { InvalidNamespaceError } from '../errors.ts'
 import type { DNSLinkParser, DNSLinkIPNSResult, DNSLinkDNSLinkResult } from '../index.ts'
 import type { Answer } from '@multiformats/dns'
@@ -14,7 +14,7 @@ export const ipns: DNSLinkParser<DNSLinkIPNSResult | DNSLinkDNSLinkResult> = (va
     // if the result parses as a PeerId, we've reached the end of the recursion
     return {
       namespace: 'ipns',
-      peerId: peerIdFromString(peerId),
+      value: CID.parse(peerId).multihash,
       path: rest.length > 0 ? `/${rest.join('/')}` : '',
       answer
     }

--- a/packages/dnslink/test/index.spec.ts
+++ b/packages/dnslink/test/index.spec.ts
@@ -5,7 +5,9 @@ import { RecordType } from '@multiformats/dns'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
 import { base36 } from 'multiformats/bases/base36'
+import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
+import * as Digest from 'multiformats/hashes/digest'
 import { stubInterface } from 'sinon-ts'
 import { dnsLink } from '../src/index.ts'
 import type { DNSLink, DNSLinkResolveResult } from '../src/index.ts'
@@ -228,7 +230,7 @@ describe('dnslink', () => {
       throw new Error('Did not resolve entry')
     }
 
-    expect(result).to.have.deep.nested.property('[0].peerId', peerId)
+    expect(result).to.have.deep.nested.property('[0].value', Digest.decode(base58btc.decode('zQmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')))
     expect(result).to.have.nested.property('[0].path', '/foobar/path/123')
   })
 
@@ -248,7 +250,7 @@ describe('dnslink', () => {
       throw new Error('Did not resolve entry')
     }
 
-    expect(result).to.have.deep.nested.property('[0].peerId', peerId)
+    expect(result).to.have.deep.nested.property('[0].value', Digest.decode(base58btc.decode('zQmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')))
     expect(result).to.have.nested.property('[0].path', '/foobar/path/123')
   })
 


### PR DESCRIPTION
Remove peer id dependency from dnslink module.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
