### PR TITLE
fix: handle multihashes in dns link results

### DIFF
--- a/packages/dnslink/package.json
+++ b/packages/dnslink/package.json
@@ -57,8 +57,6 @@
   },
   "devDependencies": {
     "@libp2p/logger": "^6.2.8",
-    "@libp2p/peer-id": "^6.0.10",
-    "@types/dns-packet": "^5.6.5",
     "aegir": "^48.0.11",
     "delay": "^7.0.0",
     "sinon-ts": "^2.0.0"

--- a/packages/dnslink/src/namespaces/ipns.ts
+++ b/packages/dnslink/src/namespaces/ipns.ts
@@ -1,7 +1,10 @@
+import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
+import * as Digest from 'multiformats/hashes/digest'
 import { InvalidNamespaceError } from '../errors.ts'
 import type { DNSLinkParser, DNSLinkIPNSResult, DNSLinkDNSLinkResult } from '../index.ts'
 import type { Answer } from '@multiformats/dns'
+import type { MultihashDigest } from 'multiformats/cid'
 
 export const ipns: DNSLinkParser<DNSLinkIPNSResult | DNSLinkDNSLinkResult> = (value: string, answer: Answer): DNSLinkIPNSResult | DNSLinkDNSLinkResult => {
   const [, protocol, peerId, ...rest] = value.split('/')
@@ -11,10 +14,11 @@ export const ipns: DNSLinkParser<DNSLinkIPNSResult | DNSLinkDNSLinkResult> = (va
   }
 
   try {
-    // if the result parses as a PeerId, we've reached the end of the recursion
+    // if the result parses as a base58btc encoded multihash or a CID, we've
+    // reached the end of the recursion
     return {
       namespace: 'ipns',
-      value: CID.parse(peerId).multihash,
+      value: decode(peerId),
       path: rest.length > 0 ? `/${rest.join('/')}` : '',
       answer
     }
@@ -26,5 +30,16 @@ export const ipns: DNSLinkParser<DNSLinkIPNSResult | DNSLinkDNSLinkResult> = (va
       path: rest.length > 0 ? `/${rest.join('/')}` : '',
       answer
     }
+  }
+}
+
+/**
+ * Attempt to decode the passed string as a base58btc encoded multihash or a CID
+ */
+function decode (str: string): MultihashDigest {
+  try {
+    return Digest.decode(base58btc.baseDecode(str))
+  } catch {
+    return CID.parse(str).multihash
   }
 }

--- a/packages/dnslink/test/index.spec.ts
+++ b/packages/dnslink/test/index.spec.ts
@@ -1,10 +1,8 @@
 import { NotFoundError } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
-import { peerIdFromString } from '@libp2p/peer-id'
 import { RecordType } from '@multiformats/dns'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
-import { base36 } from 'multiformats/bases/base36'
 import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
@@ -214,14 +212,14 @@ describe('dnslink', () => {
     expect(result).to.have.nested.property('[0].path', '/foobar/path/123')
   })
 
-  it('should resolve recursive dnslink -> <peerId>/<path>', async () => {
-    const peerId = peerIdFromString('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+  it('should resolve recursive dnslink -> <Qm_PeerId>/<path>', async () => {
+    const multihash = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
 
     dns.query.withArgs('_dnslink.foobar.baz').resolves(dnsResponse([{
       name: 'foobar.baz.',
       TTL: 60,
       type: RecordType.TXT,
-      data: `dnslink=/ipns/${peerId.toString()}/foobar/path/123`
+      data: `dnslink=/ipns/${multihash}/foobar/path/123`
     }]))
 
     const result = await name.resolve('foobar.baz')
@@ -230,18 +228,38 @@ describe('dnslink', () => {
       throw new Error('Did not resolve entry')
     }
 
-    expect(result).to.have.deep.nested.property('[0].value', Digest.decode(base58btc.decode('zQmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')))
+    expect(result).to.have.deep.nested.property('[0].value', Digest.decode(base58btc.baseDecode(multihash)))
+    expect(result).to.have.nested.property('[0].path', '/foobar/path/123')
+  })
+
+  it('should resolve recursive dnslink -> <12D3Koo_PeerId>/<path>', async () => {
+    const multihash = '12D3KooWDUyFJTGJADckWJdfh2haqj6ckaXFWi1DReJ4RP8KsHg5'
+
+    dns.query.withArgs('_dnslink.foobar.baz').resolves(dnsResponse([{
+      name: 'foobar.baz.',
+      TTL: 60,
+      type: RecordType.TXT,
+      data: `dnslink=/ipns/${multihash}/foobar/path/123`
+    }]))
+
+    const result = await name.resolve('foobar.baz')
+
+    if (result == null) {
+      throw new Error('Did not resolve entry')
+    }
+
+    expect(result).to.have.deep.nested.property('[0].value', Digest.decode(base58btc.baseDecode(multihash)))
     expect(result).to.have.nested.property('[0].path', '/foobar/path/123')
   })
 
   it('should resolve recursive dnslink -> <IPNS_base36_CID>/<path>', async () => {
-    const peerId = peerIdFromString('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
-    const peerIdBase36CID = peerId.toCID().toString(base36)
+    const cid = 'k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2'
+
     dns.query.withArgs('_dnslink.foobar.baz').resolves(dnsResponse([{
       name: 'foobar.baz.',
       TTL: 60,
       type: RecordType.TXT,
-      data: `dnslink=/ipns/${peerIdBase36CID}/foobar/path/123`
+      data: `dnslink=/ipns/${cid}/foobar/path/123`
     }]))
 
     const result = await name.resolve('foobar.baz')
@@ -250,7 +268,7 @@ describe('dnslink', () => {
       throw new Error('Did not resolve entry')
     }
 
-    expect(result).to.have.deep.nested.property('[0].value', Digest.decode(base58btc.decode('zQmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')))
+    expect(result).to.have.deep.nested.property('[0].value', CID.parse(cid).multihash)
     expect(result).to.have.nested.property('[0].path', '/foobar/path/123')
   })
 


### PR DESCRIPTION
Fixes regression caused when removing peer ids

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
