### PR TITLE
fix: add helia user agent to libp2p

### DIFF
--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -40,16 +40,42 @@ export interface HeliaWithLibp2p<M extends ServiceMap = DefaultLibp2pServices> e
 }
 
 async function getLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): Promise<Libp2p<M>> {
+  let node: Libp2p<M>
+
   if (isLibp2p(opts)) {
-    return opts as any
+    node = opts as any
+  } else {
+    node = await createLibp2p(helia, {
+      ...opts,
+      dns: helia.dns,
+      logger: helia.logger,
+      datastore: helia.datastore
+    })
   }
 
-  return createLibp2p(helia, {
-    ...opts,
-    dns: helia.dns,
-    logger: helia.logger,
-    datastore: helia.datastore
-  })
+  return addHeliaVersion(node, helia)
+}
+
+function addHeliaVersion (libp2p: Libp2p<any>, helia: Helia): Libp2p<any> {
+  function isIdentify (service: any): service is { host: { agentVersion: string } } {
+    return typeof service?.host?.agentVersion === 'string'
+  }
+
+  const userAgent = `${helia.info.name}/${helia.info.version}`
+
+  // @ts-expect-error private field
+  if (libp2p.components?.nodeInfo?.userAgent?.includes(userAgent) === false) {
+    // @ts-expect-error private field
+    libp2p.components.nodeInfo.userAgent = `${userAgent} ${libp2p.components.nodeInfo.userAgent}`
+  }
+
+  for (const service of Object.values(libp2p.services)) {
+    if (isIdentify(service) && service.host.agentVersion.includes(userAgent) === false) {
+      service.host.agentVersion = `${userAgent} ${service.host.agentVersion}`
+    }
+  }
+
+  return libp2p
 }
 
 /**

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -19,6 +19,7 @@ import { NotStartedError } from '@libp2p/interface'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import forEach from 'it-foreach'
 import { isLibp2p } from 'libp2p'
+import { userAgent } from 'libp2p/user-agent'
 import { libp2pRouting } from './routing.ts'
 import { createLibp2p } from './utils/libp2p.ts'
 import type { DefaultLibp2pServices } from './utils/libp2p-defaults.ts'
@@ -61,17 +62,17 @@ function addHeliaVersion (libp2p: Libp2p<any>, helia: Helia): Libp2p<any> {
     return typeof service?.host?.agentVersion === 'string'
   }
 
-  const userAgent = `${helia.info.name}/${helia.info.version}`
+  const heliaAgent = `${helia.info.name}/${helia.info.version}`
 
   // @ts-expect-error private field
-  if (libp2p.components?.nodeInfo?.userAgent?.includes(userAgent) === false) {
+  if (libp2p.components?.nodeInfo?.userAgent === userAgent()) {
     // @ts-expect-error private field
-    libp2p.components.nodeInfo.userAgent = `${userAgent} ${libp2p.components.nodeInfo.userAgent}`
+    libp2p.components.nodeInfo.userAgent = `${heliaAgent} ${libp2p.components.nodeInfo.userAgent}`
   }
 
   for (const service of Object.values(libp2p.services)) {
-    if (isIdentify(service) && service.host.agentVersion.includes(userAgent) === false) {
-      service.host.agentVersion = `${userAgent} ${service.host.agentVersion}`
+    if (isIdentify(service) && service.host.agentVersion === userAgent()) {
+      service.host.agentVersion = `${heliaAgent} ${service.host.agentVersion}`
     }
   }
 

--- a/packages/libp2p/test/index.spec.ts
+++ b/packages/libp2p/test/index.spec.ts
@@ -1,3 +1,5 @@
+import { identify, identifyPush } from '@libp2p/identify'
+import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { defaultLogger } from 'birnam'
 import { MemoryDatastore } from 'datastore-core'
@@ -5,10 +7,12 @@ import { createLibp2p, isLibp2p } from 'libp2p'
 import { stubInterface } from 'sinon-ts'
 import { withLibp2p } from '../src/index.ts'
 import type { HeliaWithLibp2p } from '../src/index.ts'
+import type { Libp2p } from '@libp2p/interface'
 import type { StubbedInstance } from 'sinon-ts'
 
 describe('@helia/libp2p', () => {
   let helia: StubbedInstance<HeliaWithLibp2p<any>>
+  let libp2p: Libp2p | undefined
 
   beforeEach(() => {
     helia = withLibp2p(stubInterface<any>({
@@ -20,6 +24,7 @@ describe('@helia/libp2p', () => {
 
   afterEach(async () => {
     await helia.addMixin.getCall(0).args[0]?.stop?.(helia)
+    await stop(libp2p)
   })
 
   it('should add a mixin', async () => {
@@ -32,7 +37,7 @@ describe('@helia/libp2p', () => {
   })
 
   it('allows passing a libp2p node', async () => {
-    const libp2p = await createLibp2p()
+    libp2p = await createLibp2p()
 
     helia = withLibp2p(stubInterface<any>({
       datastore: new MemoryDatastore(),
@@ -43,5 +48,29 @@ describe('@helia/libp2p', () => {
     await helia.addMixin.getCall(0).args[0]?.start?.(helia)
 
     expect(helia.libp2p).to.equal(libp2p)
+  })
+
+  it('should add helia version to identify agent', async () => {
+    libp2p = await createLibp2p({
+      services: {
+        identify: identify(),
+        identifyPush: identifyPush()
+      }
+    })
+
+    helia = withLibp2p(stubInterface<any>({
+      datastore: new MemoryDatastore(),
+      logger: defaultLogger(),
+      routing: stubInterface(),
+      info: {
+        name: 'helia',
+        version: '1.0.0'
+      }
+    }), libp2p)
+
+    await helia.addMixin.getCall(0).args[0]?.start?.(helia)
+
+    expect(helia.libp2p.services.identify.host.agentVersion).to.include('helia/1.0.0')
+    expect(helia.libp2p.services.identifyPush.host.agentVersion).to.include('helia/1.0.0')
   })
 })


### PR DESCRIPTION
Fix regression where helia version was not prepended to identify agent

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
