### PR TITLE
fix: restore config replacing

### DIFF
--- a/packages/libp2p/src/index.ts
+++ b/packages/libp2p/src/index.ts
@@ -53,7 +53,12 @@ import type { CID } from 'multiformats'
 export { libp2pDefaults } from './utils/libp2p-defaults.ts'
 export type { DefaultLibp2pServices } from './utils/libp2p-defaults.ts'
 
-export interface CreateLibp2pOptions<T extends ServiceMap> extends Libp2pOptions<T> {
+export interface CreateLibp2pOptions<T extends ServiceMap = ServiceMap> extends Libp2pOptions<T> {
+  /**
+   * If 'merge', any passed config will be merged into the default set. If
+   * 'replace' any passed config will replace the default set.
+   */
+  config?: 'merge' | 'replace'
   keychain?: KeychainInit
 }
 

--- a/packages/libp2p/src/utils/config.ts
+++ b/packages/libp2p/src/utils/config.ts
@@ -1,0 +1,51 @@
+function isPrimitive (value: any): boolean {
+  return typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'function' ||
+    typeof value === 'bigint'
+}
+
+export function merge <T> (target: T, ...sources: T[]): T {
+  const output = target as any
+
+  for (const source of sources) {
+    Object.entries(source as any).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        output[key] ??= []
+        output[key].push(...value)
+        return
+      }
+
+      if (isPrimitive(value) || output[key] == null) {
+        output[key] = value
+        return
+      }
+
+      merge(output[key], value)
+    })
+  }
+
+  return target
+}
+
+export function replace <T> (target: T, ...sources: T[]): T {
+  const output = target as any
+
+  for (const source of sources) {
+    Object.entries(source as any).forEach(([key, value]) => {
+      if (Array.isArray(value) || Array.isArray(output[key])) {
+        output[key] = value
+        return
+      }
+
+      if (isPrimitive(value) || output[key] == null) {
+        output[key] = value
+        return
+      }
+
+      replace(output[key], value)
+    })
+  }
+
+  return target
+}

--- a/packages/libp2p/src/utils/libp2p-defaults.browser.ts
+++ b/packages/libp2p/src/utils/libp2p-defaults.browser.ts
@@ -15,6 +15,7 @@ import { ping } from '@libp2p/ping'
 import { webRTC, webRTCDirect } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
 import { bootstrapConfig } from './bootstrappers.ts'
+import { merge, replace } from './config.ts'
 import type { CreateLibp2pOptions } from '../index.ts'
 import type { HTTP } from '@libp2p/http'
 import type { Identify, IdentifyPush } from '@libp2p/identify'
@@ -40,35 +41,28 @@ export type DefaultLibp2pOptions = Libp2pOptions<DefaultLibp2pServices> & Requir
 export function libp2pDefaults (): DefaultLibp2pOptions
 export function libp2pDefaults <M extends ServiceMap, Options extends CreateLibp2pOptions<M>> (options: Options): DefaultLibp2pOptions & Options
 export function libp2pDefaults (options?: any): any {
-  return {
-    ...options,
+  const defaults = {
     addresses: {
-      ...options?.addresses,
       listen: [
         '/p2p-circuit',
-        '/webrtc',
-        ...(options?.addresses?.listen ?? [])
+        '/webrtc'
       ]
     },
     transports: [
       circuitRelayTransport(),
       webRTC(),
       webRTCDirect(),
-      webSockets(),
-      ...(options?.transports ?? [])
+      webSockets()
     ],
     connectionEncrypters: [
-      noise(),
-      ...(options?.connectionEncrypters ?? [])
+      noise()
     ],
     streamMuxers: [
       yamux(),
-      mplex(),
-      ...(options?.streamMuxers ?? [])
+      mplex()
     ],
     peerDiscovery: [
-      bootstrap(bootstrapConfig),
-      ...(options?.peerDiscovery ?? [])
+      bootstrap(bootstrapConfig)
     ],
     services: {
       autoNAT: autoNAT(),
@@ -82,8 +76,17 @@ export function libp2pDefaults (options?: any): any {
       identifyPush: identifyPush(),
       keychain: keychain(options?.keychain),
       ping: ping(),
-      http: http(),
-      ...options?.services
+      http: http()
     }
   }
+
+  if (options == null) {
+    return defaults
+  }
+
+  if (options?.config === 'merge') {
+    return merge(defaults, options)
+  }
+
+  return replace(defaults, options)
 }

--- a/packages/libp2p/src/utils/libp2p-defaults.ts
+++ b/packages/libp2p/src/utils/libp2p-defaults.ts
@@ -20,6 +20,7 @@ import { uPnPNAT } from '@libp2p/upnp-nat'
 import { webRTC, webRTCDirect } from '@libp2p/webrtc'
 import { webSockets } from '@libp2p/websockets'
 import { bootstrapConfig } from './bootstrappers.ts'
+import { merge, replace } from './config.ts'
 import type { CreateLibp2pOptions } from '../index.ts'
 import type { AutoTLS } from '@ipshipyard/libp2p-auto-tls'
 import type { CircuitRelayService } from '@libp2p/circuit-relay-v2'
@@ -78,10 +79,8 @@ export type DefaultLibp2pOptions = Libp2pOptions<DefaultLibp2pServices> & Requir
 export function libp2pDefaults (): DefaultLibp2pOptions
 export function libp2pDefaults <M extends ServiceMap, Options extends CreateLibp2pOptions<M>> (options: Options): DefaultLibp2pOptions & Options
 export function libp2pDefaults (options?: any): any {
-  return {
-    ...options,
+  const defaults = {
     addresses: {
-      ...options?.addresses,
       listen: [
         '/ip4/0.0.0.0/tcp/0',
         '/ip4/0.0.0.0/tcp/0/ws',
@@ -89,8 +88,7 @@ export function libp2pDefaults (options?: any): any {
         '/ip6/::/tcp/0',
         '/ip6/::/tcp/0/ws',
         '/ip6/::/udp/0/webrtc-direct',
-        '/p2p-circuit',
-        ...(options?.addresses?.listen ?? [])
+        '/p2p-circuit'
       ]
     },
     transports: [
@@ -98,23 +96,19 @@ export function libp2pDefaults (options?: any): any {
       tcp(),
       webRTC(),
       webRTCDirect(),
-      webSockets(),
-      ...(options?.transports ?? [])
+      webSockets()
     ],
     connectionEncrypters: [
       noise(),
-      tls(),
-      ...(options?.connectionEncrypters ?? [])
+      tls()
     ],
     streamMuxers: [
       yamux(),
-      mplex(),
-      ...(options?.streamMuxers ?? [])
+      mplex()
     ],
     peerDiscovery: [
       mdns(),
-      bootstrap(bootstrapConfig),
-      ...(options?.peerDiscovery ?? [])
+      bootstrap(bootstrapConfig)
     ],
     services: {
       autoNAT: autoNAT(),
@@ -129,8 +123,17 @@ export function libp2pDefaults (options?: any): any {
       ping: ping(),
       relay: circuitRelayServer(),
       upnp: uPnPNAT(),
-      http: http(),
-      ...options?.services
+      http: http()
     }
   }
+
+  if (options == null) {
+    return defaults
+  }
+
+  if (options?.config === 'merge') {
+    return merge(defaults, options)
+  }
+
+  return replace(defaults, options)
 }

--- a/packages/libp2p/test/libp2p-defaults.spec.ts
+++ b/packages/libp2p/test/libp2p-defaults.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'aegir/chai'
 import { stubInterface } from 'sinon-ts'
 import { libp2pDefaults } from '../src/utils/libp2p-defaults.ts'
+import type { CreateLibp2pOptions } from '../src/index.ts'
 import type { DNS } from '@multiformats/dns'
 
 describe('libp2p-defaults', () => {
@@ -18,5 +19,31 @@ describe('libp2p-defaults', () => {
     const options = libp2pDefaults(opts)
 
     expect(options.foo).to.equal('bar')
+  })
+
+  it('should merge defaults', () => {
+    const defaults = libp2pDefaults()
+
+    const extra: CreateLibp2pOptions = {
+      config: 'merge',
+      streamMuxers: [
+        stubInterface()
+      ]
+    }
+
+    const updated = libp2pDefaults(extra)
+    expect(updated.streamMuxers.length).to.be.greaterThan(defaults.streamMuxers.length)
+  })
+
+  it('should replace defaults', () => {
+    const extra: CreateLibp2pOptions = {
+      config: 'replace',
+      streamMuxers: [
+        stubInterface()
+      ]
+    }
+
+    const updated = libp2pDefaults(extra)
+    expect(updated.streamMuxers.length).to.equal(1)
   })
 })


### PR DESCRIPTION
Go back to overwriting keys in libp2p config by default, pass `config: 'merge'` option to perform a deep merge instead.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
