### PR TITLE
fix: override routing operations

### DIFF
--- a/packages/libp2p/package.json
+++ b/packages/libp2p/package.json
@@ -74,6 +74,8 @@
     "@libp2p/webrtc": "^6.0.24",
     "@libp2p/websockets": "^10.1.14",
     "@multiformats/dns": "^1.0.13",
+    "@multiformats/multiaddr": "^13.0.3",
+    "it-foreach": "^2.1.7",
     "it-map": "^3.1.6",
     "libp2p": "^3.3.3",
     "multiformats": "^14.0.0",

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -16,13 +16,17 @@
  */
 
 import { NotStartedError } from '@libp2p/interface'
+import { peerIdFromCID } from '@libp2p/peer-id'
+import forEach from 'it-foreach'
 import { isLibp2p } from 'libp2p'
 import { libp2pRouting } from './routing.ts'
 import { createLibp2p } from './utils/libp2p.ts'
 import type { DefaultLibp2pServices } from './utils/libp2p-defaults.ts'
 import type { CreateLibp2pOptions } from './utils/libp2p.ts'
-import type { Helia, HeliaMixin } from '@helia/interface'
-import type { Libp2p, ServiceMap } from '@libp2p/interface'
+import type { Helia, HeliaMixin, Peer } from '@helia/interface'
+import type { Libp2p, PeerInfo, ServiceMap } from '@libp2p/interface'
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type { CID } from 'multiformats'
 
 export { libp2pDefaults } from './utils/libp2p-defaults.ts'
 export type { DefaultLibp2pServices } from './utils/libp2p-defaults.ts'
@@ -54,7 +58,7 @@ async function getLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (h
 export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap, L extends Libp2p = Libp2p<M>> (helia: H, opts: L): H & HeliaWithLibp2p<M>
 export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): H & HeliaWithLibp2p<M>
 export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): H & HeliaWithLibp2p {
-  let libp2p: any
+  let libp2p: Libp2p
 
   // add a getter that informs the user they need to start Helia
   Object.defineProperty(helia, 'libp2p', {
@@ -74,6 +78,45 @@ export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> 
     start: async (helia) => {
       if (libp2p == null) {
         libp2p = await getLibp2p(helia, opts)
+
+        // override peer discovery methods to ensure we persist peer data in the
+        // peer store, otherwise we can't dial by peer id without extra lookups
+        const findProviders = helia.routing.findProviders.bind(helia.routing)
+        helia.routing.findProviders = async function * (cid, options): AsyncIterable<Peer> {
+          yield * forEach(findProviders.call(helia.routing, cid, options), async (peer) => {
+            if (peer.routing !== 'libp2p-router') {
+              // only need to do this for peers not found via the libp2p router
+              const info = toPeerInfo(peer)
+              await libp2p.peerStore.merge(info.id, info)
+            }
+          })
+        }
+
+        const findPeer = helia.routing.findPeer.bind(helia.routing)
+        helia.routing.findPeer = async function (cid, options): Promise<Peer> {
+          const peer = await findPeer(cid, options)
+
+          if (peer.routing !== 'libp2p-router') {
+            // only need to do this for peers not found via the libp2p router
+            const info = toPeerInfo(peer)
+            await libp2p.peerStore.merge(info.id, info)
+          }
+
+          return peer
+        }
+
+        // override peer discovery methods to ensure we persist peer data in the
+        // peer store, otherwise we can't dial by peer id without extra lookups
+        const getClosestPeers = helia.routing.getClosestPeers.bind(helia.routing)
+        helia.routing.getClosestPeers = async function * (cid, options): AsyncIterable<Peer> {
+          yield * forEach(getClosestPeers.call(helia.routing, cid, options), async (peer) => {
+            if (peer.routing !== 'libp2p-router') {
+              // only need to do this for peers not found via the libp2p router
+              const info = toPeerInfo(peer)
+              await libp2p.peerStore.merge(info.id, info)
+            }
+          })
+        }
       }
 
       try {
@@ -101,4 +144,11 @@ export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> 
 
   // @ts-expect-error libp2p property is missing, even though we just defined it
   return helia
+}
+
+function toPeerInfo (peer: { id: CID, multiaddrs: Multiaddr[] }): PeerInfo {
+  return {
+    id: peerIdFromCID(peer.id),
+    multiaddrs: peer.multiaddrs
+  }
 }

--- a/packages/libp2p/test/index.spec.ts
+++ b/packages/libp2p/test/index.spec.ts
@@ -13,7 +13,8 @@ describe('@helia/libp2p', () => {
   beforeEach(() => {
     helia = withLibp2p(stubInterface<any>({
       datastore: new MemoryDatastore(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      routing: stubInterface()
     }))
   })
 
@@ -35,7 +36,8 @@ describe('@helia/libp2p', () => {
 
     helia = withLibp2p(stubInterface<any>({
       datastore: new MemoryDatastore(),
-      logger: defaultLogger()
+      logger: defaultLogger(),
+      routing: stubInterface()
     }), libp2p)
 
     await helia.addMixin.getCall(0).args[0]?.start?.(helia)


### PR DESCRIPTION
Most libp2p services dial by peer id, libp2p will check the peer store for addresses then the routing if there are either no addresses or they have all expired.

When a router is only configured for Helia and not libp2p this can lead to dialing a peer id without having an entry in the peer store - in this case libp2p will do a routing lookup first which is not necessary since we just discovered the peer via the helia routing.

Override Helia's routing methods that discover peers to add them to the peer store before yielding them to the rest of the application.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
