### PR TITLE
fix: fall through to other routings

### DIFF
--- a/packages/helia/src/routing.ts
+++ b/packages/helia/src/routing.ts
@@ -289,6 +289,7 @@ export class Routing implements RoutingInterface, Startable {
             } catch (err: any) {
               this.log('router %s failed with %e', router, err)
               errors.push(err)
+              throw err
             } finally {
               options?.onProgress?.(new CustomProgressEvent('helia:routing:get:end', {
                 routing: router.name,


### PR DESCRIPTION
Have to throw the error otherwise the other routings do not get to run due to use of Promise.any

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
