### PR TITLE
fix: remove per-request queue listeners in abstract session

### DIFF
--- a/packages/utils/src/abstract-session.ts
+++ b/packages/utils/src/abstract-session.ts
@@ -6,7 +6,7 @@ import pDefer from 'p-defer'
 import { raceSignal } from 'race-signal'
 import type { BlockBroker, BlockRetrievalOptions, CreateSessionOptions } from '@helia/interface'
 import type { AbortOptions, ComponentLogger, Logger } from '@libp2p/interface'
-import type { Filter } from '@libp2p/utils'
+import type { Filter, QueueJobFailure, QueueJobSuccess } from '@libp2p/utils'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { CID } from 'multiformats/cid'
 import type { DeferredPromise } from 'p-defer'
@@ -97,10 +97,12 @@ export abstract class AbstractSession<Provider extends SessionProvider, Retrieve
     // this queue manages outgoing requests - as new peers are added to the
     // session they will be added to the queue so we can request the current
     // block from multiple peers as they are discovered
-    const queue = new Queue<Uint8Array, { provider: Provider, priority?: number } & AbortOptions>({
+    type QueueJobOptions = { provider: Provider, priority?: number } & AbortOptions
+
+    const queue = new Queue<Uint8Array, QueueJobOptions>({
       concurrency: this.maxProviders
     })
-    queue.addEventListener('failure', (evt) => {
+    const queueFailureListener = (evt: CustomEvent<QueueJobFailure<Uint8Array, QueueJobOptions>>): void => {
       if (evt.detail.job.options.provider.fallback) {
         this.log.error('error querying fallback provider %s - %e', evt.detail.job.options.provider, evt.detail.error)
         return
@@ -113,13 +115,17 @@ export abstract class AbstractSession<Provider extends SessionProvider, Retrieve
 
       this.log.error('error querying provider %s, evicting from session - %e', evt.detail.job.options.provider, evt.detail.error)
       this.evict(evt.detail.job.options.provider)
-    })
-    queue.addEventListener('success', (evt) => {
+    }
+    queue.addEventListener('failure', queueFailureListener)
+
+    const queueSuccessListener = (evt: CustomEvent<QueueJobSuccess<Uint8Array, QueueJobOptions>>): void => {
       // peer has sent block, return it to the caller
       foundBlock = true
       deferred.resolve(evt.detail.result)
-    })
-    queue.addEventListener('idle', () => {
+    }
+    queue.addEventListener('success', queueSuccessListener)
+
+    const queueIdleListener = (): void => {
       if (foundBlock) {
         this.log.trace('session idle, found block')
         // we either found the block or the user gave up
@@ -165,7 +171,8 @@ export abstract class AbstractSession<Provider extends SessionProvider, Retrieve
           this.log.error('could not find new providers for %c - %e', cid, err)
           deferred.reject(err)
         })
-    })
+    }
+    queue.addEventListener('idle', queueIdleListener)
 
     const peerAddedToSessionListener = (event: CustomEvent<Provider>): void => {
       const filterKey = this.toFilterKey(event.detail)
@@ -264,6 +271,14 @@ export abstract class AbstractSession<Provider extends SessionProvider, Retrieve
     } finally {
       this.removeEventListener('provider', peerAddedToSessionListener)
       options.signal?.removeEventListener('abort', signalAbortedListener)
+      // a new Queue is created for every retrieve() call, so its listeners have to
+      // be detached too. Queue extends TypedEventEmitter, which extends the native
+      // EventTarget - in a browser a listener-bearing EventTarget is kept alive by
+      // its own wrapper, so without this every queue ever created stays a GC root
+      // along with the jobs, provider records and promise chains it captured.
+      queue.removeEventListener('failure', queueFailureListener)
+      queue.removeEventListener('success', queueSuccessListener)
+      queue.removeEventListener('idle', queueIdleListener)
       queue.clear()
       this.requests.delete(cidStr)
     }


### PR DESCRIPTION
> [!IMPORTANT]
> **Reframed 2026-08-12: this is hygiene, not a leak fix.** The justification I originally gave
> was wrong — see the retraction on #1101. A listener-bearing `EventTarget` *is* collected in
> Gecko; the cycle collector reclaims it. Measured with a `FinalizationRegistry`, a real
> `Queue` with all three of these listeners still attached and nothing else referencing it is
> collected 100% of the time. The queues that *were* being retained were held by a separate
> `main-event` bug, and patching that releases them whether or not this PR is applied.
>
> Retracted specifically: "every queue stays a GC root", the 53.5%-of-live-heap figure, and
> the ~930/h rate.

## What the change is for

`AbstractSession.retrieve()` adds three listeners to a per-request `Queue` and never removes
them, while removing the `provider` and `abort` listeners a few lines away in the same
`finally`. This makes the teardown consistent: what the method registers, the method releases.

It is worth having on its own terms — cleanup should not depend on the surrounding collector
being clever enough to make the omission harmless — but I want to be straight that it does not
fix a measured leak, and you should feel free to close it if you would rather not carry the
extra bookkeeping for that.

## Notes

- The three handlers were inline arrow functions; they are now named consts, which is the only
  reason the diff looks larger than three added lines.
- Event types come from `QueueJobFailure` / `QueueJobSuccess`, already exported from
  `@libp2p/utils`; the queue's job-options type is pulled into a local alias so the listener
  signatures can reuse it.
- No test: with the mechanism claim retracted there is no observable behaviour to pin here
  beyond "the listener list is empty afterwards", which `listenerCount()` already reports.
- `packages/utils` does not typecheck from a clean `npm install` on `main` (unbuilt
  `@helia/interface` siblings); I verified this change introduces no new diagnostics in
  `abstract-session.ts` beyond those already present.
