### PR TITLE
feat: add IPNS publish strategy completion events

### DIFF
--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -172,6 +172,7 @@ export type {
 
 export type PublishProgressEvents =
   ProgressEvent<'ipns:publish:start'> |
+  ProgressEvent<'ipns:publish:strategy:success', IPNSPublishStrategyResult> |
   ProgressEvent<'ipns:publish:success', IPNSEntry> |
   ProgressEvent<'ipns:publish:error', Error>
 
@@ -302,6 +303,23 @@ export interface IPNSPublishResult {
    * The public key that was used to sign and publish the record
    */
   publicKey: PublicKey
+}
+
+export interface IPNSPublishStrategyResult {
+  /**
+   * The name of the publishing strategy that completed.
+   */
+  strategy: string
+
+  /**
+   * The routing key the IPNS record was published under.
+   */
+  routingKey: Uint8Array
+
+  /**
+   * The published record.
+   */
+  record: IPNSEntry
 }
 
 export interface IPNSResolver {

--- a/packages/ipns/src/index.ts
+++ b/packages/ipns/src/index.ts
@@ -170,9 +170,13 @@ export type {
   CreateIPNSRecordOptions
 } from './records.ts'
 
+export type PublishStrategyProgressEvents =
+  ProgressEvent<'ipns:publish:strategy:start', IPNSPublishStrategyDetail> |
+  ProgressEvent<'ipns:publish:strategy:success', IPNSPublishStrategyDetail> |
+  ProgressEvent<'ipns:publish:strategy:error', Error>
+
 export type PublishProgressEvents =
   ProgressEvent<'ipns:publish:start'> |
-  ProgressEvent<'ipns:publish:strategy:success', IPNSPublishStrategyResult> |
   ProgressEvent<'ipns:publish:success', IPNSEntry> |
   ProgressEvent<'ipns:publish:error', Error>
 
@@ -187,7 +191,7 @@ export type DatastoreProgressEvents =
   ProgressEvent<'ipns:routing:datastore:list'> |
   ProgressEvent<'ipns:routing:datastore:error', Error>
 
-export interface PublishOptions extends AbortOptions, ProgressOptions<PublishProgressEvents | IPNSRoutingProgressEvents> {
+export interface PublishOptions extends AbortOptions, ProgressOptions<PublishProgressEvents | PublishStrategyProgressEvents | IPNSRoutingProgressEvents> {
   /**
    * Time duration of the signature validity in ms - after this many ms have
    * expired the record will be invalidated.
@@ -305,16 +309,21 @@ export interface IPNSPublishResult {
   publicKey: PublicKey
 }
 
-export interface IPNSPublishStrategyResult {
+export interface IPNSPublishStrategyDetail {
   /**
-   * The name of the publishing strategy that completed.
+   * The name of the publishing strategy.
    */
   strategy: string
 
   /**
-   * The routing key the IPNS record was published under.
+   * The key name used to publish the record.
    */
-  routingKey: Uint8Array
+  keyName: string
+
+  /**
+   * The public key that was used to sign and publish the record.
+   */
+  publicKey: PublicKey
 
   /**
    * The published record.

--- a/packages/ipns/src/ipns/publisher.ts
+++ b/packages/ipns/src/ipns/publisher.ts
@@ -4,7 +4,7 @@ import { DEFAULT_LIFETIME_MS } from '../constants.ts'
 import { IPNSEntry } from '../pb/ipns.ts'
 import { createIPNSRecord } from '../records.ts'
 import { decodeExtensibleData, multihashToIPNSRoutingKey } from '../utils.ts'
-import type { IPNSPublishResult, PublishOptions } from '../index.ts'
+import type { IPNSPublishResult, IPNSPublishStrategyResult, PublishOptions } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
 import type { Keychain, PrivateKey } from '@helia/interface'
@@ -35,6 +35,8 @@ export class IPNSPublisher {
 
   async publish (keyName: string, value: string, options: PublishOptions = {}): Promise<IPNSPublishResult> {
     try {
+      options.onProgress?.(new CustomProgressEvent('ipns:publish:start'))
+
       const key = await this.#loadOrCreateKey(keyName, options)
       const digest = key.publicKey.toMultihash()
       const routingKey = multihashToIPNSRoutingKey(digest)
@@ -65,6 +67,8 @@ export class IPNSPublisher {
             lifetime
           }
         })
+
+        this.#publishStrategySuccess('LocalStoreRouting()', routingKey, record, options)
       } else {
         // publish record to routing (including the local store)
         await Promise.all(this.routers.map(async r => {
@@ -75,8 +79,12 @@ export class IPNSPublisher {
               lifetime
             }
           })
+
+          this.#publishStrategySuccess(this.#strategyName(r), routingKey, record, options)
         }))
       }
+
+      options.onProgress?.(new CustomProgressEvent<IPNSEntry>('ipns:publish:success', record))
 
       return {
         record,
@@ -104,6 +112,28 @@ export class IPNSPublisher {
         throw err
       }
     }
+  }
+
+  #publishStrategySuccess (strategy: string, routingKey: Uint8Array, record: IPNSEntry, options: PublishOptions): void {
+    options.onProgress?.(new CustomProgressEvent<IPNSPublishStrategyResult>('ipns:publish:strategy:success', {
+      strategy,
+      routingKey,
+      record
+    }))
+  }
+
+  #strategyName (router: IPNSRouting): string {
+    if (router.toString === Object.prototype.toString) {
+      return 'CustomRouting()'
+    }
+
+    const strategy = router.toString()
+
+    if (typeof strategy !== 'string' || strategy === '') {
+      return 'CustomRouting()'
+    }
+
+    return strategy
   }
 
   async unpublish (keyName: string, options?: AbortOptions): Promise<void> {

--- a/packages/ipns/src/ipns/publisher.ts
+++ b/packages/ipns/src/ipns/publisher.ts
@@ -4,12 +4,13 @@ import { DEFAULT_LIFETIME_MS } from '../constants.ts'
 import { IPNSEntry } from '../pb/ipns.ts'
 import { createIPNSRecord } from '../records.ts'
 import { decodeExtensibleData, multihashToIPNSRoutingKey } from '../utils.ts'
-import type { IPNSPublishResult, IPNSPublishStrategyResult, PublishOptions } from '../index.ts'
+import type { IPNSPublishResult, IPNSPublishStrategyDetail, PublishOptions, PublishStrategyProgressEvents } from '../index.ts'
 import type { LocalStore } from '../local-store.ts'
 import type { IPNSRouting } from '../routing/index.ts'
 import type { Keychain, PrivateKey } from '@helia/interface'
 import type { AbortOptions, ComponentLogger } from '@libp2p/interface'
 import type { Datastore } from 'interface-datastore'
+import type { ProgressOptions } from 'progress-events'
 
 export interface IPNSPublisherComponents {
   datastore: Datastore
@@ -59,28 +60,38 @@ export class IPNSPublisher {
       const marshaledRecord = IPNSEntry.encode(record)
 
       if (options.offline === true) {
-        // only store record locally
-        await this.localStore.put(routingKey, marshaledRecord, {
-          ...options,
-          metadata: {
-            keyName,
-            lifetime
-          }
-        })
-
-        this.#publishStrategySuccess('LocalStoreRouting()', routingKey, record, options)
-      } else {
-        // publish record to routing (including the local store)
-        await Promise.all(this.routers.map(async r => {
-          await r.put(routingKey, marshaledRecord, {
+        await withStrategyProgressEvents({
+          strategy: 'LocalStoreRouting()',
+          keyName,
+          publicKey: key.publicKey,
+          record
+        }, options, async () => {
+          // only store record locally
+          await this.localStore.put(routingKey, marshaledRecord, {
             ...options,
             metadata: {
               keyName,
               lifetime
             }
           })
-
-          this.#publishStrategySuccess(this.#strategyName(r), routingKey, record, options)
+        })
+      } else {
+        // publish record to routing (including the local store)
+        await Promise.all(this.routers.map(async r => {
+          await withStrategyProgressEvents({
+            strategy: strategyName(r),
+            keyName,
+            publicKey: key.publicKey,
+            record
+          }, options, async () => {
+            await r.put(routingKey, marshaledRecord, {
+              ...options,
+              metadata: {
+                keyName,
+                lifetime
+              }
+            })
+          })
         }))
       }
 
@@ -114,32 +125,36 @@ export class IPNSPublisher {
     }
   }
 
-  #publishStrategySuccess (strategy: string, routingKey: Uint8Array, record: IPNSEntry, options: PublishOptions): void {
-    options.onProgress?.(new CustomProgressEvent<IPNSPublishStrategyResult>('ipns:publish:strategy:success', {
-      strategy,
-      routingKey,
-      record
-    }))
-  }
-
-  #strategyName (router: IPNSRouting): string {
-    if (router.toString === Object.prototype.toString) {
-      return 'CustomRouting()'
-    }
-
-    const strategy = router.toString()
-
-    if (typeof strategy !== 'string' || strategy === '') {
-      return 'CustomRouting()'
-    }
-
-    return strategy
-  }
-
   async unpublish (keyName: string, options?: AbortOptions): Promise<void> {
     const key = await this.keychain.exportKey(keyName, options)
     const digest = key.publicKey.toMultihash()
     const routingKey = multihashToIPNSRoutingKey(digest)
     await this.localStore.delete(routingKey, options)
   }
+}
+
+async function withStrategyProgressEvents (detail: IPNSPublishStrategyDetail, options: ProgressOptions<PublishStrategyProgressEvents>, fn: () => unknown): Promise<void> {
+  options.onProgress?.(new CustomProgressEvent<IPNSPublishStrategyDetail, 'ipns:publish:strategy:start'>('ipns:publish:strategy:start', detail))
+
+  try {
+    await fn()
+    options.onProgress?.(new CustomProgressEvent<IPNSPublishStrategyDetail, 'ipns:publish:strategy:success'>('ipns:publish:strategy:success', detail))
+  } catch (err: any) {
+    options.onProgress?.(new CustomProgressEvent<Error, 'ipns:publish:strategy:error'>('ipns:publish:strategy:error', err))
+    throw err
+  }
+}
+
+function strategyName (router: IPNSRouting): string {
+  if (router.toString === Object.prototype.toString) {
+    return 'CustomRouting()'
+  }
+
+  const strategy = router.toString()
+
+  if (typeof strategy !== 'string' || strategy === '') {
+    return 'CustomRouting()'
+  }
+
+  return strategy
 }

--- a/packages/ipns/src/local-store.ts
+++ b/packages/ipns/src/local-store.ts
@@ -73,6 +73,7 @@ export function localStore (datastore: Datastore, log: Logger): LocalStore {
         // Marshal to libp2p record as the DHT does
         const record = new Record(routingKey, marshalledRecord, new Date())
 
+        options.onProgress?.(new CustomProgressEvent('ipns:routing:datastore:put'))
         const batch = datastore.batch()
         batch.put(key, record.serialize())
 
@@ -81,7 +82,6 @@ export function localStore (datastore: Datastore, log: Logger): LocalStore {
           batch.put(ipnsMetadataKey(routingKey), IPNSPublishMetadata.encode(options.metadata))
         }
         await batch.commit(options)
-        options.onProgress?.(new CustomProgressEvent('ipns:routing:datastore:put'))
       } catch (err: any) {
         options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:datastore:error', err))
         throw err

--- a/packages/ipns/src/local-store.ts
+++ b/packages/ipns/src/local-store.ts
@@ -73,7 +73,6 @@ export function localStore (datastore: Datastore, log: Logger): LocalStore {
         // Marshal to libp2p record as the DHT does
         const record = new Record(routingKey, marshalledRecord, new Date())
 
-        options.onProgress?.(new CustomProgressEvent('ipns:routing:datastore:put'))
         const batch = datastore.batch()
         batch.put(key, record.serialize())
 
@@ -82,6 +81,7 @@ export function localStore (datastore: Datastore, log: Logger): LocalStore {
           batch.put(ipnsMetadataKey(routingKey), IPNSPublishMetadata.encode(options.metadata))
         }
         await batch.commit(options)
+        options.onProgress?.(new CustomProgressEvent('ipns:routing:datastore:put'))
       } catch (err: any) {
         options.onProgress?.(new CustomProgressEvent<Error>('ipns:routing:datastore:error', err))
         throw err

--- a/packages/ipns/test/publish.spec.ts
+++ b/packages/ipns/test/publish.spec.ts
@@ -90,12 +90,62 @@ describe('publish', () => {
 
   it('should emit progress events', async function () {
     const keyName = 'test-key-5'
-    const onProgress = Sinon.stub()
+    const progressEvents: any[] = []
     await name.publish(keyName, cid, {
-      onProgress
+      onProgress: (evt) => progressEvents.push(evt)
     })
 
-    expect(onProgress).to.have.property('called', true)
+    const eventTypes = progressEvents.map(evt => evt.type)
+
+    expect(eventTypes).to.include('ipns:publish:start')
+    expect(eventTypes).to.include('ipns:routing:datastore:put')
+    expect(eventTypes).to.include('ipns:publish:success')
+
+    const strategySuccessEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:success')
+
+    expect(strategySuccessEvents).to.have.length(3)
+    expect(strategySuccessEvents.map(evt => evt.detail.strategy)).to.include('LocalStoreRouting()')
+    expect(strategySuccessEvents.map(evt => evt.detail.strategy)).to.include('HeliaRouting()')
+    expect(strategySuccessEvents.map(evt => evt.detail.strategy)).to.include('CustomRouting()')
+  })
+
+  it('should emit only the local publish strategy event when publishing offline', async function () {
+    const keyName = 'test-key-offline-progress'
+    const progressEvents: any[] = []
+
+    await name.publish(keyName, cid, {
+      offline: true,
+      onProgress: (evt) => progressEvents.push(evt)
+    })
+
+    const strategySuccessEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:success')
+
+    expect(strategySuccessEvents).to.have.length(1)
+    expect(strategySuccessEvents[0].detail.strategy).to.equal('LocalStoreRouting()')
+  })
+
+  it('should emit datastore put progress after the batch is committed', async function () {
+    const store = localStore(result.datastore, result.log)
+    const progressEvents: any[] = []
+    let committed = false
+
+    const batch = {
+      put: Sinon.stub(),
+      delete: Sinon.stub(),
+      commit: Sinon.stub().callsFake(async () => {
+        expect(progressEvents.map(evt => evt.type)).to.not.include('ipns:routing:datastore:put')
+        committed = true
+      })
+    }
+
+    Sinon.stub(result.datastore, 'batch').returns(batch as any)
+
+    await store.put(uint8ArrayFromString('routing-key'), uint8ArrayFromString('record'), {
+      onProgress: (evt) => progressEvents.push(evt)
+    })
+
+    expect(committed).to.be.true()
+    expect(progressEvents.map(evt => evt.type)).to.include('ipns:routing:datastore:put')
   })
 
   it('should publish an IPNS record extensible metadata', async function () {

--- a/packages/ipns/test/publish.spec.ts
+++ b/packages/ipns/test/publish.spec.ts
@@ -91,7 +91,7 @@ describe('publish', () => {
   it('should emit progress events', async function () {
     const keyName = 'test-key-5'
     const progressEvents: any[] = []
-    await name.publish(keyName, cid, {
+    const publishResult = await name.publish(keyName, cid, {
       onProgress: (evt) => progressEvents.push(evt)
     })
 
@@ -101,51 +101,47 @@ describe('publish', () => {
     expect(eventTypes).to.include('ipns:routing:datastore:put')
     expect(eventTypes).to.include('ipns:publish:success')
 
+    const strategyStartEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:start')
     const strategySuccessEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:success')
+    const strategyErrorEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:error')
 
+    expect(strategyStartEvents).to.have.length(3)
     expect(strategySuccessEvents).to.have.length(3)
-    expect(strategySuccessEvents.map(evt => evt.detail.strategy)).to.include('LocalStoreRouting()')
-    expect(strategySuccessEvents.map(evt => evt.detail.strategy)).to.include('HeliaRouting()')
-    expect(strategySuccessEvents.map(evt => evt.detail.strategy)).to.include('CustomRouting()')
+    expect(strategyErrorEvents).to.be.empty()
+
+    for (const events of [strategyStartEvents, strategySuccessEvents]) {
+      expect(events.map(evt => evt.detail.strategy)).to.include('LocalStoreRouting()')
+      expect(events.map(evt => evt.detail.strategy)).to.include('HeliaRouting()')
+      expect(events.map(evt => evt.detail.strategy)).to.include('CustomRouting()')
+    }
+
+    for (const evt of [...strategyStartEvents, ...strategySuccessEvents]) {
+      expect(evt.detail).to.have.property('keyName', keyName)
+      expect(evt.detail).to.have.property('publicKey', publishResult.publicKey)
+    }
   })
 
   it('should emit only the local publish strategy event when publishing offline', async function () {
     const keyName = 'test-key-offline-progress'
     const progressEvents: any[] = []
 
-    await name.publish(keyName, cid, {
+    const publishResult = await name.publish(keyName, cid, {
       offline: true,
       onProgress: (evt) => progressEvents.push(evt)
     })
 
+    const strategyStartEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:start')
     const strategySuccessEvents = progressEvents.filter(evt => evt.type === 'ipns:publish:strategy:success')
 
+    expect(strategyStartEvents).to.have.length(1)
+    expect(strategyStartEvents[0].detail.strategy).to.equal('LocalStoreRouting()')
     expect(strategySuccessEvents).to.have.length(1)
     expect(strategySuccessEvents[0].detail.strategy).to.equal('LocalStoreRouting()')
-  })
 
-  it('should emit datastore put progress after the batch is committed', async function () {
-    const store = localStore(result.datastore, result.log)
-    const progressEvents: any[] = []
-    let committed = false
-
-    const batch = {
-      put: Sinon.stub(),
-      delete: Sinon.stub(),
-      commit: Sinon.stub().callsFake(async () => {
-        expect(progressEvents.map(evt => evt.type)).to.not.include('ipns:routing:datastore:put')
-        committed = true
-      })
+    for (const evt of [...strategyStartEvents, ...strategySuccessEvents]) {
+      expect(evt.detail).to.have.property('keyName', keyName)
+      expect(evt.detail).to.have.property('publicKey', publishResult.publicKey)
     }
-
-    Sinon.stub(result.datastore, 'batch').returns(batch as any)
-
-    await store.put(uint8ArrayFromString('routing-key'), uint8ArrayFromString('record'), {
-      onProgress: (evt) => progressEvents.push(evt)
-    })
-
-    expect(committed).to.be.true()
-    expect(progressEvents.map(evt => evt.type)).to.include('ipns:routing:datastore:put')
   })
 
   it('should publish an IPNS record extensible metadata', async function () {
@@ -364,6 +360,10 @@ describe('publish', () => {
       const errorEvent = progressEvents.find(evt => evt.type === 'ipns:routing:datastore:error')
       expect(errorEvent).to.exist()
       expect(errorEvent.detail.message).to.equal('Storage error')
+
+      const strategyErrorEvent = progressEvents.find(evt => evt.type === 'ipns:publish:strategy:error')
+      expect(strategyErrorEvent).to.exist()
+      expect(strategyErrorEvent.detail.message).to.equal('Storage error')
     })
 
     it('should handle network timeouts in localStore', async () => {


### PR DESCRIPTION
## Title

feat: add IPNS publish strategy completion events

## Description

Fixes https://github.com/ipfs/helia/issues/959.

Adds a publish progress event that fires after each IPNS publishing strategy has completed. This lets callers distinguish between local persistence, Helia routing publication, and any custom routing strategies finishing.

This also addresses the behavior requested in https://github.com/ipfs/helia/issues/945 by moving the `ipns:routing:datastore:put` progress event so it is emitted after the datastore batch commit completes. Callers can now wait for the local IPNS record to be persisted without needing to wait for slower network publishing such as DHT publication.

Changes include:

- add `ipns:publish:strategy:success`
- include the completed strategy name, routing key, and IPNS record in the event detail
- emit strategy completion after each router `put(...)` resolves
- emit a local strategy completion event for offline publishing
- emit `ipns:routing:datastore:put` after local datastore commit
- add tests for online strategy completion, offline local-only completion, and datastore post-commit timing

## Notes & open questions

The new strategy completion event uses a single event type, `ipns:publish:strategy:success`, with the completed strategy identified in `evt.detail.strategy`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
