### PR TITLE
fix: restore .aegir.js in published module

### DIFF
--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -27,7 +27,8 @@
     "src",
     "dist",
     "!dist/test",
-    "!**/*.tsbuildinfo"
+    "!**/*.tsbuildinfo",
+    ".aegir.js"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
Fixes regression introduced in #1049 - this file should be part of the published module.

Refs: https://github.com/ipfs/kubo/pull/11375

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
