### PR TITLE
fix: do not evict session peers before querying them

### DIFF
--- a/packages/bitswap/src/session.ts
+++ b/packages/bitswap/src/session.ts
@@ -1,3 +1,4 @@
+import { NoEvictionError } from '@helia/interface'
 import { AbstractSession, isCID } from '@helia/utils'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { CID } from 'multiformats/cid'
@@ -40,6 +41,10 @@ class BitswapSession extends AbstractSession<ProviderPeer, BitswapWantProgressEv
   }
 
   async queryProvider (cid: CID, provider: ProviderPeer, options: AbortOptions): Promise<Uint8Array> {
+    if (options.signal?.aborted === true) {
+      throw new NoEvictionError(`Signal to want session block for CID ${cid} from peer ${provider} was aborted prior to want`)
+    }
+
     const peerId = peerIdFromCID(provider.peerId)
 
     this.log('sending WANT-BLOCK for %c to %p', cid, peerId)

--- a/packages/interface/src/errors.ts
+++ b/packages/interface/src/errors.ts
@@ -47,3 +47,15 @@ export class UnknownCryptoError extends Error {
   static name = 'UnknownCryptoError'
   name = 'UnknownCryptoError'
 }
+
+/**
+ * Normally when retrieving a block from a session peer fails, that peer is
+ * evicted from the session.
+ *
+ * This error is thrown when the retrieval failed for a reason not related to
+ * that peer, so they should remain in the session.
+ */
+export class NoEvictionError extends Error {
+  static name = 'NoEvictionError'
+  name = 'NoEvictionError'
+}

--- a/packages/trustless-gateway-client/src/trustless-gateway.ts
+++ b/packages/trustless-gateway-client/src/trustless-gateway.ts
@@ -1,3 +1,4 @@
+import { NoEvictionError } from '@helia/interface'
 import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
 import { base64 } from 'multiformats/bases/base64'
 import { CID } from 'multiformats/cid'
@@ -127,7 +128,7 @@ export class TrustlessGateway {
     gwUrl.search = '?format=raw'
 
     if (options.signal?.aborted === true) {
-      throw new Error(`Signal to fetch raw block for CID ${cid} from gateway ${this.url} was aborted prior to fetch`)
+      throw new NoEvictionError(`Signal to fetch raw block for CID ${cid} from gateway ${this.url} was aborted prior to fetch`)
     }
 
     const blockId = this.#uniqueBlockId(cid)

--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -97,8 +97,12 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
       concurrency: this.maxProviders
     })
     queue.addEventListener('failure', (evt) => {
-      this.log.error('error querying provider %s, evicting from session - %e', evt.detail.job.options.provider, evt.detail.error)
-      this.evict(evt.detail.job.options.provider)
+      if (evt.detail.error.name === 'NoEvictionError') {
+        this.log.error('error querying provider %s - %e', evt.detail.job.options.provider, evt.detail.error)
+      } else {
+        this.log.error('error querying provider %s, evicting from session - %e', evt.detail.job.options.provider, evt.detail.error)
+        this.evict(evt.detail.job.options.provider)
+      }
     })
     queue.addEventListener('success', (evt) => {
       // peer has sent block, return it to the caller
@@ -129,6 +133,7 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
             }
 
             const provider = this.providers[Math.floor(Math.random() * this.providers.length)]
+            this.log('evicting %s to make room for more providers', provider)
             this.evict(provider)
           }
 

--- a/packages/utils/test/abstract-session.spec.ts
+++ b/packages/utils/test/abstract-session.spec.ts
@@ -1,3 +1,4 @@
+import { NoEvictionError } from '@helia/interface'
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { isPeerId } from '@libp2p/interface'
 import { defaultLogger } from '@libp2p/logger'
@@ -127,6 +128,33 @@ describe('abstract-session', () => {
 
     await expect(session.retrieve(cid)).to.eventually.deep.equal(block)
     expect(session.providers.includes(providers[0])).to.be.false()
+  })
+
+  it('should not evict session providers when a NoEvictionError error is thrown', async () => {
+    const session = new Session()
+
+    const cid = CID.parse('bafybeifaymukvfkyw6xgh4th7tsctiifr4ea2btoznf46y6b2fnvikdczi')
+    const block = Uint8Array.from([0, 1, 2, 3])
+
+    const providers: SessionPeer[] = [{
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    }, {
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+    }]
+
+    session.findNewProviders.callsFake(async function * () {
+      yield * providers
+    })
+    session.queryProvider.withArgs(cid, providers[0]).callsFake(async () => {
+      throw new NoEvictionError('Urk!')
+    })
+    session.queryProvider.withArgs(cid, providers[1]).callsFake(async () => {
+      return block
+    })
+
+    await expect(session.retrieve(cid)).to.eventually.deep.equal(block)
+    expect(session.providers.includes(providers[0])).to.be.true()
+    expect(session.providers.includes(providers[1])).to.be.true()
   })
 
   it('should join existing CID request', async () => {


### PR DESCRIPTION
If a block request is cancelled before a session peer is queried for the block, do not evict them from the session since they did not have the chance to respond to the block request negatively yet.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
