### PR TITLE
fix: add value to ipns result and export util to create records

### DIFF
--- a/packages/bitswap/src/pb/message.ts
+++ b/packages/bitswap/src/pb/message.ts
@@ -20,7 +20,7 @@ export namespace WantType {
 }
 
 export interface WantlistEntry {
-  cid: Uint8Array
+  cid: Uint8Array<ArrayBuffer>
   priority: number
   cancel?: boolean
   wantType?: WantType
@@ -161,7 +161,7 @@ export namespace WantlistEntry {
 
   export interface WantlistEntryCidFieldEvent {
     field: '$.cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface WantlistEntryPriorityFieldEvent {
@@ -310,7 +310,7 @@ export namespace Wantlist {
 
   export interface WantlistEntriesCidFieldEvent {
     field: '$.entries[].cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
@@ -357,8 +357,8 @@ export namespace Wantlist {
 }
 
 export interface Block {
-  prefix: Uint8Array
-  data: Uint8Array
+  prefix: Uint8Array<ArrayBuffer>
+  data: Uint8Array<ArrayBuffer>
 }
 
 export namespace Block {
@@ -447,12 +447,12 @@ export namespace Block {
 
   export interface BlockPrefixFieldEvent {
     field: '$.prefix'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface BlockDataFieldEvent {
     field: '$.data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<Block>): Uint8Array<ArrayBuffer> {
@@ -485,7 +485,7 @@ export namespace BlockPresenceType {
 }
 
 export interface BlockPresence {
-  cid: Uint8Array
+  cid: Uint8Array<ArrayBuffer>
   type: BlockPresenceType
 }
 
@@ -575,7 +575,7 @@ export namespace BlockPresence {
 
   export interface BlockPresenceCidFieldEvent {
     field: '$.cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface BlockPresenceTypeFieldEvent {
@@ -767,7 +767,7 @@ export namespace BitswapMessage {
 
   export interface BitswapMessageWantlistEntriesCidFieldEvent {
     field: '$.wantlist.entries[].cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
@@ -802,19 +802,19 @@ export namespace BitswapMessage {
 
   export interface BitswapMessageBlocksPrefixFieldEvent {
     field: '$.blocks[].prefix'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface BitswapMessageBlocksDataFieldEvent {
     field: '$.blocks[].data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface BitswapMessageBlockPresencesCidFieldEvent {
     field: '$.blockPresences[].cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 

--- a/packages/bitswap/src/utils/cid-prefix.ts
+++ b/packages/bitswap/src/utils/cid-prefix.ts
@@ -1,7 +1,7 @@
 import ve from './varint-encoder.ts'
 import type { CID } from 'multiformats/cid'
 
-export function cidToPrefix (cid: CID): Uint8Array {
+export function cidToPrefix (cid: CID): Uint8Array<ArrayBuffer> {
   return ve([
     cid.version, cid.code, cid.multihash.code, cid.multihash.digest.byteLength
   ])

--- a/packages/bitswap/src/utils/varint-encoder.ts
+++ b/packages/bitswap/src/utils/varint-encoder.ts
@@ -1,7 +1,7 @@
 import { encode, encodingLength } from 'uint8-varint'
 
-function varintEncoder (buf: number[]): Uint8Array {
-  let out: Uint8Array = new Uint8Array(buf.reduce((acc, curr) => {
+function varintEncoder (buf: number[]): Uint8Array<ArrayBuffer> {
+  let out = new Uint8Array(buf.reduce((acc, curr) => {
     return acc + encodingLength(curr)
   }, 0))
   let offset = 0

--- a/packages/bitswap/test/bitswap.spec.ts
+++ b/packages/bitswap/test/bitswap.spec.ts
@@ -35,7 +35,7 @@ describe('bitswap', () => {
   let components: StubbedBitswapComponents
   let bitswap: Bitswap
   let cids: CID[]
-  let blocks: Uint8Array[]
+  let blocks: Uint8Array<ArrayBuffer>[]
   let getHasher: ReturnType<typeof Sinon.stub>
   let remotePeer: PeerId
 

--- a/packages/bitswap/test/utils/split-message.spec.ts
+++ b/packages/bitswap/test/utils/split-message.spec.ts
@@ -12,7 +12,7 @@ import { cidToPrefix } from '../../src/utils/cid-prefix.ts'
 import { MAX_BLOCK_SIZE, splitMessage } from '../../src/utils/split-message.ts'
 import type { Block, BlockPresence, WantlistEntry } from '../../src/pb/message.ts'
 
-async function createBlock (size = 1024): Promise<{ cid: CID, data: Uint8Array }> {
+async function createBlock (size = 1024): Promise<{ cid: CID, data: Uint8Array<ArrayBuffer> }> {
   const randomLength = 1024
   const data = uint8ArrayConcat([randomBytes(randomLength), new Uint8Array(size)]).subarray(0, size)
   const digest = await sha256.digest(data)

--- a/packages/delegated-routing-client/src/delegated-routing-router.ts
+++ b/packages/delegated-routing-client/src/delegated-routing-router.ts
@@ -54,7 +54,7 @@ export class DelegatedHTTPRouter implements Router {
     await this.client.putIPNS(cid, value, options)
   }
 
-  async get (key: Uint8Array, options?: RoutingOptions): Promise<Uint8Array> {
+  async get (key: Uint8Array, options?: RoutingOptions): Promise<Uint8Array<ArrayBuffer>> {
     if (!isIPNSKey(key)) {
       throw new NotFoundError('Not found')
     }

--- a/packages/helia/src/routing.ts
+++ b/packages/helia/src/routing.ts
@@ -271,9 +271,9 @@ export class Routing implements RoutingInterface, Startable {
    * Get the value to the given key. The first value offered by any configured
    * router will be returned.
    */
-  async get (key: Uint8Array, options?: RoutingOptions<RoutingGetProgressEvents>): Promise<Uint8Array> {
+  async get (key: Uint8Array, options?: RoutingOptions<RoutingGetProgressEvents>): Promise<Uint8Array<ArrayBuffer>> {
     const errors: Error[] = []
-    let result: Uint8Array | undefined
+    let result: Uint8Array<ArrayBuffer> | undefined
 
     try {
       result = await Promise.any(

--- a/packages/helia/test/routing.spec.ts
+++ b/packages/helia/test/routing.spec.ts
@@ -4,16 +4,17 @@ import all from 'it-all'
 import { CID } from 'multiformats/cid'
 import { stubInterface } from 'sinon-ts'
 import { Routing } from '../src/routing.ts'
+import type { Router } from '@helia/interface'
 import type { StubbedInstance } from 'sinon-ts'
 
 describe('routing', () => {
   let routing: Routing
-  let routerA: StubbedInstance<Routing>
-  let routerB: StubbedInstance<Routing>
+  let routerA: StubbedInstance<Router>
+  let routerB: StubbedInstance<Router>
 
   beforeEach(() => {
-    routerA = stubInterface<Routing>()
-    routerB = stubInterface<Routing>()
+    routerA = stubInterface<Router>()
+    routerB = stubInterface<Router>()
 
     routing = new Routing({
       logger: defaultLogger()
@@ -28,8 +29,8 @@ describe('routing', () => {
   it('should end a provider lookup that finds no results', async () => {
     const key = CID.parse('QmaQwYWpchozXhFv8nvxprECWBSCEppN9dfd2VQiJfRo3E')
 
-    routerA.findProviders.returns((async function * () {})())
-    routerB.findProviders.returns((async function * () {})())
+    routerA.findProviders?.returns((async function * () {})())
+    routerB.findProviders?.returns((async function * () {})())
 
     await expect(all(routing.findProviders(key))).to.eventually.be.empty()
   })

--- a/packages/interface/src/routing.ts
+++ b/packages/interface/src/routing.ts
@@ -298,7 +298,7 @@ export interface Router {
    * })
    * ```
    */
-  get?(key: Uint8Array, options?: RoutingOptions<RoutingGetProgressEvents>): Promise<Uint8Array>
+  get?(key: Uint8Array, options?: RoutingOptions<RoutingGetProgressEvents>): Promise<Uint8Array<ArrayBuffer>>
 
   /**
    * Searches the network for peer info corresponding to the passed peer id.

--- a/packages/interop/src/ipns-http.spec.ts
+++ b/packages/interop/src/ipns-http.spec.ts
@@ -69,6 +69,6 @@ describe('@helia/ipns - http', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid}`)
+    expect(result.value).to.equal(`/ipfs/${cid}`)
   })
 })

--- a/packages/interop/src/ipns-pubsub.spec.ts
+++ b/packages/interop/src/ipns-pubsub.spec.ts
@@ -1,7 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 5] */
 
 import { ipns } from '@helia/ipns'
-import { pubsub } from '@helia/ipns/routing'
+import { pubSubIPNSRouting } from '@helia/ipns'
 import { floodsub } from '@libp2p/floodsub'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { expect } from 'aegir/chai'
@@ -21,7 +21,7 @@ import { createKuboNode } from './fixtures/create-kubo.ts'
 import { keyTypes } from './fixtures/key-types.ts'
 import { waitFor } from './fixtures/wait-for.ts'
 import type { IPNS, IPNSResolveResult } from '@helia/ipns'
-import type { PubSub } from '@helia/ipns/routing'
+import type { PubSub } from '@helia/ipns'
 import type { HeliaWithLibp2p } from '@helia/libp2p'
 import type { Keychain } from '@libp2p/keychain'
 import type { KuboNode } from 'ipfsd-ctl'
@@ -48,7 +48,7 @@ keyTypes.filter(keyType => keyType !== 'RSA').forEach(keyType => {
 
       name = ipns(helia, {
         routers: [
-          pubsub(helia)
+          pubSubIPNSRouting(helia)
         ]
       })
     })
@@ -185,7 +185,7 @@ keyTypes.filter(keyType => keyType !== 'RSA').forEach(keyType => {
         throw new Error('Failed to resolve CID')
       }
 
-      expect(resolveResult.record.value).to.equal(`/ipfs/${cid}`)
+      expect(resolveResult.value).to.equal(`/ipfs/${cid}`)
     })
   })
 })

--- a/packages/interop/src/ipns.spec.ts
+++ b/packages/interop/src/ipns.spec.ts
@@ -176,8 +176,6 @@ keyTypes.forEach(type => {
       const json = await response.json()
       expect(json.Id).to.equal(key.publicKey.toCID().toString(base36), 'did not import key correctly')
 
-      const oneHourNS = BigInt(60 * 60 * 1e+9)
-
       await kubo.api.name.publish(cid, {
         key: keyName,
         ttl: '1h'
@@ -189,8 +187,7 @@ keyTypes.forEach(type => {
         throw new Error('No result found')
       }
 
-      expect(result.record.value).to.equal(`/ipfs/${cid}`)
-      expect(result.record.ttl).to.equal(oneHourNS)
+      expect(result.value).to.equal(`/ipfs/${cid}`)
     })
   })
 })

--- a/packages/ipns/README.md
+++ b/packages/ipns/README.md
@@ -66,7 +66,6 @@ value.
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
 import { unixfs } from '@helia/unixfs'
-import { generateKeyPair } from '@libp2p/crypto/keys'
 
 const helia = await createHelia()
 const name = ipns(helia)
@@ -95,7 +94,6 @@ It is possible to publish CIDs with an associated path.
 import { createHelia } from 'helia'
 import { ipns } from '@helia/ipns'
 import { unixfs } from '@helia/unixfs'
-import { generateKeyPair } from '@libp2p/crypto/keys'
 
 const helia = await createHelia()
 const name = ipns(helia)
@@ -134,15 +132,13 @@ and multiple peers are listening on the topic(s), otherwise update messages
 may fail to be published with "Insufficient peers" errors.
 
 ```TypeScript
-import { ipns } from '@helia/ipns'
-import { pubsub } from '@helia/ipns/routing'
+import { ipns, pubSubIPNSRouting } from '@helia/ipns'
 import { withLibp2p, libp2pDefaults } from '@helia/libp2p'
 import { unixfs } from '@helia/unixfs'
-import { generateKeyPair } from '@libp2p/crypto/keys'
 import { floodsub } from '@libp2p/floodsub'
 import { createHelia } from 'helia'
 import type { Helia } from '@helia/interface'
-import type { PubSub } from '@helia/ipns/routing'
+import type { PubSub } from '@helia/ipns'
 import type { DefaultLibp2pServices } from '@helia/libp2p'
 import type { FloodSub } from '@libp2p/floodsub'
 import type { Libp2p } from '@libp2p/interface'
@@ -154,7 +150,7 @@ const helia = await withLibp2p<Helia, { pubsub: FloodSub }>(createHelia(), libp2
 
 const name = ipns(helia, {
  routers: [
-   pubsub(helia)
+   pubSubIPNSRouting(helia)
  ]
 })
 

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@helia/interface": "^7.0.0",
+    "@ipld/dag-cbor": "^10.0.1",
     "@ipshipyard/crypto": "^1.1.0",
     "@ipshipyard/keychain": "^1.0.2",
     "@libp2p/fetch": "^4.1.6",
@@ -61,7 +62,6 @@
     "@libp2p/utils": "^7.2.2",
     "abort-error": "^1.0.2",
     "any-signal": "^4.2.0",
-    "cborg": "^5.1.1",
     "delay": "^7.0.0",
     "interface-datastore": "^10.0.1",
     "multiformats": "^14.0.0",
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "aegir": "^48.0.11",
+    "cborg": "^5.1.5",
     "datastore-core": "^12.0.1",
     "it-drain": "^3.0.12",
     "it-last": "^3.0.11",

--- a/packages/ipns/package.json
+++ b/packages/ipns/package.json
@@ -20,22 +20,6 @@
   ],
   "type": "module",
   "types": "./dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ],
-      "src/*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ]
-    }
-  },
   "files": [
     "src",
     "dist",
@@ -47,16 +31,6 @@
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js",
       "module-sync": "./dist/src/index.js"
-    },
-    "./dns-resolvers": {
-      "types": "./dist/src/dns-resolvers/index.d.ts",
-      "import": "./dist/src/dns-resolvers/index.js",
-      "module-sync": "./dist/src/dns-resolvers/index.js"
-    },
-    "./routing": {
-      "types": "./dist/src/routing/index.d.ts",
-      "import": "./dist/src/routing/index.js",
-      "module-sync": "./dist/src/routing/index.js"
     }
   },
   "scripts": {
@@ -77,6 +51,8 @@
   },
   "dependencies": {
     "@helia/interface": "^7.0.0",
+    "@ipshipyard/crypto": "^1.1.0",
+    "@ipshipyard/keychain": "^1.0.2",
     "@libp2p/fetch": "^4.1.6",
     "@libp2p/interface": "^3.2.3",
     "@libp2p/kad-dht": "^16.3.2",
@@ -97,8 +73,6 @@
     "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
-    "@ipshipyard/crypto": "^1.1.0",
-    "@ipshipyard/keychain": "^1.0.2",
     "aegir": "^48.0.11",
     "datastore-core": "^12.0.1",
     "it-drain": "^3.0.12",

--- a/packages/ipns/src/errors.ts
+++ b/packages/ipns/src/errors.ts
@@ -3,16 +3,6 @@ export class RecordsFailedValidationError extends Error {
   name = 'RecordsFailedValidationError'
 }
 
-export class UnsupportedMultibasePrefixError extends Error {
-  static name = 'UnsupportedMultibasePrefixError'
-  name = 'UnsupportedMultibasePrefixError'
-}
-
-export class UnsupportedMultihashCodecError extends Error {
-  static name = 'UnsupportedMultihashCodecError'
-  name = 'UnsupportedMultihashCodecError'
-}
-
 export class InvalidValueError extends Error {
   static name = 'InvalidValueError'
   name = 'InvalidValueError'

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -37,7 +37,6 @@
  * import { createHelia } from 'helia'
  * import { ipns } from '@helia/ipns'
  * import { unixfs } from '@helia/unixfs'
- * import { generateKeyPair } from '@libp2p/crypto/keys'
  *
  * const helia = await createHelia()
  * const name = ipns(helia)
@@ -66,7 +65,6 @@
  * import { createHelia } from 'helia'
  * import { ipns } from '@helia/ipns'
  * import { unixfs } from '@helia/unixfs'
- * import { generateKeyPair } from '@libp2p/crypto/keys'
  *
  * const helia = await createHelia()
  * const name = ipns(helia)
@@ -105,15 +103,13 @@
  * may fail to be published with "Insufficient peers" errors.
  *
  * ```TypeScript
- * import { ipns } from '@helia/ipns'
- * import { pubsub } from '@helia/ipns/routing'
+ * import { ipns, pubSubIPNSRouting } from '@helia/ipns'
  * import { withLibp2p, libp2pDefaults } from '@helia/libp2p'
  * import { unixfs } from '@helia/unixfs'
- * import { generateKeyPair } from '@libp2p/crypto/keys'
  * import { floodsub } from '@libp2p/floodsub'
  * import { createHelia } from 'helia'
  * import type { Helia } from '@helia/interface'
- * import type { PubSub } from '@helia/ipns/routing'
+ * import type { PubSub } from '@helia/ipns'
  * import type { DefaultLibp2pServices } from '@helia/libp2p'
  * import type { FloodSub } from '@libp2p/floodsub'
  * import type { Libp2p } from '@libp2p/interface'
@@ -125,7 +121,7 @@
  *
  * const name = ipns(helia, {
  *  routers: [
- *    pubsub(helia)
+ *    pubSubIPNSRouting(helia)
  *  ]
  * })
  *
@@ -147,10 +143,10 @@ import { CID } from 'multiformats/cid'
 import { IPNSResolver as IPNSResolverClass } from './ipns/resolver.ts'
 import { IPNS as IPNSClass } from './ipns.ts'
 import { localStore } from './local-store.ts'
-import { helia } from './routing/index.ts'
-import { localStoreRouting } from './routing/local-store.ts'
+import { heliaIPNSRouting } from './routing/index.ts'
+import { localStoreIPNSRouting } from './routing/local-store.ts'
 import type { IPNSResolverComponents } from './ipns/resolver.ts'
-import type { IPNSRecord } from './records.ts'
+import type { IPNSEntry } from './pb/ipns.ts'
 import type { IPNSRouting, IPNSRoutingProgressEvents } from './routing/index.ts'
 import type { Routing, HeliaEvents, Keychain, PublicKey } from '@helia/interface'
 import type { ComponentLogger, TypedEventEmitter } from '@libp2p/interface'
@@ -159,14 +155,29 @@ import type { Datastore } from 'interface-datastore'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 import type { ProgressEvent, ProgressOptions } from 'progress-events'
 
+export * from './routing/index.ts'
+export * from './pb/ipns.ts'
+
+export {
+  multihashFromIPNSRoutingKey,
+  multihashToIPNSRoutingKey
+} from './utils.ts'
+
+export {
+  createIPNSRecord
+} from './records.ts'
+export type {
+  CreateIPNSRecordOptions
+} from './records.ts'
+
 export type PublishProgressEvents =
   ProgressEvent<'ipns:publish:start'> |
-  ProgressEvent<'ipns:publish:success', IPNSRecord> |
+  ProgressEvent<'ipns:publish:success', IPNSEntry> |
   ProgressEvent<'ipns:publish:error', Error>
 
 export type ResolveProgressEvents =
   ProgressEvent<'ipns:resolve:start', unknown> |
-  ProgressEvent<'ipns:resolve:success', IPNSRecord> |
+  ProgressEvent<'ipns:resolve:success', IPNSEntry> |
   ProgressEvent<'ipns:resolve:error', Error>
 
 export type DatastoreProgressEvents =
@@ -177,7 +188,8 @@ export type DatastoreProgressEvents =
 
 export interface PublishOptions extends AbortOptions, ProgressOptions<PublishProgressEvents | IPNSRoutingProgressEvents> {
   /**
-   * Time duration of the signature validity in ms
+   * Time duration of the signature validity in ms - after this many ms have
+   * expired the record will be invalidated.
    *
    * @default 172_800_000
    */
@@ -199,16 +211,44 @@ export interface PublishOptions extends AbortOptions, ProgressOptions<PublishPro
   v1Compatible?: boolean
 
   /**
-   * The TTL of the record in ms
+   * The TTL of the record in ms - after this many ms have expired, resolving
+   * the record will query the routing for an updated version.
+   *
+   * Before this many ms have expired any locally stored copy will be treated as
+   * the latest version and the routing will not be queried.
    *
    * @default 300_000
    */
   ttl?: number
+
+  /**
+   * Extensible data that will be added to the IPNS record data and signed to
+   * verify it's integrity.
+   *
+   * Note that this data will be encoded as DAG-CBOR so it must be valid.
+   *
+   * It is recommended that any custom fields set here are prefixed with `_` to
+   * avoid collision with any mandatory fields added to future versions of the
+   * IPNS specification.
+   *
+   * @see https://specs.ipfs.tech/ipns/ipns-record/#extensible-data-dag-cbor
+   */
+  data?: Record<string, any>
 }
 
-export interface IPNSRecordMetadata {
-  keyName: string
-  lifetime: number
+/**
+ * Extensible data from the record `data` field.
+ *
+ * The wire format of this data is DAG-CBOR.
+ *
+ * @see https://specs.ipfs.tech/ipns/ipns-record/#extensible-data-dag-cbor
+ */
+export interface IPNSRecordData extends Record<string, any> {
+  Value: Uint8Array<ArrayBuffer>
+  Validity: Uint8Array<ArrayBuffer>
+  ValidityType: IPNSEntry.ValidityType
+  Sequence: bigint
+  TTL: bigint
 }
 
 export interface IPNSResolveOptions extends AbortOptions, ProgressOptions<ResolveProgressEvents | IPNSRoutingProgressEvents> {
@@ -225,20 +265,33 @@ export interface IPNSResolveOptions extends AbortOptions, ProgressOptions<Resolv
    * @default false
    */
   nocache?: boolean
+
+  /**
+   * If true, ensure the record fields and signature are valid. If false, just
+   * return the record.
+   *
+   * @default true
+   */
+  validate?: boolean
 }
 
 export interface IPNSResolveResult {
   /**
    * The resolved record
    */
-  record: IPNSRecord
+  record: IPNSEntry
+
+  /**
+   * The value contained within the IPNS record
+   */
+  value: string
 }
 
 export interface IPNSPublishResult {
   /**
    * The published record
    */
-  record: IPNSRecord
+  record: IPNSEntry
 
   /**
    * The IPNS name that can be used to resolve this record
@@ -309,7 +362,7 @@ export interface IPNS {
   resolve(name: CID | PublicKey | MultihashDigest | string, options?: IPNSResolveOptions): AsyncGenerator<IPNSResolveResult>
 
   /**
-   * Stop republishing of an IPNS record
+   * Stop republishing of an IPNS record.
    *
    * This will delete the last signed IPNS record from the datastore.
    *
@@ -318,9 +371,6 @@ export interface IPNS {
    */
   unpublish(keyName: string, options?: AbortOptions): Promise<void>
 }
-
-export type { IPNSRouting } from './routing/index.ts'
-export type { IPNSRecord } from './records.ts'
 
 export interface IPNSComponents {
   datastore: Datastore
@@ -366,8 +416,8 @@ export function ipns (components: IPNSComponents, options: IPNSOptions = {}): IP
 export function ipnsResolver (components: IPNSResolverComponents, options: IPNSResolverOptions = {}): IPNSResolver {
   const store = localStore(components.datastore, components.logger.forComponent('helia:ipns:local-store'))
   const routers = [
-    localStoreRouting(store),
-    helia(components.routing),
+    localStoreIPNSRouting(store),
+    heliaIPNSRouting(components.routing),
     ...(options.routers ?? [])
   ]
 

--- a/packages/ipns/src/ipns.ts
+++ b/packages/ipns/src/ipns.ts
@@ -1,12 +1,13 @@
 import { CID } from 'multiformats/cid'
+import { IPNSEntry } from './index.ts'
 import { IPNSPublisher } from './ipns/publisher.ts'
 import { IPNSRepublisher } from './ipns/republisher.ts'
 import { IPNSResolver } from './ipns/resolver.ts'
 import { localStore } from './local-store.ts'
-import { helia } from './routing/helia.ts'
-import { localStoreRouting } from './routing/local-store.ts'
+import { heliaIPNSRouting } from './routing/helia.ts'
+import { localStoreIPNSRouting } from './routing/local-store.ts'
 import { ipnsSelector } from './selector.ts'
-import { normalizeKey, normalizeValue, unmarshalIPNSRecord } from './utils.ts'
+import { normalizeKey, normalizeValue } from './utils.ts'
 import { ipnsValidator } from './validator.ts'
 import type { IPNSComponents, IPNS as IPNSInterface, IPNSOptions, IPNSPublishResult, PublishOptions, IPNSResolveOptions, IPNSResolveResult } from './index.ts'
 import type { LocalStore } from './local-store.ts'
@@ -31,8 +32,8 @@ export class IPNS implements IPNSInterface, Startable {
     this.started = false
 
     this.routers = [
-      localStoreRouting(this.localStore),
-      helia(components.routing),
+      localStoreIPNSRouting(this.localStore),
+      heliaIPNSRouting(components.routing),
       ...(init.routers ?? [])
     ]
 
@@ -67,14 +68,13 @@ export class IPNS implements IPNSInterface, Startable {
           if (isKadDHT(service)) {
             // @ ts-expect-error https://github.com/libp2p/js-libp2p/pull/3506
             service.selectors.ipns = async (key: Uint8Array, values: Uint8Array[]): Promise<number> => {
-              const records = await Promise.all(values.map(buf => unmarshalIPNSRecord(key, buf, this.components.keychain)))
+              const records = values.map(buf => IPNSEntry.decode(buf))
 
               return ipnsSelector(key, records)
             }
 
             service.validators.ipns = async (key: Uint8Array, value: Uint8Array): Promise<void> => {
-              const record = await unmarshalIPNSRecord(key, value, this.components.keychain)
-              await ipnsValidator(record)
+              await ipnsValidator(key, value, this.components.keychain)
             }
           }
         }

--- a/packages/ipns/src/ipns/publisher.ts
+++ b/packages/ipns/src/ipns/publisher.ts
@@ -1,8 +1,9 @@
 import { base36 } from 'multiformats/bases/base36'
 import { CustomProgressEvent } from 'progress-events'
-import { DEFAULT_LIFETIME_MS, DEFAULT_TTL_NS } from '../constants.ts'
+import { DEFAULT_LIFETIME_MS } from '../constants.ts'
+import { IPNSEntry } from '../pb/ipns.ts'
 import { createIPNSRecord } from '../records.ts'
-import { marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from '../utils.ts'
+import { decodeExtensibleData, multihashToIPNSRoutingKey } from '../utils.ts'
 import type { IPNSPublishResult, PublishOptions } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
@@ -42,31 +43,43 @@ export class IPNSPublisher {
       if (await this.localStore.has(routingKey, options)) {
         // if we have published under this key before, increment the sequence number
         const { record } = await this.localStore.get(routingKey, options)
-        const existingRecord = await unmarshalIPNSRecord(routingKey, record, this.keychain, options)
-        sequenceNumber = existingRecord.sequence + 1n
+        const existingRecord = IPNSEntry.decode(record)
+        const data = decodeExtensibleData(existingRecord.data)
+        sequenceNumber = (data.Sequence ?? 0n) + 1n
       }
 
-      // convert ttl from milliseconds to nanoseconds as createIPNSRecord expects
-      const ttlNs = options.ttl != null ? BigInt(options.ttl) * 1_000_000n : DEFAULT_TTL_NS
       const lifetime = options.lifetime ?? DEFAULT_LIFETIME_MS
-      const record = await createIPNSRecord(key, value, sequenceNumber, lifetime, { ...options, ttlNs })
-      const marshaledRecord = marshalIPNSRecord(record)
+      const record = await createIPNSRecord(key, value, sequenceNumber, lifetime, {
+        ...options,
+        // convert ttl from milliseconds to nanoseconds as createIPNSRecord expects
+        ttlNs: options.ttl != null ? BigInt(options.ttl) * 1_000_000n : undefined
+      })
+      const marshaledRecord = IPNSEntry.encode(record)
 
       if (options.offline === true) {
         // only store record locally
-        await this.localStore.put(routingKey, marshaledRecord, { ...options, metadata: { keyName, lifetime } })
+        await this.localStore.put(routingKey, marshaledRecord, {
+          ...options,
+          metadata: {
+            keyName,
+            lifetime
+          }
+        })
       } else {
         // publish record to routing (including the local store)
         await Promise.all(this.routers.map(async r => {
-          await r.put(routingKey, marshaledRecord, { ...options, metadata: { keyName, lifetime } })
+          await r.put(routingKey, marshaledRecord, {
+            ...options,
+            metadata: {
+              keyName,
+              lifetime
+            }
+          })
         }))
       }
 
       return {
-        record: {
-          ...record,
-          publicKey: key.publicKey
-        },
+        record,
         name: `/ipns/${key.publicKey.toCID().toString(base36)}`,
         publicKey: key.publicKey
       }

--- a/packages/ipns/src/ipns/republisher.ts
+++ b/packages/ipns/src/ipns/republisher.ts
@@ -1,9 +1,10 @@
 import { Queue, repeatingTask } from '@libp2p/utils'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { DEFAULT_REPUBLISH_CONCURRENCY, DEFAULT_REPUBLISH_INTERVAL_MS, DEFAULT_TTL_NS } from '../constants.ts'
+import { IPNSEntry } from '../pb/ipns.ts'
 import { createIPNSRecord } from '../records.ts'
-import { marshalIPNSRecord, unmarshalIPNSRecord } from '../utils.ts'
-import { shouldRepublish } from '../utils.ts'
-import type { IPNSRecord } from '../index.ts'
+import { decodeExtensibleData, shouldRepublish } from '../utils.ts'
+import type { IPNSRecordData } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
 import type { Keychain, PrivateKey } from '@helia/interface'
@@ -78,7 +79,7 @@ export class IPNSRepublisher {
     })
 
     try {
-      const recordsToRepublish: Array<{ routingKey: Uint8Array, record: IPNSRecord }> = []
+      const recordsToRepublish: Array<{ routingKey: Uint8Array, record: IPNSEntry }> = []
       let listed = 0
 
       // Find all records using the localStore.list method
@@ -91,21 +92,38 @@ export class IPNSRepublisher {
           this.log('no metadata found for record %b, skipping', routingKey)
           continue
         }
-        let ipnsRecord: IPNSRecord
+
+        let ipnsRecord: IPNSEntry
+
         try {
-          ipnsRecord = await unmarshalIPNSRecord(routingKey, record, this.keychain, options)
-        } catch (err: any) {
-          this.log.error('error unmarshaling record - %e', err)
+          ipnsRecord = IPNSEntry.decode(record)
+        } catch (err) {
+          this.log.trace('skipping invalid record %b because could not decode', routingKey)
+          continue
+        }
+
+        if (ipnsRecord.data == null) {
+          this.log.trace('skipping record %b because data was missing', routingKey)
+          continue
+        }
+
+        let data: IPNSRecordData
+
+        try {
+          data = decodeExtensibleData(ipnsRecord.data)
+        } catch {
+          this.log.trace('skipping record %b because could not decode data', routingKey)
           continue
         }
 
         // Only republish records that are within the DHT or record expiry threshold
-        if (!shouldRepublish(ipnsRecord, created)) {
+        if (!shouldRepublish(created, new Date(uint8ArrayToString(data.Validity)))) {
           this.log.trace('skipping record %b within republish threshold', routingKey)
           continue
         }
-        const sequenceNumber = ipnsRecord.sequence + 1n
-        const ttlNs = ipnsRecord.ttl ?? DEFAULT_TTL_NS
+
+        const sequenceNumber = data.Sequence + 1n
+        const ttlNs = data.TTL ?? DEFAULT_TTL_NS
         let privKey: PrivateKey
 
         try {
@@ -116,7 +134,7 @@ export class IPNSRepublisher {
         }
 
         try {
-          const updatedRecord = await createIPNSRecord(privKey, ipnsRecord.value, sequenceNumber, metadata.lifetime, {
+          const updatedRecord = await createIPNSRecord(privKey, uint8ArrayToString(data.Value), sequenceNumber, metadata.lifetime, {
             ...options,
             ttlNs
           })
@@ -137,7 +155,7 @@ export class IPNSRepublisher {
         // Add job to queue to republish the record to all routers
         queue.add(async () => {
           try {
-            const marshaledRecord = marshalIPNSRecord(record)
+            const marshaledRecord = IPNSEntry.encode(record)
             await Promise.all(
               this.routers.map(r => r.put(routingKey, marshaledRecord, options))
             )

--- a/packages/ipns/src/ipns/resolver.ts
+++ b/packages/ipns/src/ipns/resolver.ts
@@ -1,9 +1,11 @@
+import { base36 } from 'multiformats/bases/base36'
 import { DEFAULT_TTL_NS } from '../constants.ts'
-import { RecordNotFoundError, RecordsFailedValidationError } from '../errors.ts'
+import { InvalidValueError, RecordNotFoundError, RecordsFailedValidationError } from '../errors.ts'
+import { IPNSEntry } from '../pb/ipns.ts'
 import { ipnsSelector } from '../selector.ts'
-import { multihashToIPNSRoutingKey, unmarshalIPNSRecord, normalizeKey, IPNS_STRING_PREFIX } from '../utils.ts'
+import { multihashToIPNSRoutingKey, normalizeKey, IPNS_STRING_PREFIX, ipnsRecordValueToString, decodeExtensibleData } from '../utils.ts'
 import { ipnsValidator } from '../validator.ts'
-import type { IPNSRecord, IPNSResolveOptions, IPNSResolveResult } from '../index.ts'
+import type { IPNSResolveOptions, IPNSResolveResult } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
 import type { Routing, Keychain } from '@helia/interface'
@@ -42,22 +44,33 @@ export class IPNSResolver {
     while (true) {
       const routingKey = multihashToIPNSRoutingKey(digest)
       const record = await this.#findIpnsRecord(routingKey, options)
+      let value = ''
 
-      yield {
-        record
+      if (record.data != null) {
+        const data = decodeExtensibleData(record.data)
+        value = ipnsRecordValueToString(data.Value)
+      } else if (record.value != null) {
+        value = ipnsRecordValueToString(record.value)
+      } else {
+        throw new InvalidValueError(`Record for key ${base36.encode(digest.bytes)} contained no value`)
       }
 
-      if (!record.value.startsWith(IPNS_STRING_PREFIX)) {
+      yield {
+        record,
+        value
+      }
+
+      if (!value.startsWith(IPNS_STRING_PREFIX)) {
         // not a recursive record
         break
       }
 
-      ({ digest } = normalizeKey(record.value))
+      ({ digest } = normalizeKey(value))
     }
   }
 
-  async #findIpnsRecord (routingKey: Uint8Array, options: IPNSResolveOptions = {}): Promise<IPNSRecord> {
-    const records: IPNSRecord[] = []
+  async #findIpnsRecord (routingKey: Uint8Array, options: IPNSResolveOptions = {}): Promise<IPNSEntry> {
+    const records: IPNSEntry[] = []
     const cached = await this.localStore.has(routingKey, options)
 
     if (cached) {
@@ -70,19 +83,23 @@ export class IPNSResolver {
 
           this.log('record retrieved from cache')
 
-          // unmarshal the record
-          const ipnsRecord = await unmarshalIPNSRecord(routingKey, marshaledIPNSRecord, this.keychain, options)
+          // unmarshal and validate the record
+          let ipnsRecord: IPNSEntry
 
-          // validate the record
-          await ipnsValidator(ipnsRecord, options)
-
-          this.log('record was valid')
+          if (options.validate === false) {
+            ipnsRecord = IPNSEntry.decode(marshaledIPNSRecord)
+            this.log('skipped validation of record')
+          } else {
+            ipnsRecord = await ipnsValidator(routingKey, marshaledIPNSRecord, this.keychain, options)
+            this.log('record was valid')
+          }
 
           // check the TTL
+          const data = decodeExtensibleData(ipnsRecord.data)
 
           // IPNS TTL is in nanoseconds, convert to milliseconds, default to one
           // hour
-          const ttlMs = Number((ipnsRecord.ttl ?? DEFAULT_TTL_NS) / 1_000_000n)
+          const ttlMs = Number((data.TTL ?? DEFAULT_TTL_NS) / 1_000_000n)
           const ttlExpires = created.getTime() + ttlMs
 
           if (ttlExpires > Date.now()) {
@@ -138,12 +155,13 @@ export class IPNSResolver {
         }
 
         try {
-          // unmarshal ensures that (1) SignatureV2 and Data are present, (2) that ValidityType
-          // and Validity are of valid types and have a value, (3) that CBOR data matches protobuf
-          // if it's a V1+V2 record
-          const record = await unmarshalIPNSRecord(routingKey, marshaledIPNSRecord, this.keychain, options)
+          let record: IPNSEntry
 
-          await ipnsValidator(record, options)
+          if (options.validate === false) {
+            record = IPNSEntry.decode(marshaledIPNSRecord)
+          } else {
+            record = await ipnsValidator(routingKey, marshaledIPNSRecord, this.keychain, options)
+          }
 
           records.push(record)
         } catch (err) {
@@ -164,7 +182,7 @@ export class IPNSResolver {
 
     const record = records[ipnsSelector(routingKey, records)]
 
-    await this.localStore.put(routingKey, record.bytes, options)
+    await this.localStore.put(routingKey, IPNSEntry.encode(record), options)
 
     return record
   }

--- a/packages/ipns/src/local-store.ts
+++ b/packages/ipns/src/local-store.ts
@@ -2,14 +2,15 @@ import { Record } from '@libp2p/kad-dht'
 import { CustomProgressEvent } from 'progress-events'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import { IPNSPublishMetadata } from './pb/metadata.ts'
 import { dhtRoutingKey, DHT_RECORD_PREFIX, ipnsMetadataKey } from './utils.ts'
-import type { DatastoreProgressEvents, GetOptions, PutOptions } from './routing/index.ts'
+import type { DatastoreProgressEvents, IPNSRoutingGetOptions, IPNSRoutingPutOptions } from './routing/index.ts'
 import type { AbortOptions, Logger } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
 
 export interface GetResult {
-  record: Uint8Array
+  record: Uint8Array<ArrayBuffer>
   created: Date
 }
 
@@ -32,8 +33,8 @@ export interface LocalStore {
    * @param marshaledRecord - The marshaled IPNS record
    * @param options - options for the put operation including metadata
    */
-  put(routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: PutOptions): Promise<void>
-  get(routingKey: Uint8Array, options?: GetOptions): Promise<GetResult>
+  put(routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: IPNSRoutingPutOptions): Promise<void>
+  get(routingKey: Uint8Array, options?: IPNSRoutingGetOptions): Promise<GetResult>
   has(routingKey: Uint8Array, options?: AbortOptions): Promise<boolean>
   delete(routingKey: Uint8Array, options?: AbortOptions): Promise<void>
   /**
@@ -50,7 +51,7 @@ export interface LocalStore {
  */
 export function localStore (datastore: Datastore, log: Logger): LocalStore {
   return {
-    async put (routingKey: Uint8Array, marshalledRecord: Uint8Array, options: PutOptions = {}) {
+    async put (routingKey: Uint8Array, marshalledRecord: Uint8Array, options: IPNSRoutingPutOptions = {}) {
       try {
         const key = dhtRoutingKey(routingKey)
 
@@ -86,7 +87,7 @@ export function localStore (datastore: Datastore, log: Logger): LocalStore {
         throw err
       }
     },
-    async get (routingKey: Uint8Array, options: GetOptions = {}): Promise<GetResult> {
+    async get (routingKey: Uint8Array, options: IPNSRoutingGetOptions = {}): Promise<GetResult> {
       try {
         const key = dhtRoutingKey(routingKey)
 
@@ -97,7 +98,7 @@ export function localStore (datastore: Datastore, log: Logger): LocalStore {
         const record = Record.deserialize(buf)
 
         return {
-          record: record.value,
+          record: withArrayBuffer(record.value),
           created: record.timeReceived
         }
       } catch (err: any) {

--- a/packages/ipns/src/pb/ipns.proto
+++ b/packages/ipns/src/pb/ipns.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-message IpnsEntry {
+message IPNSEntry {
 	enum ValidityType {
 		// setting an EOL says "this record is valid until..."
 		EOL = 0;

--- a/packages/ipns/src/pb/ipns.ts
+++ b/packages/ipns/src/pb/ipns.ts
@@ -2,19 +2,19 @@ import { decodeMessage, encodeMessage, enumeration, message, streamMessage } fro
 import type { Codec, DecodeOptions } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
-export interface IpnsEntry {
-  value?: Uint8Array
-  signatureV1?: Uint8Array
-  validityType?: IpnsEntry.ValidityType
-  validity?: Uint8Array
+export interface IPNSEntry {
+  value?: Uint8Array<ArrayBuffer>
+  signatureV1?: Uint8Array<ArrayBuffer>
+  validityType?: IPNSEntry.ValidityType
+  validity?: Uint8Array<ArrayBuffer>
   sequence?: bigint
   ttl?: bigint
-  publicKey?: Uint8Array
-  signatureV2?: Uint8Array
-  data?: Uint8Array
+  publicKey?: Uint8Array<ArrayBuffer>
+  signatureV2?: Uint8Array<ArrayBuffer>
+  data?: Uint8Array<ArrayBuffer>
 }
 
-export namespace IpnsEntry {
+export namespace IPNSEntry {
   export enum ValidityType {
     EOL = 'EOL'
   }
@@ -29,11 +29,11 @@ export namespace IpnsEntry {
     }
   }
 
-  let _codec: Codec<IpnsEntry>
+  let _codec: Codec<IPNSEntry>
 
-  export const codec = (): Codec<IpnsEntry> => {
+  export const codec = (): Codec<IPNSEntry> => {
     if (_codec == null) {
-      _codec = message<IpnsEntry>((obj, w, opts = {}) => {
+      _codec = message<IPNSEntry>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
           w.fork()
         }
@@ -50,7 +50,7 @@ export namespace IpnsEntry {
 
         if (obj.validityType != null) {
           w.uint32(24)
-          IpnsEntry.ValidityType.codec().encode(obj.validityType, w)
+          IPNSEntry.ValidityType.codec().encode(obj.validityType, w)
         }
 
         if (obj.validity != null) {
@@ -104,7 +104,7 @@ export namespace IpnsEntry {
               break
             }
             case 3: {
-              obj.validityType = IpnsEntry.ValidityType.codec().decode(reader)
+              obj.validityType = IPNSEntry.ValidityType.codec().decode(reader)
               break
             }
             case 4: {
@@ -163,7 +163,7 @@ export namespace IpnsEntry {
             case 3: {
               yield {
                 field: `${prefix}.validityType`,
-                value: IpnsEntry.ValidityType.codec().decode(reader)
+                value: IPNSEntry.ValidityType.codec().decode(reader)
               }
               break
             }
@@ -221,60 +221,60 @@ export namespace IpnsEntry {
     return _codec
   }
 
-  export interface IpnsEntryValueFieldEvent {
+  export interface IPNSEntryValueFieldEvent {
     field: '$.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
-  export interface IpnsEntrySignatureV1FieldEvent {
+  export interface IPNSEntrySignatureV1FieldEvent {
     field: '$.signatureV1'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
-  export interface IpnsEntryValidityTypeFieldEvent {
+  export interface IPNSEntryValidityTypeFieldEvent {
     field: '$.validityType'
-    value: IpnsEntry.ValidityType
+    value: IPNSEntry.ValidityType
   }
 
-  export interface IpnsEntryValidityFieldEvent {
+  export interface IPNSEntryValidityFieldEvent {
     field: '$.validity'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
-  export interface IpnsEntrySequenceFieldEvent {
+  export interface IPNSEntrySequenceFieldEvent {
     field: '$.sequence'
     value: bigint
   }
 
-  export interface IpnsEntryTtlFieldEvent {
+  export interface IPNSEntryTtlFieldEvent {
     field: '$.ttl'
     value: bigint
   }
 
-  export interface IpnsEntryPublicKeyFieldEvent {
+  export interface IPNSEntryPublicKeyFieldEvent {
     field: '$.publicKey'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
-  export interface IpnsEntrySignatureV2FieldEvent {
+  export interface IPNSEntrySignatureV2FieldEvent {
     field: '$.signatureV2'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
-  export interface IpnsEntryDataFieldEvent {
+  export interface IPNSEntryDataFieldEvent {
     field: '$.data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
-  export function encode (obj: Partial<IpnsEntry>): Uint8Array<ArrayBuffer> {
-    return encodeMessage(obj, IpnsEntry.codec())
+  export function encode (obj: Partial<IPNSEntry>): Uint8Array<ArrayBuffer> {
+    return encodeMessage(obj, IPNSEntry.codec())
   }
 
-  export function decode (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<IpnsEntry>): IpnsEntry {
-    return decodeMessage(buf, IpnsEntry.codec(), opts)
+  export function decode (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<IPNSEntry>): IPNSEntry {
+    return decodeMessage(buf, IPNSEntry.codec(), opts)
   }
 
-  export function stream (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<IpnsEntry>): Generator<IpnsEntryValueFieldEvent | IpnsEntrySignatureV1FieldEvent | IpnsEntryValidityTypeFieldEvent | IpnsEntryValidityFieldEvent | IpnsEntrySequenceFieldEvent | IpnsEntryTtlFieldEvent | IpnsEntryPublicKeyFieldEvent | IpnsEntrySignatureV2FieldEvent | IpnsEntryDataFieldEvent> {
-    return streamMessage(buf, IpnsEntry.codec(), opts)
+  export function stream (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<IPNSEntry>): Generator<IPNSEntryValueFieldEvent | IPNSEntrySignatureV1FieldEvent | IPNSEntryValidityTypeFieldEvent | IPNSEntryValidityFieldEvent | IPNSEntrySequenceFieldEvent | IPNSEntryTtlFieldEvent | IPNSEntryPublicKeyFieldEvent | IPNSEntrySignatureV2FieldEvent | IPNSEntryDataFieldEvent> {
+    return streamMessage(buf, IPNSEntry.codec(), opts)
   }
 }

--- a/packages/ipns/src/records.ts
+++ b/packages/ipns/src/records.ts
@@ -2,259 +2,106 @@ import { logger } from '@libp2p/logger'
 import NanoDate from 'timestamp-nano'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { SignatureCreationError } from './errors.ts'
-import { IpnsEntry } from './pb/ipns.ts'
-import { createCborData, ipnsRecordDataForV1Sig, ipnsRecordDataForV2Sig, marshalIPNSRecord } from './utils.ts'
+import { IPNSEntry } from './pb/ipns.ts'
+import { encodeExtensibleData, IDENTITY_CODEC, ipnsRecordDataForV1Sig, ipnsRecordDataForV2Sig } from './utils.ts'
 import type { PrivateKey, PublicKey } from '@helia/interface'
 import type { AbortOptions } from 'abort-error'
-import type { Key } from 'interface-datastore/key'
 
 const log = logger('ipns')
-const DEFAULT_TTL_NS = 5 * 60 * 1e+9 // 5 Minutes or 300 Seconds, as suggested by https://specs.ipfs.tech/ipns/ipns-record/#ttl-uint64
+const DEFAULT_TTL_NS = 300_000_000_000n // 5 Minutes or 300 Seconds, as suggested by https://specs.ipfs.tech/ipns/ipns-record/#ttl-uint64
 
-export const namespace = '/ipns/'
-export const namespaceLength = namespace.length
-
-export interface IPNSRecordV1V2 {
+export interface CreateIPNSRecordOptions extends AbortOptions {
   /**
-   * value of the record
+   * By default a IPNS V1 and a V2 signature is added to every record. Pass
+   * false here to only add a V2 signature.
+   *
+   * @default true
    */
-  value: string
-
-  /**
-   * signature of the record
-   */
-  signatureV1: Uint8Array
-
-  /**
-   * Type of validation being used
-   */
-  validityType: IpnsEntry.ValidityType
-
-  /**
-   * expiration datetime for the record in RFC3339 format
-   */
-  validity: string
-
-  /**
-   * number representing the version of the record
-   */
-  sequence: bigint
-
-  /**
-   * ttl in nanoseconds
-   */
-  ttl?: bigint
-
-  /**
-   * the public portion of the key that signed this record
-   */
-  publicKey: PublicKey
-
-  /**
-   * the v2 signature of the record
-   */
-  signatureV2: Uint8Array
-
-  /**
-   * extensible data
-   */
-  data: Uint8Array
-
-  /**
-   * The marshalled record
-   */
-  bytes: Uint8Array
-}
-
-export interface IPNSRecordV2 {
-  /**
-   * value of the record
-   */
-  value: string
-
-  /**
-   * the v2 signature of the record
-   */
-  signatureV2: Uint8Array
-
-  /**
-   * Type of validation being used
-   */
-  validityType: IpnsEntry.ValidityType
-
-  /**
-   * If the validity type is EOL, this is the expiration datetime for the record
-   * in RFC3339 format
-   */
-  validity: string
-
-  /**
-   * number representing the version of the record
-   */
-  sequence: bigint
-
-  /**
-   * ttl in nanoseconds
-   */
-  ttl?: bigint
-
-  /**
-   * the public portion of the key that signed this record
-   */
-  publicKey: PublicKey
-
-  /**
-   * extensible data
-   */
-  data: Uint8Array
-
-  /**
-   * The marshalled record
-   */
-  bytes: Uint8Array
-}
-
-export type IPNSRecord = IPNSRecordV1V2 | IPNSRecordV2
-
-export interface IPNSRecordData {
-  Value: Uint8Array
-  Validity: Uint8Array
-  ValidityType: IpnsEntry.ValidityType
-  Sequence: bigint
-  TTL: bigint
-}
-
-export interface IDKeys {
-  routingPubKey: Key
-  pkKey: Key
-  routingKey: Key
-  ipnsKey: Key
-}
-
-export interface CreateOptions extends AbortOptions {
-  ttlNs?: number | bigint
   v1Compatible?: boolean
-}
 
-export interface CreateV2OrV1Options extends AbortOptions {
-  v1Compatible: true
-}
+  /**
+   * The TTL of the record in ms - after this many ms have expired, resolving
+   * the record will query the routing for an updated version.
+   *
+   * Before this many ms have expired any locally stored copy will be treated as
+   * the latest version and the routing will not be queried.
+   *
+   * @default 300_000_000_000n
+   */
+  ttlNs?: bigint
 
-export interface CreateV2Options extends AbortOptions {
-  v1Compatible: false
-}
-
-const defaultCreateOptions: CreateOptions = {
-  v1Compatible: true,
-  ttlNs: DEFAULT_TTL_NS
+  /**
+   * Extensible data that will be added to the IPNS record data and signed to
+   * verify it's integrity.
+   *
+   * Note that this data will be encoded as DAG-CBOR so it must be valid.
+   */
+  data?: Record<string, any>
 }
 
 /**
- * Creates a new IPNS record and signs it with the given private key.
- * The IPNS Record validity should follow the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt} with nanoseconds precision.
- * Note: This function does not embed the public key. If you want to do that, use `EmbedPublicKey`.
+ * A low-level function that creates a new IPNS record and signs it with the
+ * passed private key.
  *
- * The passed value can be a CID, a PublicKey or an arbitrary string path e.g. `/ipfs/...` or `/ipns/...`.
+ * The IPNS Record validity should follow the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt}
+ * with nanosecond precision.
  *
- * CIDs will be converted to v1 and stored in the record as a string similar to: `/ipfs/${cid}`
- * PublicKeys will create recursive records, eg. the record value will be `/ipns/${cidV1Libp2pKey}`
- * String paths will be stored in the record as-is, but they must start with `"/"`
- *
- * @param {PrivateKey} privateKey - the private key for signing the record.
- * @param {CID | PublicKey | string} value - content to be stored in the record.
- * @param {number | bigint} seq - number representing the current version of the record.
- * @param {number} lifetime - lifetime of the record (in milliseconds).
- * @param {CreateOptions} options - additional create options.
+ * The passed value should be a string path e.g. `/ipfs/...` or `/ipns/...`.
  */
-export async function createIPNSRecord (privateKey: PrivateKey, value: string, seq: number | bigint, lifetime: number, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
-export async function createIPNSRecord (privateKey: PrivateKey, value: string, seq: number | bigint, lifetime: number, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function createIPNSRecord (privateKey: PrivateKey, value: string, seq: number | bigint, lifetime: number, options: CreateOptions): Promise<IPNSRecordV1V2>
-export async function createIPNSRecord (privateKey: PrivateKey, value: string, seq: number | bigint, lifetime: number, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
+export async function createIPNSRecord (privateKey: PrivateKey, val: string, seq: number | bigint, lifetime: number, options?: CreateIPNSRecordOptions): Promise<IPNSEntry> {
+  seq = BigInt(seq)
+  const value = uint8ArrayFromString(val)
+  // convert ttl from milliseconds to nanoseconds as createIPNSRecord expects
+  const ttlNs = options?.ttlNs ?? DEFAULT_TTL_NS
+
   // Validity in ISOString with nanoseconds precision and validity type EOL
   const expirationDate = new NanoDate(Date.now() + Number(lifetime))
-  const validityType = IpnsEntry.ValidityType.EOL
-  const ttlNs = BigInt(options.ttlNs ?? DEFAULT_TTL_NS)
+  const validityType = IPNSEntry.ValidityType.EOL
+  const validity = uint8ArrayFromString(expirationDate.toString())
 
-  return _create(privateKey, value, seq, validityType, expirationDate.toString(), ttlNs, options)
-}
+  const data = encodeExtensibleData({
+    ...(options?.data ?? {}),
+    Value: value,
+    Validity: validity,
+    // @ts-expect-error should be a number
+    ValidityType: 0,
+    Sequence: seq,
+    TTL: ttlNs
+  })
 
-/**
- * Same as create(), but instead of generating a new Date, it receives the intended expiration time
- * WARNING: nano precision is not standard, make sure the value in seconds is 9 orders of magnitude lesser than the one provided.
- *
- * The passed value can be a CID, a PublicKey or an arbitrary string path e.g. `/ipfs/...` or `/ipns/...`.
- *
- * CIDs will be converted to v1 and stored in the record as a string similar to: `/ipfs/${cid}`
- * PublicKeys will create recursive records, eg. the record value will be `/ipns/${cidV1Libp2pKey}`
- * String paths will be stored in the record as-is, but they must start with `"/"`
- *
- * @param {PrivateKey} privateKey - the private key for signing the record.
- * @param {CID | PublicKey | string} value - content to be stored in the record.
- * @param {number | bigint} seq - number representing the current version of the record.
- * @param {string} expiration - expiration datetime for record in the [RFC3339]{@link https://www.ietf.org/rfc/rfc3339.txt} with nanoseconds precision.
- * @param {CreateOptions} options - additional creation options.
- */
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: string, seq: number | bigint, expiration: string, options?: CreateV2OrV1Options): Promise<IPNSRecordV1V2>
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: string, seq: number | bigint, expiration: string, options: CreateV2Options): Promise<IPNSRecordV2>
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: string, seq: number | bigint, expiration: string, options: CreateOptions): Promise<IPNSRecordV1V2>
-export async function createIPNSRecordWithExpiration (privateKey: PrivateKey, value: string, seq: number | bigint, expiration: string, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> {
-  const expirationDate = NanoDate.fromString(expiration)
-  const validityType = IpnsEntry.ValidityType.EOL
-  const ttlNs = BigInt(options.ttlNs ?? DEFAULT_TTL_NS)
-
-  return _create(privateKey, value, seq, validityType, expirationDate.toString(), ttlNs, options)
-}
-
-const _create = async (privateKey: PrivateKey, value: string, seq: number | bigint, validityType: IpnsEntry.ValidityType, validity: string, ttl: bigint, options: CreateOptions = defaultCreateOptions): Promise<IPNSRecord> => {
-  seq = BigInt(seq)
-  const isoValidity = uint8ArrayFromString(validity)
-  const data = createCborData(value, validityType, isoValidity, seq, ttl)
   const sigData = ipnsRecordDataForV2Sig(data)
   const signatureV2 = await privateKey.sign(sigData, options)
-  const publicKey = shouldEmbedPublicKey(privateKey.publicKey) ? privateKey.publicKey : undefined
-  let record: any
+  let record: IPNSEntry
 
-  if (options.v1Compatible === true) {
-    const signatureV1 = await signLegacyV1(privateKey, value, validityType, isoValidity)
-
+  if (options?.v1Compatible === false) {
     record = {
-      value,
-      signatureV1,
-      validity,
-      validityType,
-      sequence: seq,
-      ttl,
       signatureV2,
-      data,
-      publicKey
+      data
     }
   } else {
     record = {
       value,
-      validity,
+      signatureV1: await signLegacyV1(privateKey, value, validityType, validity),
       validityType,
+      validity,
       sequence: seq,
-      ttl,
+      ttl: ttlNs,
       signatureV2,
-      data,
-      publicKey
+      data
     }
   }
 
-  record.bytes = marshalIPNSRecord(record)
+  if (shouldEmbedPublicKey(privateKey.publicKey)) {
+    record.publicKey = privateKey.publicKey.toProtobuf()
+  }
 
   return record
 }
 
-export { unmarshalIPNSRecord } from './utils.ts'
-export { marshalIPNSRecord } from './utils.ts'
-export { multihashToIPNSRoutingKey } from './utils.ts'
-export { multihashFromIPNSRoutingKey } from './utils.ts'
-
 /**
  * Sign ipns record data using the legacy V1 signature scheme
  */
-const signLegacyV1 = async (privateKey: PrivateKey, value: string, validityType: IpnsEntry.ValidityType, validity: Uint8Array, options?: AbortOptions): Promise<Uint8Array> => {
+const signLegacyV1 = async (privateKey: PrivateKey, value: Uint8Array, validityType: IPNSEntry.ValidityType, validity: Uint8Array, options?: AbortOptions): Promise<Uint8Array<ArrayBuffer>> => {
   try {
     const dataForSignature = ipnsRecordDataForV1Sig(value, validityType, validity)
 
@@ -269,5 +116,5 @@ const signLegacyV1 = async (privateKey: PrivateKey, value: string, validityType:
  * Returns true if the public key multihash is not an identity hash
  */
 function shouldEmbedPublicKey (key: PublicKey): boolean {
-  return key.toMultihash().code !== 0
+  return key.toMultihash().code !== IDENTITY_CODEC
 }

--- a/packages/ipns/src/routing/helia.ts
+++ b/packages/ipns/src/routing/helia.ts
@@ -1,5 +1,5 @@
 import { CustomProgressEvent } from 'progress-events'
-import type { GetOptions, PutOptions } from './index.ts'
+import type { IPNSRoutingGetOptions, IPNSRoutingPutOptions } from './index.ts'
 import type { IPNSRouting } from '../index.ts'
 import type { Routing } from '@helia/interface'
 import type { ProgressEvent } from 'progress-events'
@@ -11,14 +11,14 @@ export interface HeliaRoutingComponents {
 export type HeliaRoutingProgressEvents =
   ProgressEvent<'ipns:routing:helia:error', Error>
 
-export class HeliaRouting implements IPNSRouting {
+export class HeliaIPNSRouting implements IPNSRouting {
   private readonly routing: Routing
 
   constructor (routing: Routing) {
     this.routing = routing
   }
 
-  async put (routingKey: Uint8Array, marshaledRecord: Uint8Array, options: PutOptions = {}): Promise<void> {
+  async put (routingKey: Uint8Array, marshaledRecord: Uint8Array, options: IPNSRoutingPutOptions = {}): Promise<void> {
     try {
       await this.routing.put(routingKey, marshaledRecord, options)
     } catch (err: any) {
@@ -27,7 +27,7 @@ export class HeliaRouting implements IPNSRouting {
     }
   }
 
-  async get (routingKey: Uint8Array, options: GetOptions = {}): Promise<Uint8Array> {
+  async get (routingKey: Uint8Array, options: IPNSRoutingGetOptions = {}): Promise<Uint8Array<ArrayBuffer>> {
     try {
       return await this.routing.get(routingKey, options)
     } catch (err: any) {
@@ -45,6 +45,6 @@ export class HeliaRouting implements IPNSRouting {
  * The helia routing uses any available Routers configured on the passed Helia
  * node. This could be libp2p, HTTP API Delegated Routing, etc.
  */
-export function helia (routing: Routing): IPNSRouting {
-  return new HeliaRouting(routing)
+export function heliaIPNSRouting (routing: Routing): IPNSRouting {
+  return new HeliaIPNSRouting(routing)
 }

--- a/packages/ipns/src/routing/index.ts
+++ b/packages/ipns/src/routing/index.ts
@@ -5,11 +5,11 @@ import type { IPNSPublishMetadata } from '../pb/metadata.ts'
 import type { AbortOptions } from '@libp2p/interface'
 import type { ProgressOptions } from 'progress-events'
 
-export interface PutOptions extends AbortOptions, ProgressOptions {
+export interface IPNSRoutingPutOptions extends AbortOptions, ProgressOptions {
   metadata?: IPNSPublishMetadata
 }
 
-export interface GetOptions extends AbortOptions, ProgressOptions {
+export interface IPNSRoutingGetOptions extends AbortOptions, ProgressOptions {
   /**
    * Pass false to not perform validation actions
    *
@@ -19,8 +19,8 @@ export interface GetOptions extends AbortOptions, ProgressOptions {
 }
 
 export interface IPNSRouting {
-  put(routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: PutOptions): Promise<void>
-  get(routingKey: Uint8Array, options?: GetOptions): Promise<Uint8Array>
+  put(routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: IPNSRoutingPutOptions): Promise<void>
+  get(routingKey: Uint8Array, options?: IPNSRoutingGetOptions): Promise<Uint8Array>
 }
 
 export type { DatastoreProgressEvents }
@@ -32,6 +32,6 @@ export type IPNSRoutingProgressEvents =
   HeliaRoutingProgressEvents |
   PubSubProgressEvents
 
-export { helia } from './helia.ts'
-export { pubsub } from './pubsub.ts'
-export type { PubsubRoutingComponents, PubSub, Message, PublishResult, PubSubEvents } from './pubsub.ts'
+export { heliaIPNSRouting } from './helia.ts'
+export { pubSubIPNSRouting } from './pubsub.ts'
+export type { PubsubRoutingComponents, PubSub, PubSubMessage, PublishResult, PubSubEvents, PubSubSubscription, PubSubSubscriptionChangeData } from './pubsub.ts'

--- a/packages/ipns/src/routing/local-store.ts
+++ b/packages/ipns/src/routing/local-store.ts
@@ -1,18 +1,18 @@
 import type { LocalStore } from '../local-store.ts'
-import type { IPNSRouting, PutOptions, GetOptions } from './index.ts'
+import type { IPNSRouting, IPNSRoutingPutOptions, IPNSRoutingGetOptions } from './index.ts'
 
-class LocalStoreRouting {
+class LocalStoreIPNSRouting {
   private localStore: LocalStore
 
   constructor (localStore: LocalStore) {
     this.localStore = localStore
   }
 
-  async put (routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: PutOptions): Promise<void> {
+  async put (routingKey: Uint8Array, marshaledRecord: Uint8Array, options?: IPNSRoutingPutOptions): Promise<void> {
     await this.localStore.put(routingKey, marshaledRecord, options)
   }
 
-  async get (routingKey: Uint8Array, options?: GetOptions): Promise<Uint8Array> {
+  async get (routingKey: Uint8Array, options?: IPNSRoutingGetOptions): Promise<Uint8Array<ArrayBuffer>> {
     const { record } = await this.localStore.get(routingKey, options)
 
     return record
@@ -26,6 +26,6 @@ class LocalStoreRouting {
 /**
  * Returns an IPNSRouting implementation that reads/writes to the local store
  */
-export function localStoreRouting (localStore: LocalStore): IPNSRouting {
-  return new LocalStoreRouting(localStore)
+export function localStoreIPNSRouting (localStore: LocalStore): IPNSRouting {
+  return new LocalStoreIPNSRouting(localStore)
 }

--- a/packages/ipns/src/routing/pubsub.ts
+++ b/packages/ipns/src/routing/pubsub.ts
@@ -9,13 +9,13 @@ import { raceSignal } from 'race-signal'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import { InvalidTopicError } from '../errors.ts'
 import { localStore } from '../local-store.ts'
-import { multihashToIPNSRoutingKey } from '../records.ts'
 import { ipnsSelector } from '../selector.ts'
-import { IPNS_STRING_PREFIX, unmarshalIPNSRecord } from '../utils.ts'
+import { IPNS_STRING_PREFIX, multihashToIPNSRoutingKey } from '../utils.ts'
 import { ipnsValidator } from '../validator.ts'
-import type { GetOptions, IPNSRouting, PutOptions } from './index.ts'
+import type { IPNSRoutingGetOptions, IPNSRouting, IPNSRoutingPutOptions } from './index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { Keychain } from '@helia/interface'
 import type { Fetch } from '@libp2p/fetch'
@@ -26,26 +26,26 @@ import type { ProgressEvent } from 'progress-events'
 
 const log = logger('helia:ipns:routing:pubsub')
 
-export interface Message {
+export interface PubSubMessage {
   type: 'signed' | 'unsigned'
   from: PeerId
   topic: string
   data: Uint8Array
 }
 
-export interface Subscription {
+export interface PubSubSubscription {
   topic: string
   subscribe: boolean
 }
 
-export interface SubscriptionChangeData {
+export interface PubSubSubscriptionChangeData {
   peerId: PeerId
-  subscriptions: Subscription[]
+  subscriptions: PubSubSubscription[]
 }
 
 export interface PubSubEvents {
-  'subscription-change': CustomEvent<SubscriptionChangeData>
-  message: CustomEvent<Message>
+  'subscription-change': CustomEvent<PubSubSubscriptionChangeData>
+  message: CustomEvent<PubSubMessage>
 }
 
 export interface PublishResult {
@@ -96,7 +96,7 @@ export type PubSubProgressEvents =
   ProgressEvent<'ipns:pubsub:subscribe', { topic: string }> |
   ProgressEvent<'ipns:pubsub:error', Error>
 
-export class PubSubRouting implements IPNSRouting, Startable {
+export class PubSubIPNSRouting implements IPNSRouting, Startable {
   private readonly subscriptions: Set<string>
   private readonly localStore: LocalStore
   private readonly libp2p: Pick<Libp2p<{ pubsub: PubSub, fetch?: Fetch }>, 'peerId' | 'register' | 'unregister' | 'services'>
@@ -196,7 +196,7 @@ export class PubSubRouting implements IPNSRouting, Startable {
     }
   }
 
-  async #processPubSubMessage (message: Message, options?: AbortOptions): Promise<void> {
+  async #processPubSubMessage (message: PubSubMessage, options?: AbortOptions): Promise<void> {
     log('message received for topic', message.topic)
 
     if (message.type !== 'signed') {
@@ -212,7 +212,7 @@ export class PubSubRouting implements IPNSRouting, Startable {
     await this.#handleRecord(message.topic, topicToKey(message.topic), message.data, false, options)
   }
 
-  async #fetchFromPeer (topic: string, routingKey: Uint8Array, peerId: PeerId, options?: AbortOptions): Promise<Uint8Array> {
+  async #fetchFromPeer (topic: string, routingKey: Uint8Array, peerId: PeerId, options?: AbortOptions): Promise<Uint8Array<ArrayBuffer>> {
     const marshalledRecord = await this.fetchQueue.add(async ({ signal }) => {
       log('fetching ipns record for %m from peer %s', routingKey, peerId)
 
@@ -238,18 +238,17 @@ export class PubSubRouting implements IPNSRouting, Startable {
     return this.#handleRecord(topic, routingKey, marshalledRecord, true, options)
   }
 
-  async #handleRecord (topic: string, routingKey: Uint8Array, marshalledRecord: Uint8Array, publish: boolean, options?: AbortOptions): Promise<Uint8Array> {
-    const record = await unmarshalIPNSRecord(routingKey, marshalledRecord, this.keychain, options)
-    await ipnsValidator(record, options)
+  async #handleRecord (topic: string, routingKey: Uint8Array, marshalledRecord: Uint8Array, publish: boolean, options?: AbortOptions): Promise<Uint8Array<ArrayBuffer>> {
+    const record = await ipnsValidator(routingKey, marshalledRecord, this.keychain, options)
     this.shutdownController.signal.throwIfAborted()
 
     if (await this.localStore.has(routingKey)) {
       const { record: marshaledCurrentRecord } = await this.localStore.get(routingKey, options)
-      const currentRecord = await unmarshalIPNSRecord(routingKey, marshaledCurrentRecord, this.keychain, options)
+      const currentRecord = await ipnsValidator(routingKey, marshaledCurrentRecord, this.keychain, options)
 
-      if (uint8ArrayEquals(marshaledCurrentRecord, record.bytes)) {
+      if (uint8ArrayEquals(marshaledCurrentRecord, marshalledRecord)) {
         log.trace('found identical record for %m', routingKey)
-        return currentRecord.bytes
+        return marshaledCurrentRecord
       }
 
       const records = [currentRecord, record]
@@ -257,7 +256,7 @@ export class PubSubRouting implements IPNSRouting, Startable {
 
       if (index === 0) {
         log.trace('found old record for %m', routingKey)
-        return currentRecord.bytes
+        return marshaledCurrentRecord
       }
     }
 
@@ -276,13 +275,13 @@ export class PubSubRouting implements IPNSRouting, Startable {
       }
     }
 
-    return marshalledRecord
+    return withArrayBuffer(marshalledRecord)
   }
 
   /**
    * Put a value to the pubsub datastore indexed by the received key properly encoded
    */
-  async put (routingKey: Uint8Array, marshaledRecord: Uint8Array, options: PutOptions = {}): Promise<void> {
+  async put (routingKey: Uint8Array, marshaledRecord: Uint8Array, options: IPNSRoutingPutOptions = {}): Promise<void> {
     try {
       const topic = keyToTopic(routingKey)
 
@@ -303,7 +302,7 @@ export class PubSubRouting implements IPNSRouting, Startable {
    * Also, the identifier topic is subscribed to and the pubsub datastore records will be
    * updated once new publishes occur
    */
-  async get (routingKey: Uint8Array, options: GetOptions = {}): Promise<Uint8Array> {
+  async get (routingKey: Uint8Array, options: IPNSRoutingGetOptions = {}): Promise<Uint8Array<ArrayBuffer>> {
     const topic = keyToTopic(routingKey)
 
     try {
@@ -324,7 +323,7 @@ export class PubSubRouting implements IPNSRouting, Startable {
     await raceSignal(delay(this.fetchDelay), this.shutdownController.signal)
 
     const fetchController = new AbortController()
-    const promises: Array<Promise<Uint8Array>> = []
+    const promises: Array<Promise<Uint8Array<ArrayBuffer>>> = []
 
     for (const peerId of this.libp2p.services.pubsub.getSubscribers(topic)) {
       const signal = anySignal([
@@ -447,6 +446,6 @@ function topicToKey (topic: string): Uint8Array {
  * updated records, so the first call to `.get` should be expected
  * to fail!
  */
-export function pubsub (components: PubsubRoutingComponents, init: PubsubRoutingInit = {}): IPNSRouting {
-  return new PubSubRouting(components, init)
+export function pubSubIPNSRouting (components: PubsubRoutingComponents, init: PubsubRoutingInit = {}): IPNSRouting {
+  return new PubSubIPNSRouting(components, init)
 }

--- a/packages/ipns/src/selector.ts
+++ b/packages/ipns/src/selector.ts
@@ -1,6 +1,7 @@
 import NanoDate from 'timestamp-nano'
-import { IpnsEntry } from './pb/ipns.ts'
-import type { IPNSRecord } from './records.ts'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { IPNSEntry } from './pb/ipns.ts'
+import { decodeExtensibleData } from './utils.ts'
 
 /**
  * Selects the latest valid IPNS record from an array of marshalled IPNS records.
@@ -13,19 +14,21 @@ import type { IPNSRecord } from './records.ts'
  * @param data - Array of marshalled IPNS records to select from
  * @returns The index of the most valid record from the input array
  */
-export function ipnsSelector (key: Uint8Array, data: IPNSRecord[]): number {
+export function ipnsSelector (key: Uint8Array, data: IPNSEntry[]): number {
   const entries = data.map((record, index) => ({
     record,
     index
   }))
 
   entries.sort((a, b) => {
-    // Before we'd sort based on the signature version. Unmarshal now fails if
-    // a record does not have SignatureV2, so that is no longer needed. V1-only
-    // records haven't been issues in a long time.
+    // Before we'd sort based on the signature version. Validation fails if a
+    // record does not have SignatureV2, so that is no longer needed. V1-only
+    // records will have all expired by this point.
+    const aData = decodeExtensibleData(a.record.data)
+    const bData = decodeExtensibleData(b.record.data)
 
-    const aSeq = a.record.sequence
-    const bSeq = b.record.sequence
+    const aSeq = aData.Sequence
+    const bSeq = bData.Sequence
 
     // choose later sequence number
     if (aSeq > bSeq) {
@@ -34,10 +37,10 @@ export function ipnsSelector (key: Uint8Array, data: IPNSRecord[]): number {
       return 1
     }
 
-    if (a.record.validityType === IpnsEntry.ValidityType.EOL && b.record.validityType === IpnsEntry.ValidityType.EOL) {
+    if (aData.ValidityType === IPNSEntry.ValidityType.EOL && bData.ValidityType === IPNSEntry.ValidityType.EOL) {
       // choose longer lived record if sequence numbers the same
-      const recordAValidityDate = NanoDate.fromString(a.record.validity).toDate()
-      const recordBValidityDate = NanoDate.fromString(b.record.validity).toDate()
+      const recordAValidityDate = NanoDate.fromString(uint8ArrayToString(aData.Validity)).toDate()
+      const recordBValidityDate = NanoDate.fromString(uint8ArrayToString(bData.Validity)).toDate()
 
       if (recordAValidityDate.getTime() > recordBValidityDate.getTime()) {
         return -1

--- a/packages/ipns/src/utils.ts
+++ b/packages/ipns/src/utils.ts
@@ -1,6 +1,6 @@
 import { isPublicKey } from '@helia/interface'
+import * as dagCbor from '@ipld/dag-cbor'
 import { InvalidParametersError } from '@libp2p/interface'
-import * as cborg from 'cborg'
 import { Key } from 'interface-datastore'
 import { base36 } from 'multiformats/bases/base36'
 import { base58btc } from 'multiformats/bases/base58'
@@ -138,7 +138,7 @@ export function multihashFromIPNSRoutingKey (key: Uint8Array): MultihashDigest {
 }
 
 export function encodeExtensibleData (data?: IPNSRecordData): Uint8Array<ArrayBuffer> {
-  return withArrayBuffer(cborg.encode(data))
+  return withArrayBuffer(dagCbor.encode(data))
 }
 
 export function decodeExtensibleData (buf?: Uint8Array): IPNSRecordData {
@@ -146,8 +146,9 @@ export function decodeExtensibleData (buf?: Uint8Array): IPNSRecordData {
     throw new InvalidRecordDataError('Record data is missing')
   }
 
-  const data = cborg.decode(buf)
+  const data = dagCbor.decode<IPNSRecordData>(buf)
 
+  // @ts-expect-error TODO: remove typescript enums
   if (data.ValidityType === 0) {
     data.ValidityType = IPNSEntry.ValidityType.EOL
   }

--- a/packages/ipns/src/utils.ts
+++ b/packages/ipns/src/utils.ts
@@ -10,23 +10,18 @@ import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import { DHT_EXPIRY_MS, REPUBLISH_THRESHOLD } from './constants.ts'
-import { InvalidEmbeddedPublicKeyError, InvalidRecordDataError, InvalidValueError, RecordTooLargeError, SignatureVerificationError, UnsupportedValidityError } from './errors.ts'
-import { IpnsEntry } from './pb/ipns.ts'
-import type { IPNSRecord, IPNSRecordV2, IPNSRecordData } from './records.ts'
-import type { PublicKey, Keychain } from '@helia/interface'
-import type { AbortOptions } from '@libp2p/interface'
+import { InvalidRecordDataError, InvalidValueError, SignatureVerificationError, UnsupportedValidityError } from './errors.ts'
+import { IPNSEntry } from './pb/ipns.ts'
+import type { IPNSRecordData } from './index.ts'
+import type { PublicKey } from '@helia/interface'
 import type { MultibaseDecoder } from 'multiformats/cid'
 import type { MultihashDigest } from 'multiformats/hashes/interface'
 
 export const LIBP2P_KEY_CODEC = 0x72
 export const IDENTITY_CODEC = 0x0
 export const SHA2_256_CODEC = 0x12
-
-/**
- * Limit valid IPNS record sizes to 10kb
- */
-const MAX_RECORD_SIZE = 1024 * 10
 
 const IPNS_PREFIX = uint8ArrayFromString('/ipns/')
 export const IPNS_STRING_PREFIX = '/ipns/'
@@ -60,10 +55,9 @@ export function ipnsMetadataKey (key: Uint8Array): Key {
   return new Key(IPNS_METADATA_PREFIX + uint8ArrayToString(key, 'base32'), false)
 }
 
-export function shouldRepublish (ipnsRecord: IPNSRecord, created: Date): boolean {
+export function shouldRepublish (created: Date, expiry: Date): boolean {
   const now = Date.now()
   const dhtExpiry = created.getTime() + DHT_EXPIRY_MS
-  const recordExpiry = new Date(ipnsRecord.validity).getTime()
 
   // If the DHT expiry is within the threshold, republish it
   if (dhtExpiry - now < REPUBLISH_THRESHOLD) {
@@ -71,7 +65,7 @@ export function shouldRepublish (ipnsRecord: IPNSRecord, created: Date): boolean
   }
 
   // If the record expiry (based on validity/lifetime) is within the threshold, republish it
-  if (recordExpiry - now < REPUBLISH_THRESHOLD) {
+  if (expiry.getTime() - now < REPUBLISH_THRESHOLD) {
     return true
   }
 
@@ -101,15 +95,14 @@ export function isLibp2pCID (obj?: any): obj is CID<unknown, 0x72, 0x00 | 0x12, 
 /**
  * Utility for creating the record data for being signed
  */
-export function ipnsRecordDataForV1Sig (value: string, validityType: IpnsEntry.ValidityType, validity: Uint8Array): Uint8Array {
+export function ipnsRecordDataForV1Sig (value: Uint8Array, validityType: IPNSEntry.ValidityType, validity: Uint8Array): Uint8Array {
   const validityTypeBuffer = uint8ArrayFromString(validityType)
-  const valueBytes = uint8ArrayFromString(value)
 
   return uint8ArrayConcat([
-    valueBytes,
+    value,
     validity,
     validityTypeBuffer
-  ], valueBytes.byteLength + validity.byteLength + validityTypeBuffer.byteLength)
+  ], value.byteLength + validity.byteLength + validityTypeBuffer.byteLength)
 }
 
 /**
@@ -121,37 +114,7 @@ export function ipnsRecordDataForV2Sig (data: Uint8Array): Uint8Array {
   return uint8ArrayConcat([entryData, data])
 }
 
-export function marshalIPNSRecord (obj: IPNSRecord | IPNSRecordV2): Uint8Array {
-  let publicKey: Uint8Array | undefined = obj.publicKey?.toProtobuf()
-
-  // do not embed public keys whose multihash is an identity hash as these can
-  // be derived from the routing key
-  if (obj.publicKey?.toMultihash().code === 0x00) {
-    publicKey = undefined
-  }
-
-  if ('signatureV1' in obj) {
-    return IpnsEntry.encode({
-      value: uint8ArrayFromString(obj.value),
-      signatureV1: obj.signatureV1,
-      validityType: obj.validityType,
-      validity: uint8ArrayFromString(obj.validity),
-      sequence: obj.sequence,
-      ttl: obj.ttl,
-      publicKey,
-      signatureV2: obj.signatureV2,
-      data: obj.data
-    })
-  } else {
-    return IpnsEntry.encode({
-      publicKey,
-      signatureV2: obj.signatureV2,
-      data: obj.data
-    })
-  }
-}
-
-function valueToString (value: Uint8Array): string {
+export function ipnsRecordValueToString (value: Uint8Array): string {
   // handle legacy case where record value is raw CID bytes
   try {
     const cid = CID.decode(value)
@@ -161,76 +124,6 @@ function valueToString (value: Uint8Array): string {
   }
 
   return uint8ArrayToString(value)
-}
-
-export async function unmarshalIPNSRecord (routingKey: Uint8Array, marshalledRecord: Uint8Array, keychain: Keychain, options?: AbortOptions): Promise<IPNSRecord> {
-  if (marshalledRecord.byteLength > MAX_RECORD_SIZE) {
-    throw new RecordTooLargeError('The record is too large')
-  }
-
-  const message = IpnsEntry.decode(marshalledRecord)
-
-  // Check if we have the data field. If we don't, we fail. We've been producing
-  // V1+V2 records for quite a while and we don't support V1-only records during
-  // validation any more
-  if (message.signatureV2 == null || message.data == null) {
-    throw new SignatureVerificationError('Missing data or signatureV2')
-  }
-
-  const data = parseCborData(message.data)
-  const validity = uint8ArrayToString(data.Validity)
-
-  let publicKey: PublicKey | undefined
-
-  // try to extract public key from routing key
-  const routingMultihash = multihashFromIPNSRoutingKey(routingKey)
-
-  // identity hash
-  if (isCodec(routingMultihash, 0x0)) {
-    publicKey = await keychain.loadPublicKeyFromProtobuf(routingMultihash.digest, options)
-  }
-
-  // otherwise try to load key from message
-  if (publicKey == null && message.publicKey != null) {
-    publicKey = await keychain.loadPublicKeyFromProtobuf(message.publicKey, options)
-  }
-
-  if (publicKey == null) {
-    throw new InvalidEmbeddedPublicKeyError('Could not extract public key from IPNS record or routing key')
-  }
-
-  if (message.value != null && message.signatureV1 != null) {
-    // V1+V2
-    validateCborDataMatchesPbData(message)
-
-    return {
-      value: valueToString(data.Value),
-      validityType: IpnsEntry.ValidityType.EOL,
-      validity,
-      sequence: data.Sequence,
-      ttl: data.TTL,
-      publicKey,
-      signatureV1: message.signatureV1,
-      signatureV2: message.signatureV2,
-      data: message.data,
-      bytes: marshalledRecord
-    }
-  } else if (message.signatureV2 != null) {
-    // V2-only
-    return {
-      value: valueToString(data.Value),
-      validityType: IpnsEntry.ValidityType.EOL,
-      validity,
-      sequence: data.Sequence,
-      ttl: data.TTL,
-      publicKey,
-      signatureV2: message.signatureV2,
-      data: message.data,
-      bytes: marshalledRecord
-    }
-  } else {
-    throw new Error('invalid record: does not include signatureV1 or signatureV2')
-  }
 }
 
 export function multihashToIPNSRoutingKey (digest: MultihashDigest): Uint8Array {
@@ -244,32 +137,22 @@ export function multihashFromIPNSRoutingKey (key: Uint8Array): MultihashDigest {
   return Digest.decode(key.slice(IPNS_PREFIX.length))
 }
 
-export function createCborData (value: string, validityType: IpnsEntry.ValidityType, validity: Uint8Array, sequence: bigint, ttl: bigint): Uint8Array {
-  let ValidityType
-
-  if (validityType === IpnsEntry.ValidityType.EOL) {
-    ValidityType = 0
-  } else {
-    throw new UnsupportedValidityError('The validity type is unsupported')
-  }
-
-  const data = {
-    Value: uint8ArrayFromString(value),
-    Validity: validity,
-    ValidityType,
-    Sequence: sequence,
-    TTL: ttl
-  }
-
-  return cborg.encode(data)
+export function encodeExtensibleData (data?: IPNSRecordData): Uint8Array<ArrayBuffer> {
+  return withArrayBuffer(cborg.encode(data))
 }
 
-export function parseCborData (buf: Uint8Array): IPNSRecordData {
+export function decodeExtensibleData (buf?: Uint8Array): IPNSRecordData {
+  if (buf == null) {
+    throw new InvalidRecordDataError('Record data is missing')
+  }
+
   const data = cborg.decode(buf)
 
   if (data.ValidityType === 0) {
-    data.ValidityType = IpnsEntry.ValidityType.EOL
-  } else {
+    data.ValidityType = IPNSEntry.ValidityType.EOL
+  }
+
+  if (data.ValidityType !== IPNSEntry.ValidityType.EOL) {
     throw new UnsupportedValidityError('The validity type is unsupported')
   }
 
@@ -397,13 +280,7 @@ export function normalizeKey (key?: PublicKey | CID | MultihashDigest | string):
   throw new InvalidValueError('Value must be a valid IPNS path starting with /')
 }
 
-function validateCborDataMatchesPbData (entry: IpnsEntry): void {
-  if (entry.data == null) {
-    throw new InvalidRecordDataError('Record data is missing')
-  }
-
-  const data = parseCborData(entry.data)
-
+export function validateCborDataMatchesPbData (entry: IPNSEntry, data: IPNSRecordData): void {
   if (!uint8ArrayEquals(data.Value, entry.value ?? new Uint8Array(0))) {
     throw new SignatureVerificationError('Field "value" did not match between protobuf and CBOR')
   }

--- a/packages/ipns/src/validator.ts
+++ b/packages/ipns/src/validator.ts
@@ -1,27 +1,75 @@
 import NanoDate from 'timestamp-nano'
-import { InvalidEmbeddedPublicKeyError, RecordExpiredError, SignatureVerificationError, UnsupportedValidityError } from './errors.ts'
-import { IpnsEntry } from './pb/ipns.ts'
-import { ipnsRecordDataForV2Sig } from './utils.ts'
-import type { IPNSRecord } from './index.ts'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
+import { InvalidEmbeddedPublicKeyError, RecordExpiredError, RecordTooLargeError, SignatureVerificationError, UnsupportedValidityError } from './errors.ts'
+import { IPNSEntry } from './pb/ipns.ts'
+import { decodeExtensibleData, ipnsRecordDataForV2Sig, isCodec, multihashFromIPNSRoutingKey, validateCborDataMatchesPbData } from './utils.ts'
+import type { PublicKey } from '@ipshipyard/crypto'
+import type { Keychain } from '@ipshipyard/keychain'
 import type { AbortOptions } from '@libp2p/interface'
+
+/**
+ * Limit valid IPNS record sizes to 10kb
+ */
+const MAX_RECORD_SIZE = 1024 * 10
 
 /**
  * Validate the given IPNS record against the given routing key.
  *
+ * Ensure that
+ * - SignatureV2 and Data are present
+ * - ValidityType and Validity are of valid types and have a value
+ * - CBOR data matches protobuf if it's a V1+V2 record
+ *
  * @see https://specs.ipfs.tech/ipns/ipns-record/#routing-record for the binary
  * format of the routing key
  */
-export async function ipnsValidator (record: IPNSRecord, options?: AbortOptions): Promise<void> {
-  if (record.publicKey == null) {
-    throw new InvalidEmbeddedPublicKeyError('The record had no public key associated with it')
+export async function ipnsValidator (routingKey: Uint8Array, marshalledRecord: Uint8Array, keychain: Keychain, options?: AbortOptions): Promise<IPNSEntry> {
+  if (marshalledRecord.byteLength > MAX_RECORD_SIZE) {
+    throw new RecordTooLargeError('The record is too large')
+  }
+
+  const record = IPNSEntry.decode(marshalledRecord)
+
+  // Check if we have the data field. If we don't, we fail. We've been producing
+  // V1+V2 records for quite a while and we don't support V1-only records during
+  // validation any more
+  if (record.signatureV2 == null) {
+    throw new SignatureVerificationError('Missing signatureV2')
+  }
+
+  const data = decodeExtensibleData(record.data)
+  const validity = uint8ArrayToString(data.Validity)
+
+  let publicKey: PublicKey | undefined
+
+  // try to extract public key from routing key
+  const routingMultihash = multihashFromIPNSRoutingKey(routingKey)
+
+  // identity hash
+  if (isCodec(routingMultihash, 0x0)) {
+    publicKey = await keychain.loadPublicKeyFromProtobuf(routingMultihash.digest, options)
+  }
+
+  // otherwise try to load key from message
+  if (publicKey == null && record.publicKey != null) {
+    publicKey = await keychain.loadPublicKeyFromProtobuf(record.publicKey, options)
+  }
+
+  if (publicKey == null) {
+    throw new InvalidEmbeddedPublicKeyError('Could not extract public key from IPNS record or routing key')
   }
 
   // Validate Signature V2
   let isValid
 
   try {
+    if (record.data == null) {
+      // n.b. decodeExtensibleData would have thrown if record data was missing
+      throw new Error('Missing data')
+    }
+
     const dataForSignature = ipnsRecordDataForV2Sig(record.data)
-    isValid = await record.publicKey.verify(dataForSignature, record.signatureV2, options)
+    isValid = await publicKey.verify(dataForSignature, record.signatureV2, options)
   } catch {
     isValid = false
   }
@@ -31,13 +79,20 @@ export async function ipnsValidator (record: IPNSRecord, options?: AbortOptions)
   }
 
   // Validate according to the validity type
-  if (record.validityType === IpnsEntry.ValidityType.EOL) {
-    if (NanoDate.fromString(record.validity).toDate().getTime() < Date.now()) {
+  if (data.ValidityType === IPNSEntry.ValidityType.EOL) {
+    if (NanoDate.fromString(validity).toDate().getTime() < Date.now()) {
       throw new RecordExpiredError('record has expired')
     }
-  } else if (record.validityType != null) {
-    throw new UnsupportedValidityError('The validity type is unsupported')
+  } else if (data.ValidityType != null) {
+    throw new UnsupportedValidityError(`The validity type ${data.ValidityType} is unsupported`)
   }
+
+  if (record.value != null && record.signatureV1 != null) {
+    // V1+V2
+    validateCborDataMatchesPbData(record, data)
+  }
+
+  return record
 }
 
 /**
@@ -47,16 +102,18 @@ export async function ipnsValidator (record: IPNSRecord, options?: AbortOptions)
  * @param record - The IPNS record to validate.
  * @returns The number of milliseconds until the record expires, or 0 if the record is already expired.
  */
-export function validFor (record: IPNSRecord): number {
-  if (record.validityType !== IpnsEntry.ValidityType.EOL) {
+export function validFor (record: IPNSEntry): number {
+  const data = decodeExtensibleData(record.data)
+
+  if (data.ValidityType !== IPNSEntry.ValidityType.EOL) {
     throw new UnsupportedValidityError()
   }
 
-  if (record.validity == null) {
+  if (data.Validity == null) {
     throw new UnsupportedValidityError()
   }
 
-  const validUntil = NanoDate.fromString(record.validity).toDate().getTime()
+  const validUntil = NanoDate.fromString(uint8ArrayToString(data.Validity)).toDate().getTime()
   const now = Date.now()
 
   if (validUntil < now) {

--- a/packages/ipns/test/conformance.spec.ts
+++ b/packages/ipns/test/conformance.spec.ts
@@ -4,8 +4,10 @@ import loadFixture from 'aegir/fixtures'
 import { MemoryDatastore } from 'datastore-core'
 import { base36 } from 'multiformats/bases/base36'
 import { CID } from 'multiformats/cid'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { SignatureVerificationError } from '../src/errors.ts'
-import { marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from '../src/records.ts'
+import { IPNSEntry } from '../src/pb/ipns.ts'
+import { decodeExtensibleData, multihashToIPNSRoutingKey } from '../src/utils.ts'
 import { ipnsValidator } from '../src/validator.ts'
 import { getCrypto } from './fixtures/get-crypto.ts'
 import type { Keychain } from '@ipshipyard/keychain'
@@ -25,7 +27,7 @@ describe('conformance', function () {
     const buf = loadFixture(`test/fixtures/${cid.toString(base36)}_v1.ipns-record`)
     const routingKey = multihashToIPNSRoutingKey(cid.multihash)
 
-    await expect(unmarshalIPNSRecord(routingKey, buf, kc)).to.be.rejectedWith(/Missing data or signatureV2/)
+    await expect(ipnsValidator(routingKey, buf, kc)).to.be.rejectedWith(/Missing signatureV2/)
       .eventually.with.property('name', SignatureVerificationError.name)
   })
 
@@ -33,11 +35,10 @@ describe('conformance', function () {
     const cid = CID.parse('k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w')
     const buf = loadFixture(`test/fixtures/${cid.toString(base36)}_v1-v2.ipns-record`)
     const routingKey = multihashToIPNSRoutingKey(cid.multihash)
-    const record = await unmarshalIPNSRecord(routingKey, buf, kc)
+    const record = await ipnsValidator(routingKey, buf, kc)
 
-    await ipnsValidator(record)
-
-    expect(record.value).to.equal('/ipfs/bafkqaddwgevxmmraojswg33smq')
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString('/ipfs/bafkqaddwgevxmmraojswg33smq'))
   })
 
   it('should reject a record with inconsistent value fields', async () => {
@@ -45,7 +46,7 @@ describe('conformance', function () {
     const buf = loadFixture(`test/fixtures/${cid.toString(base36)}_v1-v2-broken-v1-value.ipns-record`)
     const routingKey = multihashToIPNSRoutingKey(cid.multihash)
 
-    await expect(unmarshalIPNSRecord(routingKey, buf, kc)).to.be.rejectedWith(/Field "value" did not match/)
+    await expect(ipnsValidator(routingKey, buf, kc)).to.be.rejectedWith(/Field "value" did not match/)
       .eventually.with.property('name', SignatureVerificationError.name)
   })
 
@@ -53,9 +54,8 @@ describe('conformance', function () {
     const cid = CID.parse('k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c')
     const buf = loadFixture(`test/fixtures/${cid.toString(base36)}_v1-v2-broken-signature-v2.ipns-record`)
     const routingKey = multihashToIPNSRoutingKey(cid.multihash)
-    const record = await unmarshalIPNSRecord(routingKey, buf, kc)
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejectedWith(/Record signature verification failed/)
+    await expect(ipnsValidator(routingKey, buf, kc)).to.eventually.be.rejectedWith(/Record signature verification failed/)
       .eventually.with.property('name', SignatureVerificationError.name)
   })
 
@@ -63,21 +63,20 @@ describe('conformance', function () {
     const cid = CID.parse('k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y')
     const buf = loadFixture(`test/fixtures/${cid.toString(base36)}_v1-v2-broken-signature-v1.ipns-record`)
     const routingKey = multihashToIPNSRoutingKey(cid.multihash)
+    const record = await ipnsValidator(routingKey, buf, kc)
 
-    const record = await unmarshalIPNSRecord(routingKey, buf, kc)
-
-    expect(record.value).to.equal('/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi')
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString('/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi'))
   })
 
   it('should validate a record with only v2 signature', async () => {
     const cid = CID.parse('k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f')
     const buf = loadFixture(`test/fixtures/${cid.toString(base36)}_v2.ipns-record`)
     const routingKey = multihashToIPNSRoutingKey(cid.multihash)
-    const record = await unmarshalIPNSRecord(routingKey, buf, kc)
+    const record = await ipnsValidator(routingKey, buf, kc)
 
-    await ipnsValidator(record)
-
-    expect(record.value).to.equal('/ipfs/bafkqadtwgiww63tmpeqhezldn5zgi')
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString('/ipfs/bafkqadtwgiww63tmpeqhezldn5zgi'))
   })
 
   it('should round trip fixtures', async () => {
@@ -97,10 +96,9 @@ describe('conformance', function () {
     }]
 
     for (const { cid, fixture } of fixtures) {
-      const routingKey = multihashToIPNSRoutingKey(cid.multihash)
       const buf = loadFixture(fixture)
-      const record = await unmarshalIPNSRecord(routingKey, buf, kc)
-      const marshalled = marshalIPNSRecord(record)
+      const record = IPNSEntry.decode(buf)
+      const marshalled = IPNSEntry.encode(record)
 
       expect(buf).to.equalBytes(marshalled, `Failed to round trip ${cid}`)
     }

--- a/packages/ipns/test/publish.spec.ts
+++ b/packages/ipns/test/publish.spec.ts
@@ -4,7 +4,10 @@ import last from 'it-last'
 import { base36 } from 'multiformats/bases/base36'
 import { CID } from 'multiformats/cid'
 import Sinon from 'sinon'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { localStore } from '../src/local-store.ts'
+import { decodeExtensibleData } from '../src/utils.ts'
 import { createIPNS } from './fixtures/create-ipns.ts'
 import type { CreateIPNSResult } from './fixtures/create-ipns.ts'
 import type { IPNS } from '../src/ipns.ts'
@@ -34,8 +37,9 @@ describe('publish', () => {
     const keyName = 'test-key-1'
     const ipnsEntry = await name.publish(keyName, cid)
 
-    expect(ipnsEntry.record).to.have.property('sequence', 1n)
-    expect(ipnsEntry.record).to.have.property('ttl', 300_000_000_000n) // 5 minutes
+    const extensibleData = decodeExtensibleData(ipnsEntry.record.data)
+    expect(extensibleData).to.have.property('Sequence', 1n)
+    expect(extensibleData).to.have.property('TTL', 300_000_000_000n) // 5 minutes
   })
 
   it('should publish an IPNS record with a custom lifetime params', async function () {
@@ -45,11 +49,12 @@ describe('publish', () => {
       lifetime
     })
 
-    expect(ipnsEntry.record).to.have.property('sequence', 1n)
+    const extensibleData = decodeExtensibleData(ipnsEntry.record.data)
+    expect(extensibleData).to.have.property('Sequence', 1n)
 
     // Calculate expected validity as a Date object
     const expectedValidity = new Date(Date.now() + lifetime)
-    const actualValidity = new Date(ipnsEntry.record.validity)
+    const actualValidity = new Date(uint8ArrayToString(extensibleData.Validity))
     const timeDifference = Math.abs(actualValidity.getTime() - expectedValidity.getTime())
     expect(timeDifference).to.be.lessThan(1000)
 
@@ -65,8 +70,9 @@ describe('publish', () => {
       ttl
     })
 
-    expect(ipnsEntry.record).to.have.property('sequence', 1n)
-    expect(ipnsEntry.record).to.have.property('ttl', BigInt(ttl * 1e+6))
+    const extensibleData = decodeExtensibleData(ipnsEntry.record.data)
+    expect(extensibleData).to.have.property('Sequence', 1n)
+    expect(extensibleData).to.have.property('TTL', BigInt(ttl * 1e+6))
 
     expect(heliaRouting.put.called).to.be.true()
     expect(customRouting.put.called).to.be.true()
@@ -92,20 +98,36 @@ describe('publish', () => {
     expect(onProgress).to.have.property('called', true)
   })
 
+  it('should publish an IPNS record extensible metadata', async function () {
+    const keyName = 'test-key'
+    const ipnsEntry = await name.publish(keyName, cid, {
+      data: {
+        hello: 'world'
+      }
+    })
+
+    const extensibleData = decodeExtensibleData(ipnsEntry.record.data)
+    expect(extensibleData).to.have.property('Sequence', 1n)
+    expect(extensibleData).to.have.property('TTL', 300_000_000_000n) // 5 minutes
+    expect(extensibleData).to.have.property('hello', 'world') // 5 minutes
+  })
+
   it('should publish recursively using a public key', async () => {
     const keyName1 = 'test-key-6'
     const published = await name.publish(keyName1, cid, {
       offline: true
     })
 
-    expect(published.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const extensibleData = decodeExtensibleData(published.record.data)
+    expect(extensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
 
     const keyName2 = 'test-key-7'
     const recursiveRecord = await name.publish(keyName2, published.publicKey, {
       offline: true
     })
 
-    expect(recursiveRecord.record.value).to.equal(`/ipns/${published.publicKey.toCID().toString(base36)}`)
+    const recursiveExtensibleData = decodeExtensibleData(recursiveRecord.record.data)
+    expect(recursiveExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipns/${published.publicKey.toCID().toString(base36)}`))
 
     const recursiveResult = await last(name.resolve(recursiveRecord.publicKey))
 
@@ -113,7 +135,10 @@ describe('publish', () => {
       throw new Error('No results found')
     }
 
-    expect(recursiveResult.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const recursiveResultExtensibleData = decodeExtensibleData(recursiveResult.record.data)
+    expect(recursiveResultExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
+
+    expect(recursiveResult).to.have.property('value').that.equals(`/ipfs/${cid.toV1()}`)
   })
 
   it('should publish recursively using a libp2p-key CID', async () => {
@@ -122,14 +147,16 @@ describe('publish', () => {
       offline: true
     })
 
-    expect(published.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const extensibleData = decodeExtensibleData(published.record.data)
+    expect(extensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
 
     const keyName2 = 'test-key-7'
     const recursiveRecord = await name.publish(keyName2, published.publicKey.toCID(), {
       offline: true
     })
 
-    expect(recursiveRecord.record.value).to.equal(`/ipns/${published.publicKey.toCID().toString(base36)}`)
+    const recursiveExtensibleData = decodeExtensibleData(recursiveRecord.record.data)
+    expect(recursiveExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipns/${published.publicKey.toCID().toString(base36)}`))
 
     const recursiveResult = await last(name.resolve(recursiveRecord.publicKey))
 
@@ -137,7 +164,10 @@ describe('publish', () => {
       throw new Error('No results found')
     }
 
-    expect(recursiveResult.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const recursiveResultExtensibleData = decodeExtensibleData(recursiveResult.record.data)
+    expect(recursiveResultExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
+
+    expect(recursiveResult).to.have.property('value').that.equals(`/ipfs/${cid.toV1()}`)
   })
 
   it('should publish recursively using a multihash', async () => {
@@ -146,14 +176,16 @@ describe('publish', () => {
       offline: true
     })
 
-    expect(published.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const extensibleData = decodeExtensibleData(published.record.data)
+    expect(extensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
 
     const keyName2 = 'test-key-9'
     const recursiveRecord = await name.publish(keyName2, published.publicKey.toMultihash(), {
       offline: true
     })
 
-    expect(recursiveRecord.record.value).to.equal(`/ipns/${base36.encode(published.publicKey.toMultihash().bytes)}`)
+    const recursiveExtensibleData = decodeExtensibleData(recursiveRecord.record.data)
+    expect(recursiveExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipns/${base36.encode(published.publicKey.toMultihash().bytes)}`))
 
     const recursiveResult = await last(name.resolve(recursiveRecord.publicKey))
 
@@ -161,7 +193,10 @@ describe('publish', () => {
       throw new Error('No results found')
     }
 
-    expect(recursiveResult.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const recursiveResultExtensibleData = decodeExtensibleData(recursiveResult.record.data)
+    expect(recursiveResultExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
+
+    expect(recursiveResult).to.have.property('value').that.equals(`/ipfs/${cid.toV1()}`)
   })
 
   it('should publish recursively using a string IPNS key', async () => {
@@ -170,14 +205,16 @@ describe('publish', () => {
       offline: true
     })
 
-    expect(published.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const extensibleData = decodeExtensibleData(published.record.data)
+    expect(extensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
 
     const keyName2 = 'test-key-11'
     const recursiveRecord = await name.publish(keyName2, `/ipns/${published.publicKey.toCID().toString(base36)}`, {
       offline: true
     })
 
-    expect(recursiveRecord.record.value).to.equal(`/ipns/${published.publicKey.toCID().toString(base36)}`)
+    const recursiveExtensibleData = decodeExtensibleData(recursiveRecord.record.data)
+    expect(recursiveExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipns/${published.publicKey.toCID().toString(base36)}`))
 
     const recursiveResult = await last(name.resolve(recursiveRecord.publicKey))
 
@@ -185,7 +222,10 @@ describe('publish', () => {
       throw new Error('No results found')
     }
 
-    expect(recursiveResult.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    const recursiveResultExtensibleData = decodeExtensibleData(recursiveResult.record.data)
+    expect(recursiveResultExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}`))
+
+    expect(recursiveResult).to.have.property('value').that.equals(`/ipfs/${cid.toV1()}`)
   })
 
   it('should publish record with a path', async () => {
@@ -197,7 +237,8 @@ describe('publish', () => {
       offline: true
     })
 
-    expect(published.record.value).to.equal(`/ipfs/${cid.toV1()}${path}`)
+    const extensibleData = decodeExtensibleData(published.record.data)
+    expect(extensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}${path}`))
 
     const result = await last(name.resolve(published.publicKey))
 
@@ -205,7 +246,10 @@ describe('publish', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}${path}`)
+    const resultExtensibleData = decodeExtensibleData(result.record.data)
+    expect(resultExtensibleData).to.have.property('Value').that.equalBytes(uint8ArrayFromString(`/ipfs/${cid.toV1()}${path}`))
+
+    expect(result).to.have.property('value').that.equals(`/ipfs/${cid.toV1()}${path}`)
   })
 
   describe('localStore error handling', () => {

--- a/packages/ipns/test/records.spec.ts
+++ b/packages/ipns/test/records.spec.ts
@@ -7,10 +7,11 @@ import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import { InvalidEmbeddedPublicKeyError, RecordExpiredError, SignatureVerificationError } from '../src/errors.ts'
-import { IpnsEntry } from '../src/pb/ipns.ts'
-import { createIPNSRecord, createIPNSRecordWithExpiration } from '../src/records.ts'
-import { parseCborData, createCborData, ipnsRecordDataForV2Sig, marshalIPNSRecord, unmarshalIPNSRecord, multihashToIPNSRoutingKey, multihashFromIPNSRoutingKey, normalizeValue } from '../src/utils.ts'
+import { IPNSEntry } from '../src/pb/ipns.ts'
+import { createIPNSRecord } from '../src/records.ts'
+import { ipnsRecordDataForV2Sig, multihashToIPNSRoutingKey, multihashFromIPNSRoutingKey, normalizeValue, decodeExtensibleData, encodeExtensibleData } from '../src/utils.ts'
 import { ipnsValidator } from '../src/validator.ts'
 import { getCrypto } from './fixtures/get-crypto.ts'
 import { kuboRecord } from './fixtures/records.ts'
@@ -37,10 +38,12 @@ describe('records', function () {
     const ttl = BigInt(5 * 60 * 1e+9)
     const validity = 1000000
 
-    const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
+    const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, {
+      v1Compatible: true
+    })
 
-    expect(record.value).to.equal(contentPath)
-    expect(record.validityType).to.equal(IpnsEntry.ValidityType.EOL)
+    expect(record.value).to.equalBytes(uint8ArrayFromString(contentPath))
+    expect(record.validityType).to.equal(IPNSEntry.ValidityType.EOL)
     expect(record.validity).to.exist()
     expect(record.sequence).to.equal(BigInt(0))
     expect(record.ttl).to.equal(ttl)
@@ -49,9 +52,9 @@ describe('records', function () {
     expect(record.data).to.exist()
 
     // Protobuf must have all fields!
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
     expect(pb.value).to.equalBytes(uint8ArrayFromString(contentPath))
-    expect(pb.validityType).to.equal(IpnsEntry.ValidityType.EOL)
+    expect(pb.validityType).to.equal(IPNSEntry.ValidityType.EOL)
     expect(pb.validity).to.exist()
     expect(pb.sequence).to.equal(BigInt(sequence))
     expect(pb.ttl).to.equal(ttl)
@@ -60,7 +63,7 @@ describe('records', function () {
     expect(pb.data).to.exist()
 
     // Protobuf.Data must have all fields and match!
-    const data = parseCborData(pb.data ?? new Uint8Array(0))
+    const data = decodeExtensibleData(pb.data ?? new Uint8Array(0))
     expect(data.Value).to.equalBytes(pb.value)
     expect(data.ValidityType).to.equal(pb.validityType)
     expect(data.Validity).to.equalBytes(pb.validity)
@@ -74,18 +77,17 @@ describe('records', function () {
     const validity = 1000000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, { v1Compatible: false })
-
-    expect(record.value).to.equal(contentPath)
-    expect(record.validityType).to.equal(IpnsEntry.ValidityType.EOL)
-    expect(record.validity).to.exist()
-    expect(record.sequence).to.equal(BigInt(0))
-    expect(record.ttl).to.equal(ttl)
+    expect(record.value).to.not.exist()
+    expect(record.validityType).to.not.exist()
+    expect(record.validity).to.not.exist()
+    expect(record.sequence).to.not.exist()
+    expect(record.ttl).to.not.exist()
+    expect(record.signatureV1).to.not.exist()
     expect(record.signatureV2).to.exist()
-    expect(record).to.not.have.property('signatureV1')
     expect(record.data).to.exist()
 
     // PB must only have signature and data.
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
     expect(pb.value).to.not.exist()
     expect(pb.validityType).to.not.exist()
     expect(pb.validity).to.not.exist()
@@ -96,75 +98,50 @@ describe('records', function () {
     expect(pb.data).to.exist()
 
     // Protobuf.Data must have all fields and match!
-    const data = parseCborData(pb.data ?? new Uint8Array(0))
+    const data = decodeExtensibleData(pb.data ?? new Uint8Array(0))
     expect(data.Value).to.equalBytes(uint8ArrayFromString(contentPath))
-    expect(data.ValidityType).to.equal(IpnsEntry.ValidityType.EOL)
+    expect(data.ValidityType).to.equal(IPNSEntry.ValidityType.EOL)
     expect(data.Validity).to.exist()
     expect(data.Sequence).to.equal(BigInt(sequence))
     expect(data.TTL).to.equal(ttl)
   })
 
-  it('should be able to create a record (V1+V2) with a fixed expiration', async () => {
-    const sequence = 0
-    const expiration = '2033-05-18T03:33:20.000000000Z'
-
-    const record = await createIPNSRecordWithExpiration(privateKey, contentPath, sequence, expiration)
-    await ipnsValidator(record)
-
-    const marshalledRecord = marshalIPNSRecord(record)
-    const pb = IpnsEntry.decode(marshalledRecord)
-    expect(pb).to.have.property('validity')
-    expect(pb.validity).to.equalBytes(uint8ArrayFromString(expiration))
-  })
-
-  it('should be able to create a record (V2) with a fixed expiration', async () => {
-    const sequence = 0
-    const expiration = '2033-05-18T03:33:20.000000000Z'
-
-    const record = await createIPNSRecordWithExpiration(privateKey, contentPath, sequence, expiration, { v1Compatible: false })
-    await ipnsValidator(record)
-
-    const marshalledRecord = marshalIPNSRecord(record)
-    const pb = IpnsEntry.decode(marshalledRecord)
-    expect(pb).to.not.have.property('validity')
-
-    const data = parseCborData(pb.data ?? new Uint8Array(0))
-    expect(data.Validity).to.equalBytes(uint8ArrayFromString(expiration))
-  })
-
   it('should be able to create a record (V1+V2) with a fixed ttl', async () => {
     const sequence = 0
-    const ttl = BigInt(0.6e+12)
+    const ttlNs = 1_600_000_000_000n
     const validity = 1000000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, {
-      ttlNs: ttl
+      ttlNs
     })
-    await ipnsValidator(record)
 
-    const marshalledRecord = marshalIPNSRecord(record)
-    const pb = IpnsEntry.decode(marshalledRecord)
-    const data = parseCborData(pb.data ?? new Uint8Array(0))
-    expect(data.TTL).to.equal(ttl)
+    const marshalledRecord = IPNSEntry.encode(record)
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    await ipnsValidator(routingKey, marshalledRecord, kc)
+
+    const pb = IPNSEntry.decode(marshalledRecord)
+    const data = decodeExtensibleData(pb.data ?? new Uint8Array(0))
+    expect(data.TTL).to.equal(ttlNs)
   })
 
   it('should be able to create a record (V2) with a fixed ttl', async () => {
     const sequence = 0
-    const ttl = BigInt(1.6e+12)
-    const validity = 1000000
+    const ttlNs = 1_600_000_000_000n
+    const validity = 1_000_000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, {
-      ttlNs: ttl,
+      ttlNs,
       v1Compatible: false
     })
-    await ipnsValidator(record)
+    const marshalledRecord = IPNSEntry.encode(record)
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    await ipnsValidator(routingKey, marshalledRecord, kc)
 
-    const marshalledRecord = marshalIPNSRecord(record)
-    const pb = IpnsEntry.decode(marshalledRecord)
+    const pb = IPNSEntry.decode(marshalledRecord)
     expect(pb).to.not.have.property('ttl')
 
-    const data = parseCborData(pb.data ?? new Uint8Array(0))
-    expect(data.TTL).to.equal(ttl)
+    const data = decodeExtensibleData(pb.data ?? new Uint8Array(0))
+    expect(data.TTL).to.equal(ttlNs)
   })
 
   it('should create an ipns record (V1+V2) and validate it correctly', async () => {
@@ -172,7 +149,10 @@ describe('records', function () {
     const validity = 1000000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
-    await ipnsValidator(record)
+
+    const marshalledRecord = IPNSEntry.encode(record)
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    await ipnsValidator(routingKey, marshalledRecord, kc)
   })
 
   it('should create an ipns record (V2) and validate it correctly', async () => {
@@ -180,14 +160,19 @@ describe('records', function () {
     const validity = 1000000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, { v1Compatible: false })
-    await ipnsValidator(record)
+
+    const marshalledRecord = IPNSEntry.encode(record)
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    await ipnsValidator(routingKey, marshalledRecord, kc)
   })
 
   it('should normalize value when creating an ipns record (arbitrary string path)', async () => {
     const inputValue = normalizeValue('/foo/bar/baz')
     const expectedValue = '/foo/bar/baz'
     const record = await createIPNSRecord(privateKey, inputValue, 0, 1000000)
-    expect(record.value).to.equal(expectedValue)
+
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when creating a recursive ipns record (Ed25519 public key)', async () => {
@@ -195,7 +180,9 @@ describe('records', function () {
     const otherKey = await crypto.generatePrivateKey()
     const expectedValue = normalizeValue(otherKey.publicKey)
     const record = await createIPNSRecord(privateKey, expectedValue, 0, 1000000)
-    expect(record.value).to.equal(expectedValue)
+
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when creating a recursive ipns record (RSA public key)', async () => {
@@ -203,7 +190,9 @@ describe('records', function () {
     const otherKey = await crypto.generatePrivateKey()
     const expectedValue = normalizeValue(otherKey.publicKey)
     const record = await createIPNSRecord(privateKey, expectedValue, 0, 1000000)
-    expect(record.value).to.equal(expectedValue)
+
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when creating a recursive ipns record (public key as CID)', async () => {
@@ -211,7 +200,9 @@ describe('records', function () {
     const otherKey = await crypto.generatePrivateKey()
     const expectedValue = normalizeValue(otherKey.publicKey.toCID())
     const record = await createIPNSRecord(privateKey, expectedValue, 0, 1000000)
-    expect(record.value).to.equal(expectedValue)
+
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when creating an ipns record (v0 cid)', async () => {
@@ -219,14 +210,18 @@ describe('records', function () {
     const inputValue = normalizeValue(cid)
     const expectedValue = `/ipfs/${cid.toV1()}`
     const record = await createIPNSRecord(privateKey, inputValue, 0, 1000000)
-    expect(record.value).to.equal(expectedValue)
+
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when creating an ipns record (v1 cid)', async () => {
     const inputValue = normalizeValue(CID.parse('bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu'))
     const expectedValue = '/ipfs/bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu'
     const record = await createIPNSRecord(privateKey, inputValue, 0, 1000000)
-    expect(record.value).to.equal(expectedValue)
+
+    const extensibleData = decodeExtensibleData(record.data)
+    expect(extensibleData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when reading an ipns record (string v0 cid path)', async () => {
@@ -234,47 +229,64 @@ describe('records', function () {
     const inputValue = normalizeValue(`/ipfs/${cid}`)
     const expectedValue = `/ipfs/${cid.toV1()}`
     const record = await createIPNSRecord(privateKey, inputValue, 0, 1000000)
-    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
 
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
-    pb.data = createCborData(inputValue, pb.validityType ?? IpnsEntry.ValidityType.EOL, pb.validity ?? new Uint8Array(0), pb.sequence ?? 0n, pb.ttl ?? 0n)
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
+    pb.data = encodeExtensibleData({
+      Value: uint8ArrayFromString(inputValue),
+      ValidityType: pb.validityType ?? IPNSEntry.ValidityType.EOL,
+      Validity: pb.validity ?? new Uint8Array(0),
+      Sequence: pb.sequence ?? 0n,
+      TTL: pb.ttl ?? 0n
+    })
     pb.value = uint8ArrayFromString(inputValue)
 
-    const modifiedRecord = await unmarshalIPNSRecord(routingKey, IpnsEntry.encode(pb), kc)
-    expect(modifiedRecord.value).to.equal(expectedValue)
+    const modifiedRecord = IPNSEntry.decode(IPNSEntry.encode(pb))
+    const modifiedRecordData = decodeExtensibleData(modifiedRecord.data)
+    expect(modifiedRecordData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should normalize value when reading an ipns record (string v1 cid path)', async () => {
     const inputValue = normalizeValue('/ipfs/bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu')
     const expectedValue = '/ipfs/bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu'
     const record = await createIPNSRecord(privateKey, inputValue, 0, 1000000)
-    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
 
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
-    pb.data = createCborData(inputValue, pb.validityType ?? IpnsEntry.ValidityType.EOL, pb.validity ?? new Uint8Array(0), pb.sequence ?? 0n, pb.ttl ?? 0n)
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
+    pb.data = encodeExtensibleData({
+      Value: uint8ArrayFromString(inputValue),
+      ValidityType: pb.validityType ?? IPNSEntry.ValidityType.EOL,
+      Validity: pb.validity ?? new Uint8Array(0),
+      Sequence: pb.sequence ?? 0n,
+      TTL: pb.ttl ?? 0n
+    })
     pb.value = uint8ArrayFromString(inputValue)
 
-    const modifiedRecord = await unmarshalIPNSRecord(routingKey, IpnsEntry.encode(pb), kc)
-    expect(modifiedRecord.value).to.equal(expectedValue)
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    const modifiedRecord = IPNSEntry.decode(marshalledRecord)
+    const modifiedRecordData = decodeExtensibleData(modifiedRecord.data)
+    expect(modifiedRecordData.Value).to.equalBytes(uint8ArrayFromString(expectedValue))
   })
 
   it('should fail to validate a v1 (deprecated legacy) message', async () => {
     const sequence = 0
     const validity = 1000000
 
-    const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
+    const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, {
+      v1Compatible: true
+    })
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
 
     // remove the extra fields added for v2 sigs
-    // @ts-expect-error data is not optional
     delete record.data
-    // @ts-expect-error signatureV2 is not optional
     delete record.signatureV2
 
     // confirm a v1 exists
     expect(pb).to.have.property('signatureV1')
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', SignatureVerificationError.name)
   })
 
@@ -282,31 +294,38 @@ describe('records', function () {
     const sequence = 0
     const validity = 1000000
 
-    const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
+    const record = await createIPNSRecord(privateKey, contentPath, sequence, validity, {
+      v1Compatible: true
+    })
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
 
     // remove v2 sig
-    // @ts-expect-error signatureV2 is not optional
     delete record.signatureV2
 
     // confirm a v1 exists
     expect(pb).to.have.property('signatureV1')
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', SignatureVerificationError.name)
   })
 
   it('should fail to validate a bad record', async () => {
     const sequence = 0
-    const validity = 1000000
+    const validity = 1_000_000
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
 
     // corrupt the record by changing the value to random bytes
-    const data = cbor.decode(record.data)
-    data.value = crypto.getRandomValues(new Uint8Array(46))
-    record.data = cbor.encode(data)
+    const data = decodeExtensibleData(record.data)
+    data.Value = crypto.getRandomValues(new Uint8Array(46))
+    record.data = withArrayBuffer(cbor.encode(data))
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', SignatureVerificationError.name)
   })
 
@@ -318,7 +337,10 @@ describe('records', function () {
 
     await new Promise(resolve => setTimeout(resolve, 1))
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', RecordExpiredError.name)
   })
 
@@ -329,19 +351,28 @@ describe('records', function () {
     const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
     const createdRecord = await createIPNSRecord(privateKey, contentPath, sequence, validity)
 
-    const marshaledData = marshalIPNSRecord(createdRecord)
-    const unmarshaledData = await unmarshalIPNSRecord(routingKey, marshaledData, kc)
+    const marshaledData = IPNSEntry.encode(createdRecord)
+    const extensibleData = decodeExtensibleData(createdRecord.data)
 
-    expect(createdRecord.value).to.equal(unmarshaledData.value)
-    expect(createdRecord.validity.toString()).to.equal(unmarshaledData.validity.toString())
-    expect(createdRecord.validityType).to.equal(unmarshaledData.validityType)
-    expect(createdRecord.signatureV1).to.equalBytes('signatureV1' in unmarshaledData ? unmarshaledData.signatureV1 : new Uint8Array(0))
-    expect(createdRecord.sequence).to.equal(unmarshaledData.sequence)
-    expect(createdRecord.ttl).to.equal(unmarshaledData.ttl)
-    expect(createdRecord.signatureV2).to.equalBytes(unmarshaledData.signatureV2)
-    expect(createdRecord.data).to.equalBytes(unmarshaledData.data)
+    const validatedRecord = await ipnsValidator(routingKey, marshaledData, kc)
+    const validatedExtensibleData = decodeExtensibleData(validatedRecord.data)
 
-    await ipnsValidator(createdRecord)
+    expect(validatedExtensibleData.Value).to.deep.equal(extensibleData.Value, 'Value did not match')
+    expect(validatedExtensibleData.Validity).to.deep.equal(extensibleData.Validity, 'Validity did not match')
+    expect(validatedExtensibleData.ValidityType).to.equal(extensibleData.ValidityType, 'ValidityType did not match')
+    expect(validatedExtensibleData.Sequence).to.equal(extensibleData.Sequence, 'Sequence did not match')
+    expect(validatedExtensibleData.TTL).to.equal(extensibleData.TTL, 'TTL did not match')
+
+    expect(createdRecord.signatureV1).to.be.ok('createdRecord did not have v1-style signatureV1')
+    expect(createdRecord.sequence).to.equal(BigInt(sequence), 'createdRecord did not have v1-style sequence')
+    expect(createdRecord.ttl).to.be.ok('createdRecord did not have v1-style TTL')
+
+    expect(validatedRecord.signatureV2).to.equalBytes(createdRecord.signatureV2, 'validatedRecord signatureV2 did not match')
+    expect(validatedRecord.data).to.equalBytes(createdRecord.data, 'validatedRecord data did not match')
+
+    expect(validatedRecord.signatureV1).to.be.ok('validatedRecord did not have v1-style signatureV1')
+    expect(validatedRecord.sequence).to.equal(BigInt(sequence), 'validatedRecord did not have v1-style sequence')
+    expect(validatedRecord.ttl).to.be.ok('validatedRecord did not have v1-style TTL')
   })
 
   it('should be able to turn routing key back into id', () => {
@@ -364,9 +395,9 @@ describe('records', function () {
     const validity = 1000000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
-    expect(record.publicKey).to.deep.equal(privateKey.publicKey)
+    expect(record.publicKey).to.deep.equal(privateKey.publicKey.toProtobuf())
 
-    const pb = IpnsEntry.decode(marshalIPNSRecord(record))
+    const pb = IPNSEntry.decode(IPNSEntry.encode(record))
     expect(pb.publicKey).to.equalBytes(privateKey.publicKey.toProtobuf())
   })
 
@@ -392,10 +423,12 @@ describe('records', function () {
     const validity = 1000000
 
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
-    // @ts-expect-error publicKey is not optional
     delete record.publicKey
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', InvalidEmbeddedPublicKeyError.name)
   })
 
@@ -404,7 +437,7 @@ describe('records', function () {
     const validity = 1000000
     const record = await createIPNSRecord(privateKey, contentPath, sequence, validity)
 
-    expect(record.publicKey).to.deep.equal(privateKey.publicKey)
+    expect(record.publicKey).to.equalBytes(privateKey.publicKey.toProtobuf())
   })
 
   it('should unmarshal a record with raw CID bytes', async () => {
@@ -422,34 +455,31 @@ describe('records', function () {
     const cid = CID.parse('bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu')
 
     // override data with raw CID bytes
-    const data = cbor.decode(input.data)
+    const data = decodeExtensibleData(input.data)
     data.Value = cid.bytes
-    input.data = cbor.encode(data)
+    input.data = withArrayBuffer(cbor.encode(data))
 
     // re-sign record
     const sigData = ipnsRecordDataForV2Sig(input.data)
     input.signatureV2 = await privateKey.sign(sigData)
 
-    const buf = marshalIPNSRecord(input)
-    const record = await unmarshalIPNSRecord(routingKey, buf, kc)
+    const marshalledRecord = IPNSEntry.encode(input)
+    const validatedRecord = await ipnsValidator(routingKey, marshalledRecord, kc)
+    const validatedExtensibleData = decodeExtensibleData(validatedRecord.data)
 
-    expect(record).to.have.property('value').that.equals('/ipfs/bafkqae3imvwgy3zamzzg63janjzs22lqnzzqu')
+    expect(validatedExtensibleData).to.have.property('Value').that.equalBytes(cid.bytes)
   })
 
   it('should round trip kubo records to bytes and back', async () => {
-    const crypto = ed25519Crypto()
-    const privateKey = await crypto.generatePrivateKey()
-    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
-
     // the IPNS spec gives an example for the Validity field as
     // 1970-01-01T00:00:00.000000001Z - e.g. nanosecond precision but Kubo only
     // uses microsecond precision. The value is a timestamp as defined by
     // rfc3339 which doesn't have a strong opinion on fractions of seconds so
     // both are valid but we must be able to round trip them intact.
-    const unmarshaled = await unmarshalIPNSRecord(routingKey, kuboRecord.bytes, kc)
-    const reMarshaled = marshalIPNSRecord(unmarshaled)
+    const unmarshaled = IPNSEntry.decode(kuboRecord.bytes)
+    const reMarshaled = IPNSEntry.encode(unmarshaled)
 
-    const reUnmarshaled = await unmarshalIPNSRecord(routingKey, reMarshaled, kc)
+    const reUnmarshaled = IPNSEntry.decode(reMarshaled)
 
     expect(unmarshaled).to.deep.equal(reUnmarshaled)
     expect(reMarshaled).to.equalBytes(kuboRecord.bytes)

--- a/packages/ipns/test/republish.spec.ts
+++ b/packages/ipns/test/republish.spec.ts
@@ -2,8 +2,11 @@ import { start, stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { CID } from 'multiformats/cid'
 import sinon from 'sinon'
+import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { localStore } from '../src/local-store.ts'
-import { createIPNSRecord, marshalIPNSRecord, unmarshalIPNSRecord, multihashToIPNSRoutingKey } from '../src/records.ts'
+import { IPNSEntry } from '../src/pb/ipns.ts'
+import { createIPNSRecord } from '../src/records.ts'
+import { decodeExtensibleData, multihashToIPNSRoutingKey } from '../src/utils.ts'
 import { createIPNS } from './fixtures/create-ipns.ts'
 import type { IPNS } from '../src/ipns.ts'
 import type { CreateIPNSResult } from './fixtures/create-ipns.ts'
@@ -63,7 +66,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore using the localStore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: SHORTENED_VALIDITY
@@ -86,7 +89,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore using the localStore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: SHORTENED_VALIDITY
@@ -115,7 +118,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: SHORTENED_VALIDITY
@@ -131,8 +134,9 @@ describe('republish', () => {
       const callArgs = putStubCustom.firstCall.args
       expect(callArgs[0]).to.deep.equal(routingKey)
 
-      const republishedRecord = await unmarshalIPNSRecord(routingKey, callArgs[1], result.keychain)
-      expect(republishedRecord.sequence).to.equal(2n) // Incremented from 1n
+      const republishedRecord = IPNSEntry.decode(callArgs[1])
+      const republishedRecordData = decodeExtensibleData(republishedRecord.data)
+      expect(republishedRecordData.Sequence).to.equal(2n) // Incremented from 1n
     })
   })
 
@@ -144,7 +148,7 @@ describe('republish', () => {
 
       // Store the record without metadata (simulate old records)
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record)) // No metadata
+      await store.put(routingKey, IPNSEntry.encode(record)) // No metadata
 
       await start(name)
       await new Promise(resolve => setTimeout(resolve, 20))
@@ -179,7 +183,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: SHORTENED_VALIDITY
@@ -192,8 +196,9 @@ describe('republish', () => {
       expect(putStubCustom.called).to.be.true()
 
       const callArgs = putStubCustom.firstCall.args
-      const republishedRecord = await unmarshalIPNSRecord(routingKey, callArgs[1], result.keychain)
-      expect(republishedRecord.sequence).to.equal(6n) // Incremented from 5n
+      const republishedRecord = IPNSEntry.decode(callArgs[1])
+      const republishedRecordData = decodeExtensibleData(republishedRecord.data)
+      expect(republishedRecordData.Sequence).to.equal(6n) // Incremented from 5n
     })
   })
 
@@ -206,7 +211,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: SHORTENED_VALIDITY
@@ -221,9 +226,10 @@ describe('republish', () => {
       const callArgs = putStubCustom.firstCall.args
       expect(callArgs[0]).to.deep.equal(routingKey)
 
-      const republishedRecord = await unmarshalIPNSRecord(routingKey, callArgs[1], result.keychain)
-      expect(republishedRecord.sequence).to.equal(2n) // Incremented from 1n
-      expect(republishedRecord.ttl).to.equal(customTtl)
+      const republishedRecord = IPNSEntry.decode(callArgs[1])
+      const republishedRecordData = decodeExtensibleData(republishedRecord.data)
+      expect(republishedRecordData.Sequence).to.equal(2n) // Incremented from 1n
+      expect(republishedRecordData.TTL).to.equal(customTtl, 'incorrect TTL was used')
     })
 
     it('should use default TTL when not present', async () => {
@@ -233,7 +239,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: SHORTENED_VALIDITY
@@ -245,8 +251,9 @@ describe('republish', () => {
 
       expect(putStubCustom.called).to.be.true()
       const callArgs = putStubCustom.firstCall.args
-      const republishedRecord = await unmarshalIPNSRecord(routingKey, callArgs[1], result.keychain)
-      expect(republishedRecord.ttl).to.equal(5n * 60n * 1000n * 1_000_000n) // Default TTL
+      const republishedRecord = IPNSEntry.decode(callArgs[1])
+      const republishedRecordData = decodeExtensibleData(republishedRecord.data)
+      expect(republishedRecordData.TTL).to.equal(5n * 60n * 1000n * 1_000_000n) // Default TTL
     })
 
     it('should use metadata lifetime', async () => {
@@ -257,7 +264,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'test-key',
           lifetime: customLifetime
@@ -272,10 +279,11 @@ describe('republish', () => {
       expect(putStubCustom.called).to.be.true()
 
       const callArgs = putStubCustom.firstCall.args
-      const republishedRecord = await unmarshalIPNSRecord(routingKey, callArgs[1], result.keychain)
+      const republishedRecord = IPNSEntry.decode(callArgs[1])
+      const republishedRecordData = decodeExtensibleData(republishedRecord.data)
 
       // Check that the validity is set to the custom lifetime
-      const actualValidity = new Date(republishedRecord.validity)
+      const actualValidity = new Date(uint8ArrayToString(republishedRecordData.Validity))
 
       const timeDiff = Math.abs(actualValidity.getTime() - expectedValidity)
       expect(timeDiff).to.be.lessThan(200)
@@ -290,7 +298,7 @@ describe('republish', () => {
 
       // Store the record in the real datastore (but don't import the key)
       const store = localStore(result.datastore, result.log)
-      await store.put(routingKey, marshalIPNSRecord(record), {
+      await store.put(routingKey, IPNSEntry.encode(record), {
         metadata: {
           keyName: 'missing-key',
           lifetime: SHORTENED_VALIDITY
@@ -397,7 +405,7 @@ describe('republish', () => {
           lifetime: SHORTENED_VALIDITY
         }
       })
-      await store.put(routingKey2, marshalIPNSRecord(record2), {
+      await store.put(routingKey2, IPNSEntry.encode(record2), {
         metadata: {
           keyName: 'test-key-2',
           lifetime: SHORTENED_VALIDITY

--- a/packages/ipns/test/resolve.spec.ts
+++ b/packages/ipns/test/resolve.spec.ts
@@ -7,7 +7,9 @@ import last from 'it-last'
 import { CID } from 'multiformats/cid'
 import Sinon from 'sinon'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import { createIPNSRecord, createIPNSRecordWithExpiration, marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from '../src/records.ts'
+import { IPNSEntry } from '../src/pb/ipns.ts'
+import { createIPNSRecord } from '../src/records.ts'
+import { decodeExtensibleData, encodeExtensibleData, ipnsRecordDataForV2Sig, multihashToIPNSRoutingKey } from '../src/utils.ts'
 import { createIPNS } from './fixtures/create-ipns.ts'
 import type { IPNS } from '../src/index.ts'
 import type { Routing } from '@helia/interface'
@@ -46,7 +48,7 @@ describe('resolve', () => {
     // empty the datastore to ensure we resolve using the routing
     await drain(datastore.deleteMany(datastore.queryKeys({})))
 
-    heliaRouting.get.resolves(marshalIPNSRecord(record))
+    heliaRouting.get.resolves(IPNSEntry.encode(record))
 
     const result = await last(name.resolve(publicKey))
 
@@ -54,7 +56,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     expect(heliaRouting.get.called).to.be.true()
     expect(customRouting.get.called).to.be.true()
@@ -67,7 +69,7 @@ describe('resolve', () => {
     // empty the datastore to ensure we resolve using the routing
     await drain(datastore.deleteMany(datastore.queryKeys({})))
 
-    heliaRouting.get.resolves(marshalIPNSRecord(record))
+    heliaRouting.get.resolves(IPNSEntry.encode(record))
 
     const result = await last(name.resolve(publicKey.toCID()))
 
@@ -75,7 +77,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     expect(heliaRouting.get.called).to.be.true()
     expect(customRouting.get.called).to.be.true()
@@ -96,7 +98,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     expect(heliaRouting.get.called).to.be.false()
     expect(customRouting.get.called).to.be.false()
@@ -109,7 +111,7 @@ describe('resolve', () => {
     const keyName = 'test-key'
     const { record, publicKey } = await name.publish(keyName, cid)
 
-    heliaRouting.get.resolves(marshalIPNSRecord(record))
+    heliaRouting.get.resolves(IPNSEntry.encode(record))
 
     const result = await last(name.resolve(publicKey, {
       nocache: true
@@ -119,7 +121,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     expect(heliaRouting.get.called).to.be.true()
     expect(customRouting.get.called).to.be.true()
@@ -140,7 +142,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     expect(heliaRouting.get.called).to.be.false()
     expect(customRouting.get.called).to.be.false()
@@ -160,7 +162,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
   })
 
   it('should resolve a recursive record with path', async () => {
@@ -176,7 +178,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
   })
 
   it('should emit progress events', async function () {
@@ -199,7 +201,7 @@ describe('resolve', () => {
     expect(datastore.has(dhtKey)).to.be.false('already had record')
 
     const record = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 0n, 60000)
-    const marshalledRecord = marshalIPNSRecord(record)
+    const marshalledRecord = IPNSEntry.encode(record)
 
     customRouting.get.withArgs(customRoutingKey).resolves(marshalledRecord)
 
@@ -209,7 +211,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     expect(datastore.has(dhtKey)).to.be.true('did not cache record locally')
   })
@@ -219,8 +221,8 @@ describe('resolve', () => {
     const customRoutingKey = multihashToIPNSRoutingKey(key.publicKey.toMultihash())
     const dhtKey = new Key('/dht/record/' + uint8ArrayToString(customRoutingKey, 'base32'), false)
 
-    const marshalledRecordA = marshalIPNSRecord(await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 0n, 60000))
-    const marshalledRecordB = marshalIPNSRecord(await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 10n, 60000))
+    const marshalledRecordA = IPNSEntry.encode(await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 0n, 60000))
+    const marshalledRecordB = IPNSEntry.encode(await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 10n, 60000))
 
     // records should not match
     expect(marshalledRecordA).to.not.equalBytes(marshalledRecordB)
@@ -235,7 +237,7 @@ describe('resolve', () => {
       throw new Error('No results found')
     }
 
-    expect(result.record.value).to.equal(`/ipfs/${cid.toV1()}`)
+    expect(result.value).to.equal(`/ipfs/${cid.toV1()}`)
 
     const cached = await datastore.get(dhtKey)
     const record = Record.deserialize(cached)
@@ -255,7 +257,7 @@ describe('resolve', () => {
     }
 
     expect(result).to.have.property('record')
-    expect(marshalIPNSRecord(result.record)).to.deep.equal(marshalIPNSRecord(record))
+    expect(IPNSEntry.encode(result.record)).to.equalBytes(IPNSEntry.encode(record))
   })
 
   it('should not search the routing for updated IPNS records when a locally cached copy is within the TTL', async () => {
@@ -265,37 +267,39 @@ describe('resolve', () => {
 
     // create a record with a valid lifetime and a non-expired TTL
     const ipnsRecord = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 1, Math.pow(2, 10), {
-      ttlNs: 10_000_000_000
+      ttlNs: 10_000_000_000n
     })
-    const dhtRecord = new Record(customRoutingKey, marshalIPNSRecord(ipnsRecord), new Date(Date.now()))
+    const dhtRecord = new Record(customRoutingKey, IPNSEntry.encode(ipnsRecord), new Date(Date.now()))
 
     await datastore.put(dhtKey, dhtRecord.serialize())
 
     const result = await last(name.resolve(key.publicKey))
-    expect(result).to.have.deep.property('record', await unmarshalIPNSRecord(customRoutingKey, marshalIPNSRecord(ipnsRecord), keychain))
+    expect(result).to.have.deep.property('record', ipnsRecord)
+    expect(result).to.have.property('value', `/ipfs/${cid.toV1()}`)
 
     // should not have searched the routing
-    expect(customRouting.get.called).to.be.false()
+    expect(customRouting.get.called).to.be.false('searched the routing for an updated record')
   })
 
   it('should search the routing for updated IPNS records when a locally cached copy has passed the TTL', async () => {
     const key = await keychain.generateKey('test-key')
-    const customRoutingKey = multihashToIPNSRoutingKey(key.publicKey.toMultihash())
-    const dhtKey = new Key('/dht/record/' + uint8ArrayToString(customRoutingKey, 'base32'), false)
+    const routingKey = multihashToIPNSRoutingKey(key.publicKey.toMultihash())
+    const dhtKey = new Key('/dht/record/' + uint8ArrayToString(routingKey, 'base32'), false)
 
     // create a record with a valid lifetime but an expired ttl
     const ipnsRecord = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 1, Math.pow(2, 10), {
-      ttlNs: 10
+      ttlNs: 10n
     })
-    const dhtRecord = new Record(customRoutingKey, marshalIPNSRecord(ipnsRecord), new Date(Date.now() - 1000))
+    const dhtRecord = new Record(routingKey, IPNSEntry.encode(ipnsRecord), new Date(Date.now() - 1000))
 
     await datastore.put(dhtKey, dhtRecord.serialize())
 
     const result = await last(name.resolve(key.publicKey))
-    expect(result).to.have.deep.property('record', await unmarshalIPNSRecord(customRoutingKey, marshalIPNSRecord(ipnsRecord), keychain))
+    expect(result).to.have.deep.property('record', ipnsRecord)
+    expect(result).to.have.property('value', `/ipfs/${cid.toV1()}`)
 
     // should have searched the routing
-    expect(customRouting.get.called).to.be.true()
+    expect(customRouting.get.called).to.be.true('did not search the routing for an updated record')
   })
 
   it('should search the routing for updated IPNS records when a locally cached copy has passed the TTL and choose the record with a higher sequence number', async () => {
@@ -305,20 +309,20 @@ describe('resolve', () => {
 
     // create a record with a valid lifetime but an expired ttl
     const ipnsRecord = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 10, Math.pow(2, 10), {
-      ttlNs: 10
+      ttlNs: 10n
     })
-    const dhtRecord = new Record(customRoutingKey, marshalIPNSRecord(ipnsRecord), new Date(Date.now() - 1000))
+    const dhtRecord = new Record(customRoutingKey, IPNSEntry.encode(ipnsRecord), new Date(Date.now() - 1000))
 
     await datastore.put(dhtKey, dhtRecord.serialize())
 
     // the routing returns a valid record with an higher sequence number
     const ipnsRecordFromRouting = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 11, Math.pow(2, 10), {
-      ttlNs: 10_000_000
+      ttlNs: 10_000_000n
     })
-    customRouting.get.withArgs(customRoutingKey).resolves(marshalIPNSRecord(ipnsRecordFromRouting))
+    customRouting.get.withArgs(customRoutingKey).resolves(IPNSEntry.encode(ipnsRecordFromRouting))
 
     const result = await last(name.resolve(key.publicKey))
-    expect(result).to.have.deep.property('record', await unmarshalIPNSRecord(customRoutingKey, marshalIPNSRecord(ipnsRecordFromRouting), keychain))
+    expect(result).to.have.deep.property('record', ipnsRecordFromRouting)
 
     // should have searched the routing
     expect(customRouting.get.called).to.be.true()
@@ -330,23 +334,46 @@ describe('resolve', () => {
     const dhtKey = new Key('/dht/record/' + uint8ArrayToString(customRoutingKey, 'base32'), false)
 
     // create a record with an expired lifetime but valid TTL
-    const ipnsRecord = await createIPNSRecordWithExpiration(key, `/ipfs/${cid.toV1()}`, 10, new Date(Date.now() - Math.pow(2, 10)).toString(), {
-      ttlNs: 10_000_000
+    const ipnsRecord = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 10, -Math.pow(2, 10), {
+      ttlNs: 10_000_000n
     })
-    const dhtRecord = new Record(customRoutingKey, marshalIPNSRecord(ipnsRecord), new Date(Date.now()))
+    const dhtRecord = new Record(customRoutingKey, IPNSEntry.encode(ipnsRecord), new Date(Date.now()))
 
     await datastore.put(dhtKey, dhtRecord.serialize())
 
     // the routing returns a valid record with an higher sequence number
     const ipnsRecordFromRouting = await createIPNSRecord(key, `/ipfs/${cid.toV1()}`, 11, Math.pow(2, 10), {
-      ttlNs: 10_000_000
+      ttlNs: 10_000_000n
     })
-    customRouting.get.withArgs(customRoutingKey).resolves(marshalIPNSRecord(ipnsRecordFromRouting))
+    customRouting.get.withArgs(customRoutingKey).resolves(IPNSEntry.encode(ipnsRecordFromRouting))
 
     const result = await last(name.resolve(key.publicKey))
-    expect(result).to.have.deep.property('record', await unmarshalIPNSRecord(customRoutingKey, marshalIPNSRecord(ipnsRecordFromRouting), keychain))
+    expect(result).to.have.deep.property('record', ipnsRecordFromRouting)
 
     // should have searched the routing
     expect(customRouting.get.called).to.be.true()
+  })
+
+  it('should resolve a legacy record with CID bytes as the value', async () => {
+    const privateKey = await keychain.generateKey('test-key')
+    const routingKey = multihashToIPNSRoutingKey(privateKey.publicKey.toMultihash())
+    const dhtKey = new Key('/dht/record/' + uint8ArrayToString(routingKey, 'base32'), false)
+
+    const record = await createIPNSRecord(privateKey, 'will-be-overwritten', 10, 30_000)
+    const data = decodeExtensibleData(record.data)
+    data.Value = cid.bytes
+    record.value = cid.bytes
+
+    // re-sign record
+    record.data = encodeExtensibleData(data)
+    const sigData = ipnsRecordDataForV2Sig(record.data)
+    record.signatureV2 = await privateKey.sign(sigData)
+
+    const dhtRecord = new Record(routingKey, IPNSEntry.encode(record), new Date(Date.now()))
+    await datastore.put(dhtKey, dhtRecord.serialize())
+
+    const result = await last(name.resolve(privateKey.publicKey))
+    expect(result).to.have.deep.property('record', record)
+    expect(result).to.have.property('value', `/ipfs/${cid}`)
   })
 })

--- a/packages/ipns/test/routing/pubsub.spec.ts
+++ b/packages/ipns/test/routing/pubsub.spec.ts
@@ -7,14 +7,17 @@ import delay from 'delay'
 import Sinon from 'sinon'
 import { stubInterface } from 'sinon-ts'
 import { toString } from 'uint8arrays'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { DEFAULT_LIFETIME_MS } from '../../src/constants.ts'
 import { localStore } from '../../src/local-store.ts'
-import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from '../../src/records.ts'
-import { PubSubRouting } from '../../src/routing/pubsub.ts'
+import { IPNSEntry } from '../../src/pb/ipns.ts'
+import { createIPNSRecord } from '../../src/records.ts'
+import { PubSubIPNSRouting } from '../../src/routing/pubsub.ts'
+import { decodeExtensibleData, multihashToIPNSRoutingKey } from '../../src/utils.ts'
+import { ipnsValidator } from '../../src/validator.ts'
 import { getCrypto } from '../fixtures/get-crypto.ts'
-import type { IPNSRecord } from '../../src/index.ts'
 import type { LocalStore } from '../../src/local-store.ts'
-import type { Message, PubSub, PubSubEvents, Subscription } from '../../src/routing/pubsub.ts'
+import type { PubSubMessage, PubSub, PubSubEvents, PubSubSubscription } from '../../src/routing/pubsub.ts'
 import type { Keychain, PrivateKey } from '@helia/interface'
 import type { Fetch } from '@libp2p/fetch'
 import type { Libp2p, PeerId } from '@libp2p/interface'
@@ -27,11 +30,11 @@ describe('pubsub routing', () => {
   let peerId: StubbedInstance<PeerId>
   let pubsub: StubbedInstance<PubSub>
   let fetch: StubbedInstance<Fetch>
-  let pubsubRouter: PubSubRouting
+  let pubsubRouter: PubSubIPNSRouting
   let routingKey: Uint8Array
   let topic: string
   let privateKey: PrivateKey
-  let record: IPNSRecord
+  let record: IPNSEntry
   let target: TypedEventEmitter<PubSubEvents>
   let libp2p: StubbedInstance<Libp2p<{ pubsub: StubbedInstance<PubSub>, fetch: StubbedInstance<Fetch> }>>
   let kc: Keychain
@@ -62,7 +65,7 @@ describe('pubsub routing', () => {
       getCrypto
     })
 
-    pubsubRouter = new PubSubRouting({
+    pubsubRouter = new PubSubIPNSRouting({
       datastore,
       logger,
       libp2p,
@@ -82,7 +85,7 @@ describe('pubsub routing', () => {
   })
 
   describe('message', () => {
-    let message: StubbedInstance<Message>
+    let message: StubbedInstance<PubSubMessage>
     let event: PubSubEvents['message']
 
     beforeEach(() => {
@@ -90,7 +93,7 @@ describe('pubsub routing', () => {
       message.topic = topic
       message.type = 'signed'
       message.from.equals = () => false
-      message.data = marshalIPNSRecord(record)
+      message.data = IPNSEntry.encode(record)
 
       event = new CustomEvent('message', { detail: message })
     })
@@ -107,7 +110,7 @@ describe('pubsub routing', () => {
         recipients: []
       })
 
-      const marshaledRecord = marshalIPNSRecord(record)
+      const marshaledRecord = IPNSEntry.encode(record)
       fetch.fetch.withArgs(peerId).resolves(marshaledRecord)
 
       const result = await pubsubRouter.get(routingKey)
@@ -137,15 +140,16 @@ describe('pubsub routing', () => {
 
         const newRecord = await createIPNSRecord(privateKey, '/test2', 2n, DEFAULT_LIFETIME_MS)
 
-        message.data = marshalIPNSRecord(newRecord)
+        message.data = IPNSEntry.encode(newRecord)
         target.safeDispatchEvent('message', event)
 
         await delay(100)
 
         const result = await store.get(routingKey)
-        const updatedRecord = await unmarshalIPNSRecord(routingKey, result.record, kc)
-        expect(updatedRecord.sequence).to.equal(2n)
-        expect(updatedRecord.value).to.equal('/test2')
+        const updatedRecord = await ipnsValidator(routingKey, result.record, kc)
+        const data = decodeExtensibleData(updatedRecord.data)
+        expect(data.Sequence).to.equal(2n)
+        expect(data.Value).to.equalBytes(uint8ArrayFromString('/test2'))
       })
 
       it('skips the message if duplicate record', async () => {
@@ -153,7 +157,7 @@ describe('pubsub routing', () => {
 
         await expect(pubsubRouter.get(routingKey)).to.eventually.be.rejected
           .with.property('name', 'NotFoundError')
-        await store.put(routingKey, marshalIPNSRecord(record))
+        await store.put(routingKey, IPNSEntry.encode(record))
 
         const batchSpy = Sinon.spy(datastore.batch)
 
@@ -210,7 +214,7 @@ describe('pubsub routing', () => {
 
   describe('subscription-change', () => {
     let peerId: StubbedInstance<PeerId>
-    let subscription: StubbedInstance<Subscription>
+    let subscription: StubbedInstance<PubSubSubscription>
     let event: PubSubEvents['subscription-change']
 
     beforeEach(async () => {
@@ -229,7 +233,7 @@ describe('pubsub routing', () => {
         }
       })
 
-      fetch.fetch.callsFake(async () => marshalIPNSRecord(record))
+      fetch.fetch.callsFake(async () => IPNSEntry.encode(record))
 
       // the peer supports fetch
       libp2p.register.getCall(0).args[1]?.onConnect?.(peerId, stubInterface())

--- a/packages/ipns/test/selector.spec.ts
+++ b/packages/ipns/test/selector.spec.ts
@@ -1,7 +1,8 @@
 import { rsaCrypto } from '@ipshipyard/crypto'
 import { expect } from 'aegir/chai'
-import { createIPNSRecord, multihashToIPNSRoutingKey } from '../src/records.ts'
+import { createIPNSRecord } from '../src/records.ts'
 import { ipnsSelector } from '../src/selector.ts'
+import { multihashToIPNSRoutingKey } from '../src/utils.ts'
 import type { PrivateKey } from '@helia/interface'
 
 describe('selector', function () {

--- a/packages/ipns/test/utils.spec.ts
+++ b/packages/ipns/test/utils.spec.ts
@@ -2,88 +2,72 @@ import { expect } from 'aegir/chai'
 import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
-import { stubInterface } from 'sinon-ts'
 import { InvalidValueError } from '../src/errors.ts'
 import { shouldRepublish } from '../src/utils.ts'
 import { normalizeValue, multihashFromIPNSRoutingKey, multihashToIPNSRoutingKey } from '../src/utils.ts'
-import type { IPNSRecord } from '../src/index.ts'
 import type { MultihashDigest } from 'multiformats/cid'
 
 describe('shouldRepublish', () => {
   it('should return true when DHT expiry is within threshold', () => {
     const now = Date.now()
     const created = new Date(now - 48 * 60 * 60 * 1000 + 12 * 60 * 60 * 1000) // 36 hours ago (within 24h threshold)
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now + 24 * 60 * 60 * 1000).toISOString() // Valid for 24 more hours
-    })
+    const expiry = new Date(now + 24 * 60 * 60 * 1000) // Valid for 24 more hours
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
   it('should return true when record expiry is within threshold', () => {
     const now = Date.now()
     const created = new Date(now - 12 * 60 * 60 * 1000) // 12 hours ago (DHT not expired)
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now + 12 * 60 * 60 * 1000).toISOString() // Valid for only 12 more hours (within 24h threshold)
-    })
+    const expiry = new Date(now + 12 * 60 * 60 * 1000) // Valid for only 12 more hours (within 24h threshold)
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
   it('should return false when both DHT and record expiry are beyond threshold', () => {
     const now = Date.now()
     const created = new Date(now - 12 * 60 * 60 * 1000) // 12 hours ago
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now + 36 * 60 * 60 * 1000).toISOString() // Valid for 36 more hours
-    })
+    const expiry = new Date(now + 36 * 60 * 60 * 1000) // Valid for 36 more hours
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.false()
   })
 
   it('should return true when both expiries are within threshold', () => {
     const now = Date.now()
     const created = new Date(now - 36 * 60 * 60 * 1000) // 36 hours ago (DHT within threshold)
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now + 12 * 60 * 60 * 1000).toISOString() // Valid for 12 more hours (record within threshold)
-    })
+    const expiry = new Date(now + 12 * 60 * 60 * 1000) // Valid for 12 more hours (record within threshold)
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
   it('should handle edge case with very old DHT record', () => {
     const now = Date.now()
     const created = new Date(now - 72 * 60 * 60 * 1000) // 72 hours ago (well past DHT expiry)
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now + 48 * 60 * 60 * 1000).toISOString() // Valid for 48 more hours
-    })
+    const expiry = new Date(now + 48 * 60 * 60 * 1000) // Valid for 48 more hours
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
   it('should handle edge case with expired record', () => {
     const now = Date.now()
     const created = new Date(now - 12 * 60 * 60 * 1000) // 12 hours ago
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now - 1 * 60 * 60 * 1000).toISOString() // Expired 1 hour ago
-    })
+    const expiry = new Date(now - 1 * 60 * 60 * 1000) // Expired 1 hour ago
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
   it('should work with string date format from IPNS record', () => {
     const now = Date.now()
     const created = new Date(now - 12 * 60 * 60 * 1000) // 12 hours ago
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now + 12 * 60 * 60 * 1000).toISOString() // 12 hours from now (within threshold)
-    })
+    const expiry = new Date(now + 12 * 60 * 60 * 1000) // 12 hours from now (within threshold)
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
@@ -92,38 +76,32 @@ describe('shouldRepublish', () => {
 
     // Test just under threshold (should not republish)
     const createdJustUnder = new Date(now - 23 * 60 * 60 * 1000) // 23 hours ago
-    const recordJustUnder = stubInterface<IPNSRecord>({
-      validity: new Date(now + 25 * 60 * 60 * 1000).toISOString() // Valid for 25 more hours
-    })
-    expect(shouldRepublish(recordJustUnder, createdJustUnder)).to.be.false()
+    const expiryJustUnder = new Date(now + 25 * 60 * 60 * 1000) // Valid for 25 more hours
+
+    expect(shouldRepublish(createdJustUnder, expiryJustUnder)).to.be.false()
 
     // Test just over threshold (should republish)
     const createdJustOver = new Date(now - 25 * 60 * 60 * 1000) // 25 hours ago
-    const recordJustOver = stubInterface<IPNSRecord>({
-      validity: new Date(now + 25 * 60 * 60 * 1000).toISOString() // Valid for 25 more hours
-    })
-    expect(shouldRepublish(recordJustOver, createdJustOver)).to.be.true()
+    const expiryJustOver = new Date(now + 25 * 60 * 60 * 1000) // Valid for 25 more hours
+
+    expect(shouldRepublish(createdJustOver, expiryJustOver)).to.be.true()
   })
 
   it('should return true for already expired records', () => {
     const now = Date.now()
     const created = new Date(now - 6 * 60 * 60 * 1000) // 6 hours ago (DHT still valid)
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now - 3 * 60 * 60 * 1000).toISOString() // Expired 3 hours ago (recordExpiry - now is negative)
-    })
+    const expiry = new Date(now - 3 * 60 * 60 * 1000) // Expired 3 hours ago (recordExpiry - now is negative)
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 
   it('should return true for records that expired long ago', () => {
     const now = Date.now()
     const created = new Date(now - 12 * 60 * 60 * 1000) // 12 hours ago (DHT still valid)
-    const record = stubInterface<IPNSRecord>({
-      validity: new Date(now - 48 * 60 * 60 * 1000).toISOString() // Expired 48 hours ago (very negative value)
-    })
+    const expiry = new Date(now - 48 * 60 * 60 * 1000) // Expired 48 hours ago (very negative value)
 
-    const result = shouldRepublish(record, created)
+    const result = shouldRepublish(created, expiry)
     expect(result).to.be.true()
   })
 })

--- a/packages/ipns/test/validator.spec.ts
+++ b/packages/ipns/test/validator.spec.ts
@@ -3,8 +3,11 @@ import { keychain } from '@ipshipyard/keychain'
 import { expect } from 'aegir/chai'
 import * as cborg from 'cborg'
 import { MemoryDatastore } from 'datastore-core'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import { InvalidEmbeddedPublicKeyError, RecordTooLargeError, SignatureVerificationError, UnsupportedValidityError } from '../src/errors.ts'
-import { createIPNSRecord, unmarshalIPNSRecord } from '../src/records.ts'
+import { IPNSEntry } from '../src/pb/ipns.ts'
+import { createIPNSRecord } from '../src/records.ts'
+import { decodeExtensibleData, encodeExtensibleData, ipnsRecordDataForV2Sig, multihashToIPNSRoutingKey } from '../src/utils.ts'
 import { ipnsValidator, validFor } from '../src/validator.ts'
 import { getCrypto } from './fixtures/get-crypto.ts'
 import type { Keychain, PrivateKey } from '@helia/interface'
@@ -31,29 +34,36 @@ describe('validator', function () {
     const sequence = 0
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity, { v1Compatible: false })
+    const routingKey = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
 
-    await ipnsValidator(record)
+    await ipnsValidator(routingKey, marshalledRecord, kc)
   })
 
   it('should validate a (V1+V2) record', async () => {
     const sequence = 0
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity, { v1Compatible: true })
+    const routingKey = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
+    const marshalledRecord = IPNSEntry.encode(record)
 
-    await ipnsValidator(record)
+    await ipnsValidator(routingKey, marshalledRecord, kc)
   })
 
   it('should use validator.validate to verify that a record is not valid', async () => {
     const sequence = 0
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
+    const routingKey = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
     // corrupt the record by changing the value to random bytes
-    const data = cborg.decode(record.data)
+    const data = decodeExtensibleData(record.data)
     data.Data = `not original value ${Math.random()}`
-    record.data = cborg.encode(data)
+    record.data = withArrayBuffer(cborg.encode(data))
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', SignatureVerificationError.name)
   })
 
@@ -61,11 +71,13 @@ describe('validator', function () {
     const sequence = 0
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
+    const routingKey = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
-    // @ts-expect-error publicKey is not optional
     delete record.publicKey
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', InvalidEmbeddedPublicKeyError.name)
   })
 
@@ -73,10 +85,13 @@ describe('validator', function () {
     const sequence = 0
     const validity = 1000000
     const record = await createIPNSRecord(privateKey1, contentPath, sequence, validity)
+    const routingKey = multihashToIPNSRoutingKey(privateKey1.publicKey.toMultihash())
 
-    record.publicKey = privateKey2.publicKey
+    record.publicKey = privateKey2.publicKey.toProtobuf()
 
-    await expect(ipnsValidator(record)).to.eventually.be.rejected()
+    const marshalledRecord = IPNSEntry.encode(record)
+
+    await expect(ipnsValidator(routingKey, marshalledRecord, kc)).to.eventually.be.rejected()
       .with.property('name', SignatureVerificationError.name)
   })
 
@@ -84,7 +99,7 @@ describe('validator', function () {
     const marshalledData = new Uint8Array(1024 * 1024)
     const key = new Uint8Array()
 
-    await expect(unmarshalIPNSRecord(key, marshalledData, kc)).to.eventually.be.rejected()
+    await expect(ipnsValidator(key, marshalledData, kc)).to.eventually.be.rejected()
       .with.property('name', RecordTooLargeError.name)
   })
 
@@ -103,14 +118,26 @@ describe('validator', function () {
 
     it('should throw UnsupportedValidityError for non-EOL validity types', async () => {
       const record = await createIPNSRecord(privateKey1, contentPath, 0, 1000000)
-      record.validityType = 5 as any
+      const data = decodeExtensibleData(record.data)
+      data.ValidityType = 5 as any
+
+      // re-sign record
+      record.data = encodeExtensibleData(data)
+      const sigData = ipnsRecordDataForV2Sig(record.data)
+      record.signatureV2 = await privateKey1.sign(sigData)
 
       expect(() => validFor(record)).to.throw(UnsupportedValidityError)
     })
 
     it('should throw UnsupportedValidityError for null validity', async () => {
       const record = await createIPNSRecord(privateKey1, contentPath, 0, 1000000)
-      record.validityType = null as any
+      const data = decodeExtensibleData(record.data)
+      data.ValidityType = null as any
+
+      // re-sign record
+      record.data = encodeExtensibleData(data)
+      const sigData = ipnsRecordDataForV2Sig(record.data)
+      record.signatureV2 = await privateKey1.sign(sigData)
 
       expect(() => validFor(record)).to.throw(UnsupportedValidityError)
     })

--- a/packages/ipns/typedoc.json
+++ b/packages/ipns/typedoc.json
@@ -1,8 +1,6 @@
 {
   "readme": "none",
   "entryPoints": [
-    "./src/index.ts",
-    "./src/dns-resolvers/index.ts",
-    "./src/routing/index.ts"
+    "./src/index.ts"
   ]
 }

--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -76,7 +76,8 @@
     "@multiformats/dns": "^1.0.13",
     "it-map": "^3.1.6",
     "libp2p": "^3.3.3",
-    "multiformats": "^14.0.0"
+    "multiformats": "^14.0.0",
+    "uint8arrays": "^6.1.1"
   },
   "devDependencies": {
     "aegir": "^48.0.11",

--- a/packages/libp2p/src/routing.ts
+++ b/packages/libp2p/src/routing.ts
@@ -1,5 +1,6 @@
 import { peerIdFromCID } from '@libp2p/peer-id'
 import map from 'it-map'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import type { Peer, Provider, Router, RoutingOptions } from '@helia/interface'
 import type { Libp2p, PeerInfo } from '@libp2p/interface'
 import type { CID } from 'multiformats'
@@ -38,8 +39,8 @@ class Libp2pRouter implements Router {
     await this.libp2p.contentRouting.put(key, value, options)
   }
 
-  async get (key: Uint8Array, options?: RoutingOptions): Promise<Uint8Array> {
-    return this.libp2p.contentRouting.get(key, options)
+  async get (key: Uint8Array, options?: RoutingOptions): Promise<Uint8Array<ArrayBuffer>> {
+    return withArrayBuffer(await this.libp2p.contentRouting.get(key, options))
   }
 
   async findPeer (peerId: CID, options?: RoutingOptions): Promise<Peer> {

--- a/packages/libp2p/test/routing.spec.ts
+++ b/packages/libp2p/test/routing.spec.ts
@@ -68,6 +68,8 @@ describe('libp2p-routing', () => {
     const key = Uint8Array.from([0, 1, 2, 3, 4])
     const options = {}
 
+    contentRouting.get.resolves(key)
+
     await router.get?.(key, options)
 
     expect(contentRouting.get.calledWith(key, options)).to.be.true()


### PR DESCRIPTION
Exports low level record creation method to allow removal of `ipns` module.

Adds `validate` option to resolve to skip validation for learining purposes.

Adds `data` option to publish to add arbitrary data.

Returns raw pb record to remove need for extra marshall/unmarshall functions.

Performs all validation in ipnsValidator instead of half there and half during unmarshalling.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
