### PR TITLE
fix: pin kubo interop node to unixfs-v1-2025

### DIFF
--- a/packages/interop/src/fixtures/create-kubo.browser.ts
+++ b/packages/interop/src/fixtures/create-kubo.browser.ts
@@ -9,6 +9,9 @@ export async function createKuboNode (): Promise<KuboNode> {
     test: true,
     endpoint: process.env.IPFSD_SERVER,
     init: {
+      // Mirror create-kubo.ts: pin the unixfs-v1-2025 import profile (IPIP-499)
+      // so browser-mode interop produces the same deterministic CIDs.
+      profiles: ['unixfs-v1-2025'],
       config: {
         Addresses: {
           Swarm: [

--- a/packages/interop/src/fixtures/create-kubo.ts
+++ b/packages/interop/src/fixtures/create-kubo.ts
@@ -10,6 +10,12 @@ export async function createKuboNode (): Promise<KuboNode> {
     bin: kuboPath(),
     test: true,
     init: {
+      // Pin the unixfs-v1-2025 import profile (IPIP-499,
+      // https://specs.ipfs.tech/ipips/ipip-0499/) so every interop test uses
+      // the same CIDv1 / 1 MiB-chunk import settings regardless of the Kubo
+      // version's default (Kubo <= 0.42 defaults to CIDv0). Keeps CID-based
+      // assertions deterministic; the profile has existed since Kubo v0.40.
+      profiles: ['unixfs-v1-2025'],
       config: {
         Addresses: {
           Swarm: [

--- a/packages/interop/src/providers.spec.ts
+++ b/packages/interop/src/providers.spec.ts
@@ -80,7 +80,10 @@ describe('providers', () => {
       }
     }))
 
-    expect(buf).to.have.lengthOf(1930)
+    // The Kubo node uses the unixfs-v1-2025 profile (see create-kubo.ts), so a
+    // 10 MiB file is 1 MiB chunks -> 10 raw CIDv1 leaf links -> 509-byte dag-pb
+    // root (the legacy CIDv0 / 256 KiB defaults gave 40 links / 1930).
+    expect(buf).to.have.lengthOf(509)
     expect(sender).to.deep.equal(peerIdFromString(kuboInfo.peerId?.toString() ?? '').toCID())
   })
 

--- a/packages/interop/src/unixfs-files.spec.ts
+++ b/packages/interop/src/unixfs-files.spec.ts
@@ -56,14 +56,14 @@ describe('@helia/unixfs - files', () => {
 
   async function expectSameCid (data: () => ByteStream, heliaOpts: Partial<AddOptions> = {}, kuboOpts: KuboAddOptions = {}): Promise<void> {
     const heliaCid = await importToHelia(data(), {
-      // these are the default kubo options
-      cidVersion: 0,
-      rawLeaves: false,
+      // these are the modern CIDv1 options (unixfs-v1-2025 profile, IPIP-499)
+      cidVersion: 1,
+      rawLeaves: true,
       layout: balanced({
-        maxChildrenPerNode: 174
+        maxChildrenPerNode: 1024
       }),
       chunker: fixedSize({
-        chunkSize: 262144
+        chunkSize: 1048576
       }),
 
       ...heliaOpts
@@ -169,15 +169,15 @@ describe('@helia/unixfs - files', () => {
     const block = await toBuffer(helia.blockstore.get(largeFileCid))
     const node = dagPb.decode(block)
 
-    expect(node.Links).to.have.lengthOf(40)
+    expect(node.Links).to.have.lengthOf(10)
 
     const stats = await unixFs.stat(largeFileCid, {
       extended: true
     })
 
     expect(stats.unixfs?.fileSize()).to.equal(10485760n)
-    expect(stats.blocks).to.equal(41n)
-    expect(stats.dagSize).to.equal(10488250n)
+    expect(stats.blocks).to.equal(11n)
+    expect(stats.dagSize).to.equal(10486269n)
     expect(stats.localSize).to.equal(10485760n)
 
     // remove one of the blocks so we now have an incomplete DAG
@@ -190,9 +190,9 @@ describe('@helia/unixfs - files', () => {
     })
 
     expect(updatedStats.unixfs?.fileSize()).to.equal(10485760n)
-    expect(updatedStats.blocks).to.equal(40n)
-    expect(updatedStats.dagSize).to.equal(10226092n)
-    expect(updatedStats.localSize).to.equal(10223616n)
+    expect(updatedStats.blocks).to.equal(10n)
+    expect(updatedStats.dagSize).to.equal(9437693n)
+    expect(updatedStats.localSize).to.equal(9437184n)
 
     await new Promise<void>((resolve) => {
       setTimeout(() => {


### PR DESCRIPTION
## Problem

Kubo 0.42 introduced [`unixfs-v1-2025`](https://specs.ipfs.tech/ipips/ipip-0499/) (IPIP-499) and 0.43 might switch to that as the default import profile (ipfs/kubo#8185), so `ipfs add` produces 1 MiB chunks with raw CIDv1 leaves instead of 256 KiB dag-pb. 

The `providers` interop spec adds a 10 MiB file and asserts its root block is 1930 bytes, the old 40-leaf shape. Under the new default that root is 10 leaves / 509 bytes, so the interop test is outdated and fails long term.

## Fix

- Pin the `unixfs-v1-2025` profile on the interop Kubo node via `ipfsd-ctl`'s `init.profiles`, so imports are deterministic regardless of the Kubo version's default. The profile has existed since Kubo v0.40, so it also holds against the `^0.42.0` this package pins today.
- Update the root-block assertion to 509.

Only the interop test setup changes, no shipping Helia code. This keeps CID-based interop assertions stable across Kubo releases.