### PR TITLE
fix: init added block brokers and routers

### DIFF
--- a/packages/helia/src/helia.ts
+++ b/packages/helia/src/helia.ts
@@ -200,6 +200,7 @@ export class Helia implements HeliaInterface {
   private readonly log: Logger
   private readonly blockBrokers: BlockBroker[]
   private readonly mixins: HeliaMixin[]
+  private readonly components: Components
 
   constructor (init: HeliaInit & { name: string, version: string }) {
     this.info = {
@@ -218,7 +219,7 @@ export class Helia implements HeliaInterface {
     this.mixins = []
 
     // @ts-expect-error routing and keychain are not set
-    const components: Components = {
+    this.components = {
       blockstore: init.blockstore ?? new MemoryBlockstore(),
       datastore: init.datastore ?? new MemoryDatastore(),
       logger: this.logger,
@@ -231,12 +232,12 @@ export class Helia implements HeliaInterface {
       ...(init.components ?? {})
     }
 
-    this.keychain = components.keychain = keychain()(components)
+    this.keychain = this.components.keychain = keychain()(this.components)
 
-    this.routing = components.routing = new RoutingClass(components, {
+    this.routing = this.components.routing = new RoutingClass(this.components, {
       routers: (init.routers ?? []).flatMap((router: Router | ((components: any) => Router)) => {
         if (typeof router === 'function') {
-          router = router(components)
+          router = router(this.components)
         }
 
         // if the router itself is a router
@@ -249,27 +250,31 @@ export class Helia implements HeliaInterface {
       providerLookupConcurrency: init.providerLookupConcurrency
     })
 
-    this.blockBrokers = components.blockBrokers = (init.blockBrokers ?? []).map((broker) => {
+    this.blockBrokers = this.components.blockBrokers = (init.blockBrokers ?? []).map((broker) => {
       if (typeof broker === 'function') {
-        broker = broker(components)
+        broker = broker(this.components)
       }
 
       return broker
     })
 
-    const networkedStorage = new NetworkedStorage(components, init)
-    this.pins = new PinsImpl(components.datastore, networkedStorage, this.getCodec)
+    const networkedStorage = new NetworkedStorage(this.components, init)
+    this.pins = new PinsImpl(this.components.datastore, networkedStorage, this.getCodec)
     this.blockstore = new BlockStorage(networkedStorage, this.pins, this.routing, {
       holdGcLock: init.holdGcLock ?? true
     })
-    this.datastore = components.datastore
+    this.datastore = this.components.datastore
   }
 
   hasRouter (name: string): boolean {
     return this.routing.hasRouter(name)
   }
 
-  addRouter (router: Router): void {
+  addRouter (router: Router | ((components: any) => Router)): void {
+    if (typeof router === 'function') {
+      router = router(this.components)
+    }
+
     this.routing.addRouter(router)
   }
 
@@ -277,7 +282,11 @@ export class Helia implements HeliaInterface {
     return this.blockBrokers.findIndex(b => b.name === name) !== -1
   }
 
-  addBlockBroker (blockBroker: BlockBroker): void {
+  addBlockBroker (blockBroker: BlockBroker | ((components: any) => BlockBroker)): void {
+    if (typeof blockBroker === 'function') {
+      blockBroker = blockBroker(this.components)
+    }
+
     this.blockBrokers.push(blockBroker)
   }
 

--- a/packages/helia/test/index.spec.ts
+++ b/packages/helia/test/index.spec.ts
@@ -1,4 +1,9 @@
 import { expect } from 'aegir/chai'
+import drain from 'it-drain'
+import toBuffer from 'it-to-buffer'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { stubInterface } from 'sinon-ts'
 import { createHelia } from '../src/index.ts'
 import type { Helia } from '@helia/interface'
 
@@ -29,5 +34,79 @@ describe('helia', () => {
 
   it('should have a datastore', async () => {
     expect(helia).to.have.property('datastore').that.is.ok()
+  })
+
+  it('should add a block broker', async () => {
+    const block = crypto.getRandomValues(new Uint8Array(32))
+    const cid = CID.createV0(await sha256.digest(block))
+
+    await expect(drain(helia.blockstore.get(cid, {
+      signal: AbortSignal.timeout(100)
+    }))).to.eventually.be.rejected()
+
+    helia.addBlockBroker({
+      name: 'test-broker',
+      retrieve: async () => {
+        return block
+      }
+    })
+
+    await expect(toBuffer(helia.blockstore.get(cid)))
+      .to.eventually.deep.equal(block)
+  })
+
+  it('should add a block broker as a factory', async () => {
+    const block = crypto.getRandomValues(new Uint8Array(32))
+    const cid = CID.createV0(await sha256.digest(block))
+
+    await expect(drain(helia.blockstore.get(cid, {
+      signal: AbortSignal.timeout(100)
+    }))).to.eventually.be.rejected()
+
+    helia.addBlockBroker(() => ({
+      name: 'test-broker',
+      retrieve: async () => {
+        return block
+      }
+    }))
+
+    await expect(toBuffer(helia.blockstore.get(cid)))
+      .to.eventually.deep.equal(block)
+  })
+
+  it.skip('should add a router', async () => {
+    const block = crypto.getRandomValues(new Uint8Array(32))
+    const cid = CID.createV0(await sha256.digest(block))
+
+    const router = stubInterface({
+      name: 'test-broker',
+      findProviders: async function * () {}
+    })
+
+    helia.addRouter(router)
+
+    await expect(drain(helia.blockstore.get(cid, {
+      signal: AbortSignal.timeout(1_000)
+    }))).to.eventually.be.rejected()
+
+    expect(router.findProviders.called).to.be.true()
+  })
+
+  it.skip('should add a router as a factory', async () => {
+    const block = crypto.getRandomValues(new Uint8Array(32))
+    const cid = CID.createV0(await sha256.digest(block))
+
+    const router = stubInterface({
+      name: 'test-broker',
+      findProviders: async function * () {}
+    })
+
+    helia.addRouter(() => router)
+
+    await expect(drain(helia.blockstore.get(cid, {
+      signal: AbortSignal.timeout(1_000)
+    }))).to.eventually.be.rejected()
+
+    expect(router.findProviders.called).to.be.true()
   })
 })

--- a/packages/interface/src/index.ts
+++ b/packages/interface/src/index.ts
@@ -154,7 +154,7 @@ export interface Helia {
   /**
    * Add a router
    */
-  addRouter(router: Router): void
+  addRouter(router: Router | ((components: any) => Router)): void
 
   /**
    * Returns `true` if a block broker with the passed name has been configured
@@ -164,7 +164,7 @@ export interface Helia {
   /**
    * Add a block broker
    */
-  addBlockBroker(blockBroker: BlockBroker): void
+  addBlockBroker(blockBroker: BlockBroker | ((components: any) => BlockBroker)): void
 
   /**
    * Add a mixin to extend runtime functionality


### PR DESCRIPTION
If a block broker or router is added by a mixin as a factory, ensure it is inited properly before use.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
