### PR TITLE
fix: always use fallback routers

### DIFF
--- a/packages/helia/src/routing.ts
+++ b/packages/helia/src/routing.ts
@@ -204,8 +204,8 @@ export class Routing implements RoutingInterface, Startable {
     // use non-fallback routers first
     yield * findProviders(defaultRouters)
 
-    // only use fallback routers if no providers have been found
-    if (foundProviders === 0 && fallbackRouters.length > 0) {
+    // use fallback routers last
+    if (fallbackRouters.length > 0) {
       this.log('findProviders for %c using fallback routers %s', key, fallbackRouters.map(r => r.name).join(', '))
       yield * findProviders(fallbackRouters)
     }

--- a/packages/helia/test/routing.spec.ts
+++ b/packages/helia/test/routing.spec.ts
@@ -89,10 +89,14 @@ describe('routing', () => {
     expect(firstRouter).to.equal('b')
   })
 
-  it('should not use a fallback router if a regular router finds providers', async () => {
+  it('should use a fallback router even if a regular router finds providers', async () => {
     const key = CID.parse('QmaQwYWpchozXhFv8nvxprECWBSCEppN9dfd2VQiJfRo3E')
 
-    routerA.findProviders?.returns((async function * () {})())
+    routerA.findProviders?.returns((async function * () {
+      yield stubInterface<Provider>({
+        multiaddrs: [stubInterface<Multiaddr>()]
+      })
+    })())
     routerB.findProviders?.returns((async function * () {
       yield stubInterface<Provider>({
         multiaddrs: [stubInterface<Multiaddr>()]
@@ -101,8 +105,8 @@ describe('routing', () => {
 
     routerA.capabilities?.returns(['fallback'])
 
-    await expect(all(routing.findProviders(key))).to.eventually.have.lengthOf(1, 'did not find provider')
-    expect(routerA.findProviders?.called).to.be.false('called fallback router')
+    await expect(all(routing.findProviders(key))).to.eventually.have.lengthOf(2, 'did not find regular and fallback providers')
+    expect(routerA.findProviders?.called).to.be.true('did not call fallback router')
     expect(routerB.findProviders?.called).to.be.true('did not call regular router')
   })
 })


### PR DESCRIPTION
Block brokers may reject providers if they don't speak the right protocol or transport so always use fallback routers to yield any preconfigured providers.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
