### PR TITLE
fix: allow passing libp2p, http, and bitswap options

### DIFF
--- a/packages/helia/src/helia.ts
+++ b/packages/helia/src/helia.ts
@@ -59,9 +59,8 @@ export interface HeliaInit {
   datastore?: Datastore
 
   /**
-   * By default sha256, sha512 and identity hashes are supported for
-   * bitswap operations. To bitswap blocks with CIDs using other hashes
-   * pass appropriate MultihashHashers here.
+   * By default sha256, and identity hashes are supported. To bitswap blocks
+   * with CIDs using other hashes pass appropriate MultihashHashers here.
    */
   hashers?: MultihashHasher[]
 

--- a/packages/helia/src/index.ts
+++ b/packages/helia/src/index.ts
@@ -29,7 +29,11 @@ import { sha512 } from 'multiformats/hashes/sha2'
 import { Helia as HeliaClass } from './helia.ts'
 import { name, version } from './version.ts'
 import type { HeliaInit } from './helia.ts'
+import type { BitswapOptions } from '@helia/bitswap'
+import type { HTTPOptions } from '@helia/http'
 import type { Helia } from '@helia/interface'
+import type { CreateLibp2pOptions } from '@helia/libp2p'
+import type { ServiceMap } from '@libp2p/interface'
 
 // re-export interface types so people don't have to depend on @helia/interface
 // if they don't want to
@@ -38,7 +42,10 @@ export * from '@helia/interface'
 export type { HeliaInit }
 
 /**
- * Create and return a Helia node
+ * Create and return a Helia node using the default configuration including
+ * libp2p and HTTP routing.
+ *
+ * For full control, and smaller bundle sizes use `createHeliaLight`.
  *
  * @example Creating a Helia node
  *
@@ -58,7 +65,7 @@ export type { HeliaInit }
  * }
  * ```
  */
-export function createHelia (init: HeliaInit = {}): Helia {
+export function createHelia <M extends ServiceMap> (init: HeliaInit & { libp2p?: CreateLibp2pOptions<M>, http?: HTTPOptions, bitswap?: BitswapOptions } = {}): Helia {
   return withBitswap(withLibp2p(withHTTP(createHeliaLight({
     ...init,
     codecs: [
@@ -71,7 +78,7 @@ export function createHelia (init: HeliaInit = {}): Helia {
       sha512,
       ...(init.hashers ?? [])
     ]
-  }))))
+  }), init.http), init.libp2p), init.bitswap)
 }
 
 /**


### PR DESCRIPTION
When creating a helia node with the default config, allow passing options to libp2p, http, and bitswap.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
