### PR TITLE
fix: do not evict fallback providers from session

### DIFF
--- a/packages/bitswap/src/session.ts
+++ b/packages/bitswap/src/session.ts
@@ -21,6 +21,7 @@ interface ProviderPeer {
   peerId: CID
   router: string
   toString(): string
+  fallback: boolean
 }
 
 class BitswapSession extends AbstractSession<ProviderPeer, BitswapWantProgressEvents> {
@@ -69,7 +70,8 @@ class BitswapSession extends AbstractSession<ProviderPeer, BitswapWantProgressEv
       yield {
         peerId: provider.id,
         router: provider.router,
-        toString: () => `Bitswap(${provider.id})`
+        toString: () => `Bitswap(${provider.id})`,
+        fallback: provider.fallback
       }
     }
   }
@@ -87,7 +89,8 @@ class BitswapSession extends AbstractSession<ProviderPeer, BitswapWantProgressEv
       return {
         peerId: provider,
         router,
-        toString: () => `Bitswap(${provider})`
+        toString: () => `Bitswap(${provider})`,
+        fallback: false
       }
     }
 
@@ -101,7 +104,8 @@ class BitswapSession extends AbstractSession<ProviderPeer, BitswapWantProgressEv
       return {
         peerId: connection.remotePeer.toCID(),
         router,
-        toString: () => `Bitswap(${connection.remotePeer})`
+        toString: () => `Bitswap(${connection.remotePeer})`,
+        fallback: false
       }
     } catch {}
   }
@@ -113,7 +117,8 @@ class BitswapSession extends AbstractSession<ProviderPeer, BitswapWantProgressEv
       provider: {
         id: provider.peerId,
         multiaddrs: [],
-        router: provider.router
+        router: provider.router,
+        fallback: provider.fallback
       },
       router: provider.router
     }))

--- a/packages/bitswap/test/network.spec.ts
+++ b/packages/bitswap/test/network.spec.ts
@@ -159,7 +159,8 @@ describe('network', () => {
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -183,7 +184,8 @@ describe('network', () => {
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001/p2p-circuit')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -219,7 +221,8 @@ describe('network', () => {
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001/p2p-circuit')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -243,7 +246,8 @@ describe('network', () => {
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {
@@ -280,7 +284,8 @@ describe('network', () => {
       multiaddrs: [
         multiaddr('/ip4/127.0.0.1/tcp/4001/p2p-circuit')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.routing.findProviders.withArgs(cid).returns((async function * () {

--- a/packages/bitswap/test/session.spec.ts
+++ b/packages/bitswap/test/session.spec.ts
@@ -53,7 +53,8 @@ describe('session', () => {
           multiaddrs: [
             multiaddr(`/ip4/4${i}.4${i}.4${i}.4${i}/tcp/${1234 + i}`)
           ],
-          router: 'test-routing'
+          router: 'test-routing',
+          fallback: false
         }
       })
     )
@@ -136,7 +137,8 @@ describe('session', () => {
       multiaddrs: [
         multiaddr('/ip4/41.41.41.41/tcp/1234')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.network.findProviders.withArgs(cid).returns((async function * () {
@@ -162,13 +164,15 @@ describe('session', () => {
       multiaddrs: [
         multiaddr('/ip4/41.41.41.41/tcp/1234')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }, {
       id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')).toCID(),
       multiaddrs: [
         multiaddr('/ip4/41.41.41.41/tcp/1235')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.network.findProviders.withArgs(cid).returns((async function * () {

--- a/packages/delegated-routing-client/src/delegated-routing-router.ts
+++ b/packages/delegated-routing-client/src/delegated-routing-router.ts
@@ -38,7 +38,8 @@ export class DelegatedHTTPRouter implements Router {
         id: record.ID,
         multiaddrs: record.Addrs,
         protocols: record.Protocols,
-        router: this.name
+        router: this.name,
+        fallback: false
       }
     })
   }

--- a/packages/fallback-router/src/index.ts
+++ b/packages/fallback-router/src/index.ts
@@ -20,6 +20,11 @@ import type { Version } from 'multiformats'
 export interface FallbackRouterInit {
   /**
    * Where to send requests
+   *
+   * Important - fallback providers are never evicted from block broker sessions
+   * so you should not configure more than five gateways here otherwise the
+   * routing will never be queried for additional providers, or you should
+   * increase `maxProviders` in the session init args.
    */
   gateways: Array<URL | string>
 
@@ -75,7 +80,8 @@ class FallbackRouter implements Router {
         ...info,
         id: info.id,
         protocols: ['transport-ipfs-gateway-http'],
-        router: 'fallback-router'
+        router: 'fallback-router',
+        fallback: true
       }
 
       return provider

--- a/packages/helia/src/routing.ts
+++ b/packages/helia/src/routing.ts
@@ -173,7 +173,8 @@ export class Routing implements RoutingInterface, Startable {
               return {
                 ...provider,
                 protocols: peer.protocols,
-                router: peer.router
+                router: peer.router,
+                fallback: peer.fallback
               }
             } catch (err) {
               self.log.error('could not load multiaddrs for peer %p - %e', peer.id, err)

--- a/packages/interface/src/routing.ts
+++ b/packages/interface/src/routing.ts
@@ -89,6 +89,13 @@ export interface Provider {
    * The name of the routing implementation that found the provider
    */
   router: string
+
+  /**
+   * If true, this is a fallback provider that can fetch blocks on our behalf.
+   *
+   * Fallback providers will remain in sessions.
+   */
+  fallback: boolean
 }
 
 export interface RoutingFindProvidersStartEvent {

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -23,7 +23,7 @@ import { libp2pRouting } from './routing.ts'
 import { createLibp2p } from './utils/libp2p.ts'
 import type { DefaultLibp2pServices } from './utils/libp2p-defaults.ts'
 import type { CreateLibp2pOptions } from './utils/libp2p.ts'
-import type { Helia, HeliaMixin, Peer } from '@helia/interface'
+import type { Helia, HeliaMixin, Peer, Provider } from '@helia/interface'
 import type { Libp2p, PeerInfo, ServiceMap } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { CID } from 'multiformats'
@@ -82,7 +82,7 @@ export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> 
         // override peer discovery methods to ensure we persist peer data in the
         // peer store, otherwise we can't dial by peer id without extra lookups
         const findProviders = helia.routing.findProviders.bind(helia.routing)
-        helia.routing.findProviders = async function * (cid, options): AsyncIterable<Peer> {
+        helia.routing.findProviders = async function * (cid, options): AsyncIterable<Provider> {
           yield * forEach(findProviders.call(helia.routing, cid, options), async (peer) => {
             if (peer.router !== 'libp2p-router') {
               // only need to do this for peers not found via the libp2p router

--- a/packages/libp2p/src/routing.ts
+++ b/packages/libp2p/src/routing.ts
@@ -13,6 +13,15 @@ function peerInfoToPeer (info: PeerInfo): Peer {
   }
 }
 
+function peerInfoToProvider (info: PeerInfo): Provider {
+  return {
+    ...info,
+    id: info.id.toCID(),
+    router: 'libp2p-router',
+    fallback: false
+  }
+}
+
 class Libp2pRouter implements Router {
   public readonly name = 'libp2p-router'
   private readonly libp2p: Libp2p
@@ -31,7 +40,7 @@ class Libp2pRouter implements Router {
 
   async * findProviders (cid: CID, options?: RoutingOptions): AsyncIterable<Provider> {
     yield * map(this.libp2p.contentRouting.findProviders(cid, options), prov => ({
-      ...peerInfoToPeer(prov)
+      ...peerInfoToProvider(prov)
     }))
   }
 

--- a/packages/trustless-gateway-client/src/session.ts
+++ b/packages/trustless-gateway-client/src/session.ts
@@ -97,7 +97,7 @@ class TrustlessGatewaySession extends AbstractSession<TrustlessGateway, Trustles
     // etc
     const uri = multiaddrToUri(httpAddresses[0])
 
-    return new TrustlessGateway(uri, {
+    return new TrustlessGateway(uri, false, {
       logger: this.logger,
       transformRequestInit: this.transformRequestInit,
       router

--- a/packages/trustless-gateway-client/src/trustless-gateway.ts
+++ b/packages/trustless-gateway-client/src/trustless-gateway.ts
@@ -50,6 +50,7 @@ export interface GetRawBlockOptions extends ProgressOptions<BlockBrokerGetBlockP
  */
 export class TrustlessGateway {
   public readonly url: URL
+  public readonly fallback: boolean
   private readonly peer: CID
 
   /**
@@ -92,8 +93,9 @@ export class TrustlessGateway {
 
   public readonly router: string
 
-  constructor (url: URL | string, { logger, transformRequestInit, router }: TrustlessGatewayComponents) {
+  constructor (url: URL | string, fallback: boolean, { logger, transformRequestInit, router }: TrustlessGatewayComponents) {
     this.url = url instanceof URL ? url : new URL(url)
+    this.fallback = fallback
     this.transformRequestInit = transformRequestInit
     this.log = logger.forComponent(`helia:trustless-gateway-block-broker:${this.url.host}`)
     this.router = router

--- a/packages/trustless-gateway-client/src/utils.ts
+++ b/packages/trustless-gateway-client/src/utils.ts
@@ -66,7 +66,7 @@ export async function * findHttpGatewayProviders (cid: CID, routing: Routing, lo
     // etc
     const uri = new URL(multiaddrToUri(httpAddresses[0]))
 
-    yield new TrustlessGateway(uri, {
+    yield new TrustlessGateway(uri, provider.fallback, {
       logger,
       transformRequestInit: options.transformRequestInit,
       router: provider.router

--- a/packages/trustless-gateway-client/test/index.spec.ts
+++ b/packages/trustless-gateway-client/test/index.spec.ts
@@ -32,14 +32,16 @@ describe('trustless-gateway-block-broker', () => {
       multiaddrs: [
         uriToMultiaddr(process.env.BAD_TRUSTLESS_GATEWAY ?? '')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }
     goodGatewayPeer = {
       id: (await ed25519Crypto().generatePrivateKey()).publicKey.toCID(),
       multiaddrs: [
         uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }
 
     gatewayBlockBroker = new TrustlessGatewayBlockBroker({
@@ -115,13 +117,15 @@ describe('trustless-gateway-block-broker', () => {
         multiaddrs: [
           multiaddr('/ip4/132.32.25.6/tcp/1234')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
       // expired peer info
       yield {
         id: (await ed25519Crypto().generatePrivateKey()).publicKey.toCID(),
         multiaddrs: [],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
       // http gateway
       yield {
@@ -129,7 +133,8 @@ describe('trustless-gateway-block-broker', () => {
         multiaddrs: [
           uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
     }())
 
@@ -150,7 +155,7 @@ describe('trustless-gateway-block-broker', () => {
     if (process.env.TRUSTLESS_GATEWAY == null) {
       return this.skip()
     }
-    const trustlessGateway = new TrustlessGateway(process.env.TRUSTLESS_GATEWAY, {
+    const trustlessGateway = new TrustlessGateway(process.env.TRUSTLESS_GATEWAY, false, {
       logger: defaultLogger(),
       router: 'test'
     })
@@ -182,7 +187,7 @@ describe('trustless-gateway-block-broker', () => {
     }
     const cid = CID.parse('bafybeic3q4y65yxu3yckr76q63bcvanhklwf6cwxuacnrot6v3gykrgsvq')
 
-    const trustlessGateway = new TrustlessGateway(process.env.TRUSTLESS_GATEWAY, {
+    const trustlessGateway = new TrustlessGateway(process.env.TRUSTLESS_GATEWAY, false, {
       logger: defaultLogger(),
       router: 'test',
       transformRequestInit: (requestInit) => {

--- a/packages/trustless-gateway-client/test/sessions.spec.ts
+++ b/packages/trustless-gateway-client/test/sessions.spec.ts
@@ -43,7 +43,8 @@ describe('trustless-gateway sessions', () => {
         multiaddrs: [
           uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
     }())
 
@@ -65,21 +66,24 @@ describe('trustless-gateway sessions', () => {
         multiaddrs: [
           multiaddr('/ip4/127.0.0.1/tcp/1234')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
       yield {
         id: (await ed25519Crypto().generatePrivateKey()).publicKey.toCID(),
         multiaddrs: [
           multiaddr('/ip4/127.0.0.1/udp/1234/quic-v1')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
       yield {
         id: (await ed25519Crypto().generatePrivateKey()).publicKey.toCID(),
         multiaddrs: [
           uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
     }())
 
@@ -102,7 +106,8 @@ describe('trustless-gateway sessions', () => {
       multiaddrs: [
         uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }
 
     components.routing.findProviders.returns(async function * () {
@@ -136,7 +141,8 @@ describe('trustless-gateway sessions', () => {
         multiaddrs: [
           uriToMultiaddr(process.env.BAD_TRUSTLESS_GATEWAY ?? '')
         ],
-        router: 'test-routing'
+        router: 'test-routing',
+        fallback: false
       }
     }())
 
@@ -157,14 +163,16 @@ describe('trustless-gateway sessions', () => {
       multiaddrs: [
         uriToMultiaddr(process.env.BAD_TRUSTLESS_GATEWAY ?? '')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     },
     {
       id: (await ed25519Crypto().generatePrivateKey()).publicKey.toCID(),
       multiaddrs: [
         uriToMultiaddr(process.env.TRUSTLESS_GATEWAY ?? '')
       ],
-      router: 'test-routing'
+      router: 'test-routing',
+      fallback: false
     }]
 
     components.routing.findProviders.returns(async function * () {

--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -24,13 +24,17 @@ export interface BlockstoreSessionEvents<Provider> {
   provider: CustomEvent<Provider>
 }
 
+export interface SessionProvider {
+  fallback: boolean
+}
+
 interface Request {
   promise: Promise<Uint8Array>
   observers: number
   queryFilter: Filter
 }
 
-export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents extends ProgressEvent> extends TypedEventEmitter<BlockstoreSessionEvents<Provider>> implements BlockBroker<RetrieveBlockProgressEvents> {
+export abstract class AbstractSession<Provider extends SessionProvider, RetrieveBlockProgressEvents extends ProgressEvent> extends TypedEventEmitter<BlockstoreSessionEvents<Provider>> implements BlockBroker<RetrieveBlockProgressEvents> {
   public abstract name: string
   private initialPeerSearchComplete?: Promise<void>
   private readonly requests: Map<string, Request>
@@ -97,12 +101,18 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
       concurrency: this.maxProviders
     })
     queue.addEventListener('failure', (evt) => {
-      if (evt.detail.error.name === 'NoEvictionError') {
-        this.log.error('error querying provider %s - %e', evt.detail.job.options.provider, evt.detail.error)
-      } else {
-        this.log.error('error querying provider %s, evicting from session - %e', evt.detail.job.options.provider, evt.detail.error)
-        this.evict(evt.detail.job.options.provider)
+      if (evt.detail.job.options.provider.fallback) {
+        this.log.error('error querying fallback provider %s - %e', evt.detail.job.options.provider, evt.detail.error)
+        return
       }
+
+      if (evt.detail.error.name === 'NoEvictionError') {
+        this.log.error('no-eviction error querying provider %s - %e', evt.detail.job.options.provider, evt.detail.error)
+        return
+      }
+
+      this.log.error('error querying provider %s, evicting from session - %e', evt.detail.job.options.provider, evt.detail.error)
+      this.evict(evt.detail.job.options.provider)
     })
     queue.addEventListener('success', (evt) => {
       // peer has sent block, return it to the caller
@@ -133,6 +143,12 @@ export abstract class AbstractSession<Provider, RetrieveBlockProgressEvents exte
             }
 
             const provider = this.providers[Math.floor(Math.random() * this.providers.length)]
+
+            // do not evict fallback peer
+            if (provider.fallback) {
+              continue
+            }
+
             this.log('evicting %s to make room for more providers', provider)
             this.evict(provider)
           }

--- a/packages/utils/test/abstract-session.spec.ts
+++ b/packages/utils/test/abstract-session.spec.ts
@@ -16,6 +16,7 @@ import type { ProgressEvent } from 'progress-events'
 
 interface SessionPeer {
   id: PeerId
+  fallback: boolean
 }
 
 class Session extends AbstractSession<SessionPeer, ProgressEvent> {
@@ -43,7 +44,8 @@ class Session extends AbstractSession<SessionPeer, ProgressEvent> {
   async convertToProvider (provider: CID | Multiaddr | Multiaddr[]): Promise<SessionPeer | undefined> {
     if (isPeerId(provider)) {
       return {
-        id: provider
+        id: provider,
+        fallback: false
       }
     }
   }
@@ -77,9 +79,11 @@ describe('abstract-session', () => {
     const block = Uint8Array.from([0, 1, 2, 3])
 
     const providers: SessionPeer[] = [{
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }, {
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }]
 
     session.findNewProviders.callsFake(async function * () {
@@ -111,9 +115,11 @@ describe('abstract-session', () => {
     const block = Uint8Array.from([0, 1, 2, 3])
 
     const providers: SessionPeer[] = [{
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }, {
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }]
 
     session.findNewProviders.callsFake(async function * () {
@@ -137,9 +143,11 @@ describe('abstract-session', () => {
     const block = Uint8Array.from([0, 1, 2, 3])
 
     const providers: SessionPeer[] = [{
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }, {
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }]
 
     session.findNewProviders.callsFake(async function * () {
@@ -147,6 +155,35 @@ describe('abstract-session', () => {
     })
     session.queryProvider.withArgs(cid, providers[0]).callsFake(async () => {
       throw new NoEvictionError('Urk!')
+    })
+    session.queryProvider.withArgs(cid, providers[1]).callsFake(async () => {
+      return block
+    })
+
+    await expect(session.retrieve(cid)).to.eventually.deep.equal(block)
+    expect(session.providers.includes(providers[0])).to.be.true()
+    expect(session.providers.includes(providers[1])).to.be.true()
+  })
+
+  it('should not evict fallback session providers', async () => {
+    const session = new Session()
+
+    const cid = CID.parse('bafybeifaymukvfkyw6xgh4th7tsctiifr4ea2btoznf46y6b2fnvikdczi')
+    const block = Uint8Array.from([0, 1, 2, 3])
+
+    const providers: SessionPeer[] = [{
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: true
+    }, {
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
+    }]
+
+    session.findNewProviders.callsFake(async function * () {
+      yield * providers
+    })
+    session.queryProvider.withArgs(cid, providers[0]).callsFake(async () => {
+      throw new Error('Urk!')
     })
     session.queryProvider.withArgs(cid, providers[1]).callsFake(async () => {
       return block
@@ -220,9 +257,11 @@ describe('abstract-session', () => {
     const block = Uint8Array.from([0, 1, 2, 3])
 
     const providers: SessionPeer[] = [{
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }, {
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }]
 
     session.findNewProviders.onFirstCall().callsFake(async function * () {
@@ -250,9 +289,11 @@ describe('abstract-session', () => {
     const block = Uint8Array.from([0, 1, 2, 3])
 
     const providers: SessionPeer[] = [{
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }, {
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }]
 
     session.findNewProviders.onFirstCall().callsFake(async function * () {
@@ -333,9 +374,11 @@ describe('abstract-session', () => {
     const block = Uint8Array.from([0, 1, 2, 3])
 
     const providers: SessionPeer[] = [{
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }, {
-      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519'))
+      id: peerIdFromPrivateKey(await generateKeyPair('Ed25519')),
+      fallback: false
     }]
 
     session.findNewProviders.callsFake(async function * () {


### PR DESCRIPTION
If a session contains a fallback provider, do not evict it as this peer should be queried again in the future.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
