### PR TITLE
fix: include which router found the peer in get peer

### DIFF
--- a/packages/delegated-routing-client/src/delegated-routing-router.ts
+++ b/packages/delegated-routing-client/src/delegated-routing-router.ts
@@ -38,7 +38,7 @@ export class DelegatedHTTPRouter implements Router {
         id: record.ID,
         multiaddrs: record.Addrs,
         protocols: record.Protocols,
-        routing: 'delegated-http-routing'
+        routing: this.name
       }
     })
   }
@@ -81,7 +81,8 @@ export class DelegatedHTTPRouter implements Router {
     if (peer != null) {
       return {
         id: peer.ID,
-        multiaddrs: peer.Addrs ?? []
+        multiaddrs: peer.Addrs ?? [],
+        routing: this.name
       }
     }
 

--- a/packages/fallback-router/src/index.ts
+++ b/packages/fallback-router/src/index.ts
@@ -41,7 +41,8 @@ function toPeerInfo (url: string | URL): Peer {
     id: CID.createV1(TRANSPORT_IPFS_GATEWAY_HTTP_CODE, identity.digest(uint8ArrayFromString(url))),
     multiaddrs: [
       uriToMultiaddr(url)
-    ]
+    ],
+    routing: 'fallback-router'
   }
 }
 
@@ -68,7 +69,7 @@ class FallbackRouter implements Router {
         ...info,
         id: info.id,
         protocols: ['transport-ipfs-gateway-http'],
-        routing: 'http-gateway-routing'
+        routing: 'fallback-router'
       }
 
       return provider
@@ -76,7 +77,7 @@ class FallbackRouter implements Router {
   }
 
   toString (): string {
-    return `HTTPGatewayRouter([${this.gateways.map(info => toUrl(info)).join(', ')}])`
+    return `FallbackRouter([${this.gateways.map(info => toUrl(info)).join(', ')}])`
   }
 }
 

--- a/packages/interface/src/routing.ts
+++ b/packages/interface/src/routing.ts
@@ -50,6 +50,11 @@ export interface Peer {
    * The multiaddrs a peer is listening on
    */
   multiaddrs: Multiaddr[]
+
+  /**
+   * The name of the routing implementation that found the peer
+   */
+  routing: string
 }
 
 /**

--- a/packages/libp2p/src/routing.ts
+++ b/packages/libp2p/src/routing.ts
@@ -8,7 +8,8 @@ import type { CID } from 'multiformats'
 function peerInfoToPeer (info: PeerInfo): Peer {
   return {
     ...info,
-    id: info.id.toCID()
+    id: info.id.toCID(),
+    routing: 'libp2p-router'
   }
 }
 
@@ -30,7 +31,6 @@ class Libp2pRouter implements Router {
 
   async * findProviders (cid: CID, options?: RoutingOptions): AsyncIterable<Provider> {
     yield * map(this.libp2p.contentRouting.findProviders(cid, options), prov => ({
-      routing: this.name,
       ...peerInfoToPeer(prov)
     }))
   }


### PR DESCRIPTION
For better visibility include which router found the peer info.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
