### PR TITLE
fix!: only accept libp2p config, not running nodes

### DIFF
--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -70,7 +70,6 @@
     "@ipld/dag-json": "^11.0.0",
     "@ipld/dag-pb": "^4.1.7",
     "@libp2p/floodsub": "^11.0.23",
-    "@libp2p/identify": "^4.1.8",
     "@libp2p/interface": "^3.2.3",
     "@libp2p/kad-dht": "^16.3.2",
     "@libp2p/keychain": "^6.1.2",

--- a/packages/interop/src/libp2p.spec.ts
+++ b/packages/interop/src/libp2p.spec.ts
@@ -3,7 +3,7 @@ import { identify } from '@libp2p/identify'
 import { webSockets } from '@libp2p/websockets'
 import { expect } from 'aegir/chai'
 import { createHeliaLight } from 'helia'
-import { createLibp2p, isLibp2p } from 'libp2p'
+import { isLibp2p } from 'libp2p'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { HeliaWithLibp2p } from '@helia/libp2p'
 
@@ -47,7 +47,7 @@ describe('@helia/libp2p', () => {
   })
 
   it('does not add helia details to the AgentVersion when it has been overridden', async () => {
-    helia = await withLibp2p(createHeliaLight(), await createLibp2p({
+    helia = await withLibp2p(createHeliaLight(), {
       nodeInfo: {
         userAgent: 'my custom user agent'
       },
@@ -57,7 +57,7 @@ describe('@helia/libp2p', () => {
       services: {
         identify: identify()
       }
-    })).start()
+    }).start()
 
     expect(helia).to.have.nested.property('libp2p.services.identify.host.agentVersion')
       .that.does.not.include('helia/')
@@ -88,14 +88,6 @@ describe('@helia/libp2p', () => {
     }).start()
 
     expect(helia.libp2p.peerId.toString()).to.equal(peerId.toString())
-  })
-
-  it('allows passing a libp2p node', async () => {
-    const libp2p = await createLibp2p()
-
-    helia = await withLibp2p(createHeliaLight(), libp2p).start()
-
-    expect(helia.libp2p).to.equal(libp2p)
   })
 
   it('adds helia details to the AgentVersion', async () => {

--- a/packages/interop/src/libp2p.spec.ts
+++ b/packages/interop/src/libp2p.spec.ts
@@ -1,6 +1,4 @@
 import { withLibp2p } from '@helia/libp2p'
-import { identify } from '@libp2p/identify'
-import { webSockets } from '@libp2p/websockets'
 import { expect } from 'aegir/chai'
 import { createHeliaLight } from 'helia'
 import { isLibp2p } from 'libp2p'
@@ -50,12 +48,6 @@ describe('@helia/libp2p', () => {
     helia = await withLibp2p(createHeliaLight(), {
       nodeInfo: {
         userAgent: 'my custom user agent'
-      },
-      transports: [
-        webSockets()
-      ],
-      services: {
-        identify: identify()
       }
     }).start()
 

--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -41,50 +41,23 @@ export interface HeliaWithLibp2p<M extends ServiceMap = DefaultLibp2pServices> e
 }
 
 async function getLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): Promise<Libp2p<M>> {
-  let node: Libp2p<M>
+  const heliaAgent = `${helia.info.name}/${helia.info.version} ${userAgent()}`
 
-  if (isLibp2p(opts)) {
-    node = opts as any
-  } else {
-    node = await createLibp2p(helia, {
-      ...opts,
-      dns: helia.dns,
-      logger: helia.logger,
-      datastore: helia.datastore
-    })
-  }
-
-  return addHeliaVersion(node, helia)
-}
-
-function addHeliaVersion (libp2p: Libp2p<any>, helia: Helia): Libp2p<any> {
-  function isIdentify (service: any): service is { host: { agentVersion: string } } {
-    return typeof service?.host?.agentVersion === 'string'
-  }
-
-  const heliaAgent = `${helia.info.name}/${helia.info.version}`
-
-  // @ts-expect-error private field
-  if (libp2p.components?.nodeInfo?.userAgent === userAgent()) {
-    // @ts-expect-error private field
-    libp2p.components.nodeInfo.userAgent = `${heliaAgent} ${libp2p.components.nodeInfo.userAgent}`
-  }
-
-  for (const service of Object.values(libp2p.services)) {
-    if (isIdentify(service) && service.host.agentVersion === userAgent()) {
-      service.host.agentVersion = `${heliaAgent} ${service.host.agentVersion}`
+  return createLibp2p(helia, {
+    ...opts,
+    dns: helia.dns,
+    logger: helia.logger,
+    datastore: helia.datastore,
+    nodeInfo: {
+      userAgent: opts?.nodeInfo?.userAgent ?? heliaAgent
     }
-  }
-
-  return libp2p
+  })
 }
 
 /**
  * Return a Helia node augmented with a libp2p instance
  */
-export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap, L extends Libp2p = Libp2p<M>> (helia: H, opts: L): H & HeliaWithLibp2p<M>
-export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): H & HeliaWithLibp2p<M>
-export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): H & HeliaWithLibp2p {
+export function withLibp2p <H extends Helia, M extends ServiceMap = ServiceMap> (helia: H, opts?: CreateLibp2pOptions<M>): H & HeliaWithLibp2p<M> {
   let libp2p: Libp2p
 
   // add a getter that informs the user they need to start Helia

--- a/packages/libp2p/test/index.spec.ts
+++ b/packages/libp2p/test/index.spec.ts
@@ -1,18 +1,15 @@
 import { identify, identifyPush } from '@libp2p/identify'
-import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { defaultLogger } from 'birnam'
 import { MemoryDatastore } from 'datastore-core'
-import { createLibp2p, isLibp2p } from 'libp2p'
+import { isLibp2p } from 'libp2p'
 import { stubInterface } from 'sinon-ts'
 import { withLibp2p } from '../src/index.ts'
 import type { HeliaWithLibp2p } from '../src/index.ts'
-import type { Libp2p } from '@libp2p/interface'
 import type { StubbedInstance } from 'sinon-ts'
 
 describe('@helia/libp2p', () => {
   let helia: StubbedInstance<HeliaWithLibp2p<any>>
-  let libp2p: Libp2p | undefined
 
   beforeEach(() => {
     helia = withLibp2p(stubInterface<any>({
@@ -24,7 +21,6 @@ describe('@helia/libp2p', () => {
 
   afterEach(async () => {
     await helia.addMixin.getCall(0).args[0]?.stop?.(helia)
-    await stop(libp2p)
   })
 
   it('should add a mixin', async () => {
@@ -36,28 +32,7 @@ describe('@helia/libp2p', () => {
     expect(isLibp2p(helia.libp2p)).to.be.true()
   })
 
-  it('allows passing a libp2p node', async () => {
-    libp2p = await createLibp2p()
-
-    helia = withLibp2p(stubInterface<any>({
-      datastore: new MemoryDatastore(),
-      logger: defaultLogger(),
-      routing: stubInterface()
-    }), libp2p)
-
-    await helia.addMixin.getCall(0).args[0]?.start?.(helia)
-
-    expect(helia.libp2p).to.equal(libp2p)
-  })
-
   it('should add helia version to identify agent', async () => {
-    libp2p = await createLibp2p({
-      services: {
-        identify: identify(),
-        identifyPush: identifyPush()
-      }
-    })
-
     helia = withLibp2p(stubInterface<any>({
       datastore: new MemoryDatastore(),
       logger: defaultLogger(),
@@ -66,7 +41,12 @@ describe('@helia/libp2p', () => {
         name: 'helia',
         version: '1.0.0'
       }
-    }), libp2p)
+    }), {
+      services: {
+        identify: identify(),
+        identifyPush: identifyPush()
+      }
+    })
 
     await helia.addMixin.getCall(0).args[0]?.start?.(helia)
 


### PR DESCRIPTION
In order to ensure we can modify the libp2p config to do things like update the agent version, we need to control the libp2p node's lifecycle so only accept libp2p config and not a running node.

BREAKING CHANGE: pass libp2p config to withLibp2p, not a running node

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
