### PR TITLE
fix: override defaults in browsers

### DIFF
--- a/packages/delegated-routing-client/src/utils/delegated-http-routing-defaults.browser.ts
+++ b/packages/delegated-routing-client/src/utils/delegated-http-routing-defaults.browser.ts
@@ -4,6 +4,7 @@ export function delegatedHTTPRoutingDefaults (init?: DelegatedRoutingV1HttpApiCl
   return {
     url: 'https://delegated-ipfs.dev',
     filterProtocols: ['unknown', 'transport-bitswap', 'transport-ipfs-gateway-http'],
-    filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss', 'tls']
+    filterAddrs: ['https', 'webtransport', 'webrtc', 'webrtc-direct', 'wss', 'tls'],
+    ...(init ?? {})
   }
 }


### PR DESCRIPTION
Have to override defaults with passed values otherwise you always get delegated-ipfs.dev.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
